### PR TITLE
feat(models): add Task, Attempt, Worker, Node dataclasses and enums

### DIFF
--- a/antfarm/core/models.py
+++ b/antfarm/core/models.py
@@ -1,0 +1,253 @@
+"""Data model definitions for Antfarm.
+
+Core dataclasses and enums representing Tasks, Attempts, Workers, and Nodes
+in the Antfarm distributed agent orchestration system.
+
+All timestamps are ISO 8601 strings. Priority follows Unix nice convention:
+lower number = higher priority.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class TaskStatus(StrEnum):
+    READY = "ready"
+    ACTIVE = "active"
+    DONE = "done"
+
+
+class AttemptStatus(StrEnum):
+    ACTIVE = "active"
+    DONE = "done"
+    MERGED = "merged"
+    SUPERSEDED = "superseded"
+
+
+class WorkerStatus(StrEnum):
+    IDLE = "idle"
+    ACTIVE = "active"
+    OFFLINE = "offline"
+
+
+# ---------------------------------------------------------------------------
+# Simple entry types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TrailEntry:
+    ts: str
+    worker_id: str
+    message: str
+
+    def to_dict(self) -> dict:
+        return {
+            "ts": self.ts,
+            "worker_id": self.worker_id,
+            "message": self.message,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> TrailEntry:
+        return cls(
+            ts=data["ts"],
+            worker_id=data["worker_id"],
+            message=data["message"],
+        )
+
+
+@dataclass
+class SignalEntry:
+    ts: str
+    worker_id: str
+    message: str
+
+    def to_dict(self) -> dict:
+        return {
+            "ts": self.ts,
+            "worker_id": self.worker_id,
+            "message": self.message,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> SignalEntry:
+        return cls(
+            ts=data["ts"],
+            worker_id=data["worker_id"],
+            message=data["message"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Attempt
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Attempt:
+    attempt_id: str
+    worker_id: str | None
+    status: AttemptStatus
+    branch: str | None
+    pr: str | None
+    started_at: str
+    completed_at: str | None
+
+    def to_dict(self) -> dict:
+        return {
+            "attempt_id": self.attempt_id,
+            "worker_id": self.worker_id,
+            "status": self.status.value,
+            "branch": self.branch,
+            "pr": self.pr,
+            "started_at": self.started_at,
+            "completed_at": self.completed_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Attempt:
+        return cls(
+            attempt_id=data["attempt_id"],
+            worker_id=data.get("worker_id"),
+            status=AttemptStatus(data["status"]),
+            branch=data.get("branch"),
+            pr=data.get("pr"),
+            started_at=data["started_at"],
+            completed_at=data.get("completed_at"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Task:
+    id: str
+    title: str
+    spec: str
+    created_at: str
+    updated_at: str
+    created_by: str
+    complexity: str = "M"
+    priority: int = field(default=10)
+    depends_on: list[str] = field(default_factory=list)
+    touches: list[str] = field(default_factory=list)
+    status: TaskStatus = TaskStatus.READY
+    current_attempt: str | None = None
+    attempts: list[Attempt] = field(default_factory=list)
+    trail: list[TrailEntry] = field(default_factory=list)
+    signals: list[SignalEntry] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "spec": self.spec,
+            "complexity": self.complexity,
+            "priority": self.priority,
+            "depends_on": list(self.depends_on),
+            "touches": list(self.touches),
+            "status": self.status.value,
+            "current_attempt": self.current_attempt,
+            "attempts": [a.to_dict() for a in self.attempts],
+            "trail": [t.to_dict() for t in self.trail],
+            "signals": [s.to_dict() for s in self.signals],
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "created_by": self.created_by,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Task:
+        return cls(
+            id=data["id"],
+            title=data["title"],
+            spec=data["spec"],
+            complexity=data.get("complexity", "M"),
+            priority=data.get("priority", 10),
+            depends_on=list(data.get("depends_on", [])),
+            touches=list(data.get("touches", [])),
+            status=TaskStatus(data.get("status", TaskStatus.READY)),
+            current_attempt=data.get("current_attempt"),
+            attempts=[Attempt.from_dict(a) for a in data.get("attempts", [])],
+            trail=[TrailEntry.from_dict(t) for t in data.get("trail", [])],
+            signals=[SignalEntry.from_dict(s) for s in data.get("signals", [])],
+            created_at=data["created_at"],
+            updated_at=data["updated_at"],
+            created_by=data["created_by"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Worker
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Worker:
+    worker_id: str
+    node_id: str
+    agent_type: str
+    workspace_root: str
+    registered_at: str
+    last_heartbeat: str
+    status: WorkerStatus = WorkerStatus.IDLE
+
+    def to_dict(self) -> dict:
+        return {
+            "worker_id": self.worker_id,
+            "node_id": self.node_id,
+            "agent_type": self.agent_type,
+            "workspace_root": self.workspace_root,
+            "status": self.status.value,
+            "registered_at": self.registered_at,
+            "last_heartbeat": self.last_heartbeat,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Worker:
+        return cls(
+            worker_id=data["worker_id"],
+            node_id=data["node_id"],
+            agent_type=data["agent_type"],
+            workspace_root=data["workspace_root"],
+            status=WorkerStatus(data.get("status", WorkerStatus.IDLE)),
+            registered_at=data["registered_at"],
+            last_heartbeat=data["last_heartbeat"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Node
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Node:
+    node_id: str
+    joined_at: str
+    last_seen: str
+
+    def to_dict(self) -> dict:
+        return {
+            "node_id": self.node_id,
+            "joined_at": self.joined_at,
+            "last_seen": self.last_seen,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Node:
+        return cls(
+            node_id=data["node_id"],
+            joined_at=data["joined_at"],
+            last_seen=data["last_seen"],
+        )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,240 @@
+"""Tests for antfarm.core.models dataclasses and enums."""
+
+from antfarm.core.models import (
+    Attempt,
+    AttemptStatus,
+    Node,
+    SignalEntry,
+    Task,
+    TaskStatus,
+    TrailEntry,
+    Worker,
+    WorkerStatus,
+)
+
+
+def _make_attempt(attempt_id: str = "a-1") -> Attempt:
+    return Attempt(
+        attempt_id=attempt_id,
+        worker_id="w-1",
+        status=AttemptStatus.ACTIVE,
+        branch="feat/test",
+        pr="https://github.com/org/repo/pull/1",
+        started_at="2026-04-04T10:00:00Z",
+        completed_at=None,
+    )
+
+
+def _make_trail_entry() -> TrailEntry:
+    return TrailEntry(ts="2026-04-04T10:00:00Z", worker_id="w-1", message="started work")
+
+
+def _make_signal_entry() -> SignalEntry:
+    return SignalEntry(ts="2026-04-04T10:01:00Z", worker_id="w-1", message="needs review")
+
+
+def _make_task(include_nested: bool = True) -> Task:
+    attempts = [_make_attempt("a-1"), _make_attempt("a-2")] if include_nested else []
+    trail = [_make_trail_entry()] if include_nested else []
+    signals = [_make_signal_entry()] if include_nested else []
+    return Task(
+        id="t-1",
+        title="Add login flow",
+        spec="Implement JWT-based login",
+        complexity="L",
+        priority=5,
+        depends_on=["t-0"],
+        touches=["auth.py", "middleware.py"],
+        status=TaskStatus.ACTIVE,
+        current_attempt="a-2",
+        attempts=attempts,
+        trail=trail,
+        signals=signals,
+        created_at="2026-04-04T09:00:00Z",
+        updated_at="2026-04-04T10:00:00Z",
+        created_by="user-1",
+    )
+
+
+def _make_worker() -> Worker:
+    return Worker(
+        worker_id="w-1",
+        node_id="node-1",
+        agent_type="engineer",
+        workspace_root="/tmp/ws",
+        status=WorkerStatus.ACTIVE,
+        registered_at="2026-04-04T08:00:00Z",
+        last_heartbeat="2026-04-04T10:00:00Z",
+    )
+
+
+def _make_node() -> Node:
+    return Node(
+        node_id="node-1",
+        joined_at="2026-04-04T08:00:00Z",
+        last_seen="2026-04-04T10:00:00Z",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Roundtrip tests
+# ---------------------------------------------------------------------------
+
+
+def test_trail_entry_roundtrip():
+    entry = _make_trail_entry()
+    assert TrailEntry.from_dict(entry.to_dict()) == entry
+
+
+def test_signal_entry_roundtrip():
+    entry = _make_signal_entry()
+    assert SignalEntry.from_dict(entry.to_dict()) == entry
+
+
+def test_attempt_roundtrip():
+    attempt = _make_attempt()
+    assert Attempt.from_dict(attempt.to_dict()) == attempt
+
+
+def test_attempt_roundtrip_nulls():
+    attempt = Attempt(
+        attempt_id="a-null",
+        worker_id=None,
+        status=AttemptStatus.SUPERSEDED,
+        branch=None,
+        pr=None,
+        started_at="2026-04-04T10:00:00Z",
+        completed_at="2026-04-04T11:00:00Z",
+    )
+    assert Attempt.from_dict(attempt.to_dict()) == attempt
+
+
+def test_task_roundtrip():
+    task = _make_task(include_nested=True)
+    assert Task.from_dict(task.to_dict()) == task
+
+
+def test_worker_roundtrip():
+    worker = _make_worker()
+    assert Worker.from_dict(worker.to_dict()) == worker
+
+
+def test_node_roundtrip():
+    node = _make_node()
+    assert Node.from_dict(node.to_dict()) == node
+
+
+# ---------------------------------------------------------------------------
+# Enum value tests
+# ---------------------------------------------------------------------------
+
+
+def test_enum_values():
+    assert TaskStatus.READY.value == "ready"
+    assert TaskStatus.ACTIVE.value == "active"
+    assert TaskStatus.DONE.value == "done"
+
+    assert AttemptStatus.ACTIVE.value == "active"
+    assert AttemptStatus.DONE.value == "done"
+    assert AttemptStatus.MERGED.value == "merged"
+    assert AttemptStatus.SUPERSEDED.value == "superseded"
+
+    assert WorkerStatus.IDLE.value == "idle"
+    assert WorkerStatus.ACTIVE.value == "active"
+    assert WorkerStatus.OFFLINE.value == "offline"
+
+
+def test_enum_is_str():
+    assert isinstance(TaskStatus.READY, str)
+    assert isinstance(AttemptStatus.MERGED, str)
+    assert isinstance(WorkerStatus.IDLE, str)
+
+
+# ---------------------------------------------------------------------------
+# Default values
+# ---------------------------------------------------------------------------
+
+
+def test_task_default_values():
+    task = Task(
+        id="t-min",
+        title="Minimal task",
+        spec="Do something",
+        created_at="2026-04-04T09:00:00Z",
+        updated_at="2026-04-04T09:00:00Z",
+        created_by="user-1",
+    )
+    assert task.complexity == "M"
+    assert task.priority == 10
+    assert task.depends_on == []
+    assert task.touches == []
+    assert task.status == TaskStatus.READY
+    assert task.current_attempt is None
+    assert task.attempts == []
+    assert task.trail == []
+    assert task.signals == []
+
+
+def test_worker_default_status():
+    worker = Worker(
+        worker_id="w-default",
+        node_id="node-1",
+        agent_type="researcher",
+        workspace_root="/tmp/ws",
+        registered_at="2026-04-04T08:00:00Z",
+        last_heartbeat="2026-04-04T09:00:00Z",
+    )
+    assert worker.status == WorkerStatus.IDLE
+
+
+# ---------------------------------------------------------------------------
+# Nested serialization
+# ---------------------------------------------------------------------------
+
+
+def test_task_with_nested_attempts():
+    task = _make_task(include_nested=True)
+    d = task.to_dict()
+
+    assert len(d["attempts"]) == 2
+    assert d["attempts"][0]["attempt_id"] == "a-1"
+    assert d["attempts"][1]["attempt_id"] == "a-2"
+    assert d["attempts"][0]["status"] == "active"
+
+    assert len(d["trail"]) == 1
+    assert d["trail"][0]["message"] == "started work"
+
+    assert len(d["signals"]) == 1
+    assert d["signals"][0]["message"] == "needs review"
+
+    # Verify full roundtrip still holds
+    assert Task.from_dict(d) == task
+
+
+def test_enum_serializes_as_value():
+    task = Task(
+        id="t-ser",
+        title="Serialization test",
+        spec="Check enum values in dict",
+        status=TaskStatus.DONE,
+        created_at="2026-04-04T09:00:00Z",
+        updated_at="2026-04-04T09:00:00Z",
+        created_by="user-1",
+    )
+    d = task.to_dict()
+    assert d["status"] == "done"
+    assert isinstance(d["status"], str)
+
+
+def test_attempt_merged_status_roundtrip():
+    attempt = Attempt(
+        attempt_id="a-merged",
+        worker_id="w-1",
+        status=AttemptStatus.MERGED,
+        branch="feat/done",
+        pr="https://github.com/org/repo/pull/42",
+        started_at="2026-04-04T10:00:00Z",
+        completed_at="2026-04-04T12:00:00Z",
+    )
+    assert Attempt.from_dict(attempt.to_dict()) == attempt
+    assert attempt.to_dict()["status"] == "merged"


### PR DESCRIPTION
## Summary
- Add `TaskStatus`, `AttemptStatus`, `WorkerStatus` StrEnums
- Add `TrailEntry`, `SignalEntry`, `Attempt`, `Task`, `Worker`, `Node` dataclasses
- Each dataclass has `to_dict()` and `from_dict()` for serialization (no `dataclasses.asdict()` — handles StrEnum correctly)
- 14 tests covering roundtrips, defaults, nested serialization, and enum behavior

## Test plan
- [x] `pytest tests/test_models.py` — 14 passed
- [x] `ruff check .` — no issues

closes #4