### PR TITLE
chore(ci): add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[dev]"
+      - run: ruff check .
+      - run: pytest tests/ -x -q


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with pytest + ruff on push/PR to main
- Single Python 3.12, no matrix, no caching — minimal by design

closes #3