### PR TITLE
feat(workspace): add git worktree manager

### DIFF
--- a/antfarm/core/workspace.py
+++ b/antfarm/core/workspace.py
@@ -1,0 +1,129 @@
+"""Git worktree manager for task attempt isolation.
+
+Each task attempt gets its own git worktree branched from the integration
+branch (default: main). This provides filesystem isolation between concurrent
+agent sessions without requiring separate repository clones.
+"""
+
+import os
+import subprocess
+
+
+class WorkspaceManager:
+    """Manages git worktrees for task attempt isolation.
+
+    Args:
+        workspace_root: Directory under which per-attempt worktrees are created.
+        repo_path: Path to the git repository used as the worktree source.
+        integration_branch: Remote branch new worktrees branch off of.
+    """
+
+    def __init__(self, workspace_root: str, repo_path: str, integration_branch: str = "dev"):
+        self.workspace_root = workspace_root
+        self.repo_path = repo_path
+        self.integration_branch = integration_branch
+
+    def create(self, task_id: str, attempt_id: str) -> str:
+        """Create a git worktree for a task attempt.
+
+        Fetches origin, then creates a new branch and worktree rooted at
+        ``{workspace_root}/{task_id}-{attempt_id}``.
+
+        Args:
+            task_id: Identifier for the task (e.g. "task-001").
+            attempt_id: Identifier for the attempt (e.g. "att-001").
+
+        Returns:
+            Absolute path to the created worktree.
+
+        Raises:
+            subprocess.CalledProcessError: If any git command fails.
+        """
+        subprocess.run(
+            ["git", "fetch", "origin"],
+            cwd=self.repo_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        branch = f"feat/{task_id}-{attempt_id}"
+        workspace_path = os.path.join(self.workspace_root, f"{task_id}-{attempt_id}")
+
+        subprocess.run(
+            [
+                "git",
+                "worktree",
+                "add",
+                "-b",
+                branch,
+                workspace_path,
+                f"origin/{self.integration_branch}",
+            ],
+            cwd=self.repo_path,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        return workspace_path
+
+    def validate(self, workspace_path: str) -> bool:
+        """Check that a worktree path exists and has a clean working tree.
+
+        Args:
+            workspace_path: Path to the worktree to validate.
+
+        Returns:
+            True if the path is inside a git work tree and has no uncommitted
+            changes; False otherwise.
+        """
+        if not os.path.exists(workspace_path):
+            return False
+
+        try:
+            result = subprocess.run(
+                ["git", "-C", workspace_path, "rev-parse", "--is-inside-work-tree"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            if result.stdout.strip() != "true":
+                return False
+
+            status = subprocess.run(
+                ["git", "-C", workspace_path, "status", "--porcelain"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            return status.stdout.strip() == ""
+
+        except subprocess.CalledProcessError:
+            return False
+
+    def list_orphans(self) -> list[str]:
+        """List worktree paths under workspace_root from the repository's worktree list.
+
+        Parses ``git worktree list --porcelain`` output. Only paths that start
+        with ``self.workspace_root`` are returned; the caller decides which are
+        orphans.
+
+        Returns:
+            List of worktree paths located under workspace_root.
+        """
+        result = subprocess.run(
+            ["git", "-C", self.repo_path, "worktree", "list", "--porcelain"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        paths: list[str] = []
+        for line in result.stdout.splitlines():
+            if line.startswith("worktree "):
+                path = line[len("worktree "):]
+                if path.startswith(self.workspace_root):
+                    paths.append(path)
+
+        return paths

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,128 @@
+"""Tests for antfarm.core.workspace.WorkspaceManager."""
+
+import os
+import subprocess
+
+import pytest
+
+from antfarm.core.workspace import WorkspaceManager
+
+
+@pytest.fixture()
+def git_repo(tmp_path):
+    """Set up a bare origin and a working clone with a dev branch.
+
+    Yields a dict with:
+        repo_path   — path to the working clone
+        workspace_root — scratch directory for worktrees
+    """
+    origin = tmp_path / "origin.git"
+    clone = tmp_path / "clone"
+    workspaces = tmp_path / "workspaces"
+    workspaces.mkdir()
+
+    # Create bare origin
+    subprocess.run(["git", "init", "--bare", str(origin)], check=True, capture_output=True)
+
+    # Clone origin
+    subprocess.run(["git", "clone", str(origin), str(clone)], check=True, capture_output=True)
+
+    # Configure identity inside the clone so commits work in CI
+    subprocess.run(
+        ["git", "-C", str(clone), "config", "user.email", "test@antfarm.test"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(clone), "config", "user.name", "Antfarm Test"],
+        check=True, capture_output=True,
+    )
+
+    # Make an initial commit so HEAD exists
+    readme = clone / "README.md"
+    readme.write_text("antfarm test repo")
+    subprocess.run(["git", "-C", str(clone), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(clone), "commit", "-m", "init"],
+        check=True, capture_output=True,
+    )
+
+    # Push to origin and create dev branch tracking remote
+    subprocess.run(
+        ["git", "-C", str(clone), "push", "-u", "origin", "HEAD:dev"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(clone), "fetch", "origin"],
+        check=True, capture_output=True,
+    )
+
+    yield {"repo_path": str(clone), "workspace_root": str(workspaces)}
+
+
+def test_create_worktree(git_repo):
+    mgr = WorkspaceManager(
+        workspace_root=git_repo["workspace_root"],
+        repo_path=git_repo["repo_path"],
+        integration_branch="dev",
+    )
+    path = mgr.create("task-001", "att-001")
+
+    expected = os.path.join(git_repo["workspace_root"], "task-001-att-001")
+    assert path == expected
+    assert os.path.exists(path)
+
+    result = subprocess.run(
+        ["git", "-C", path, "rev-parse", "--abbrev-ref", "HEAD"],
+        check=True, capture_output=True, text=True,
+    )
+    assert result.stdout.strip() == "feat/task-001-att-001"
+
+
+def test_validate_clean(git_repo):
+    mgr = WorkspaceManager(
+        workspace_root=git_repo["workspace_root"],
+        repo_path=git_repo["repo_path"],
+        integration_branch="dev",
+    )
+    path = mgr.create("task-002", "att-001")
+    assert mgr.validate(path) is True
+
+
+def test_validate_dirty(git_repo):
+    mgr = WorkspaceManager(
+        workspace_root=git_repo["workspace_root"],
+        repo_path=git_repo["repo_path"],
+        integration_branch="dev",
+    )
+    path = mgr.create("task-003", "att-001")
+
+    # Write an untracked file to make the tree dirty
+    (os.path.join(path, "dirty.txt"),)
+    with open(os.path.join(path, "dirty.txt"), "w") as f:
+        f.write("dirty")
+
+    assert mgr.validate(path) is False
+
+
+def test_list_orphans(git_repo):
+    mgr = WorkspaceManager(
+        workspace_root=git_repo["workspace_root"],
+        repo_path=git_repo["repo_path"],
+        integration_branch="dev",
+    )
+    path1 = mgr.create("task-004", "att-001")
+    path2 = mgr.create("task-005", "att-001")
+
+    orphans = mgr.list_orphans()
+
+    assert path1 in orphans
+    assert path2 in orphans
+
+
+def test_validate_nonexistent_path(git_repo):
+    mgr = WorkspaceManager(
+        workspace_root=git_repo["workspace_root"],
+        repo_path=git_repo["repo_path"],
+        integration_branch="dev",
+    )
+    assert mgr.validate("/nonexistent/path") is False


### PR DESCRIPTION
## Summary

- Add `WorkspaceManager` class in `antfarm/core/workspace.py`
- `create()` fetches origin, creates a git worktree on a new branch `feat/{task_id}-{attempt_id}`
- `validate()` checks the worktree exists, is inside a git work tree, and has a clean status
- `list_orphans()` parses `git worktree list --porcelain` and returns paths under `workspace_root`
- Full test coverage with 5 passing tests

closes #9