### PR TITLE
feat(scheduler): add scope-aware task scheduler

### DIFF
--- a/antfarm/core/scheduler.py
+++ b/antfarm/core/scheduler.py
@@ -1,0 +1,59 @@
+"""Scope-aware task scheduler for Antfarm.
+
+Selects the next task from a queue of ready tasks using a deterministic
+scheduling policy that respects dependencies, scope isolation, priority,
+and FIFO ordering.
+"""
+
+from antfarm.core.models import Task
+
+
+def select_task(
+    ready_tasks: list[Task],
+    done_task_ids: set[str],
+    active_tasks: list[Task],
+) -> Task | None:
+    """Select next task using v0.1 scheduling policy.
+
+    Policy (applied in order):
+    1. Dependency check — skip if depends_on not all in done_task_ids
+    2. Scope preference — prefer non-overlapping touches with active tasks
+    3. Priority — lower number = higher priority
+    4. FIFO — oldest created_at first among equals
+
+    Args:
+        ready_tasks: Tasks with status READY that are candidates for scheduling.
+        done_task_ids: Set of task IDs that have been completed.
+        active_tasks: Tasks currently being executed by workers.
+
+    Returns:
+        The selected Task, or None if no eligible task exists.
+    """
+    # Step 1: Filter to tasks with all dependencies satisfied
+    eligible = [
+        t for t in ready_tasks
+        if all(dep in done_task_ids for dep in t.depends_on)
+    ]
+
+    if not eligible:
+        return None
+
+    # Step 2: Collect all file/scope touches from active tasks
+    active_touches: set[str] = set()
+    for t in active_tasks:
+        active_touches.update(t.touches)
+
+    # Step 3: Split into non-overlapping and overlapping groups
+    non_overlapping = [t for t in eligible if not set(t.touches) & active_touches]
+    overlapping = [t for t in eligible if set(t.touches) & active_touches]
+
+    # Step 4: Prefer non-overlapping; fall back to overlapping
+    chosen_group = non_overlapping if non_overlapping else overlapping
+
+    if not chosen_group:
+        return None
+
+    # Step 5: Sort by priority (ascending), then by created_at (ascending = oldest first)
+    chosen_group.sort(key=lambda t: (t.priority, t.created_at))
+
+    return chosen_group[0]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,127 @@
+"""Tests for the scope-aware task scheduler."""
+
+from antfarm.core.models import Task, TaskStatus
+from antfarm.core.scheduler import select_task
+
+
+def make_task(
+    id: str,
+    priority: int = 10,
+    created_at: str = "2026-01-01T00:00:00Z",
+    depends_on: list[str] | None = None,
+    touches: list[str] | None = None,
+    status: TaskStatus = TaskStatus.READY,
+) -> Task:
+    return Task(
+        id=id,
+        title=f"Task {id}",
+        spec="",
+        created_at=created_at,
+        updated_at=created_at,
+        created_by="test",
+        priority=priority,
+        depends_on=depends_on or [],
+        touches=touches or [],
+        status=status,
+    )
+
+
+def test_dependency_blocks():
+    """Task with unmet dependency is skipped."""
+    t = make_task("t1", depends_on=["t0"])
+    result = select_task([t], done_task_ids=set(), active_tasks=[])
+    assert result is None
+
+
+def test_dependency_allows():
+    """Task with all dependencies met is eligible."""
+    t = make_task("t1", depends_on=["t0"])
+    result = select_task([t], done_task_ids={"t0"}, active_tasks=[])
+    assert result is t
+
+
+def test_scope_prefers_non_overlapping():
+    """Non-overlapping task is chosen over overlapping task."""
+    active = make_task("active", touches=["file_a.py"], status=TaskStatus.ACTIVE)
+    overlapping = make_task("t_overlap", touches=["file_a.py"], priority=1)
+    non_overlapping = make_task("t_clean", touches=["file_b.py"], priority=10)
+
+    result = select_task(
+        [overlapping, non_overlapping],
+        done_task_ids=set(),
+        active_tasks=[active],
+    )
+    assert result is non_overlapping
+
+
+def test_scope_allows_overlap_when_no_alternative():
+    """Overlapping task is returned when it's the only option."""
+    active = make_task("active", touches=["file_a.py"], status=TaskStatus.ACTIVE)
+    overlapping = make_task("t_overlap", touches=["file_a.py"])
+
+    result = select_task(
+        [overlapping],
+        done_task_ids=set(),
+        active_tasks=[active],
+    )
+    assert result is overlapping
+
+
+def test_priority_ordering():
+    """Lower priority number wins (priority 1 before priority 10)."""
+    low_prio = make_task("t_low", priority=10)
+    high_prio = make_task("t_high", priority=1)
+
+    result = select_task([low_prio, high_prio], done_task_ids=set(), active_tasks=[])
+    assert result is high_prio
+
+
+def test_fifo_among_equals():
+    """Among tasks with equal priority, oldest created_at wins."""
+    newer = make_task("t_newer", priority=5, created_at="2026-01-02T00:00:00Z")
+    older = make_task("t_older", priority=5, created_at="2026-01-01T00:00:00Z")
+
+    result = select_task([newer, older], done_task_ids=set(), active_tasks=[])
+    assert result is older
+
+
+def test_empty_queue():
+    """Returns None when there are no ready tasks."""
+    result = select_task([], done_task_ids=set(), active_tasks=[])
+    assert result is None
+
+
+def test_all_deps_unmet():
+    """Returns None when all tasks have unmet dependencies."""
+    t1 = make_task("t1", depends_on=["missing1"])
+    t2 = make_task("t2", depends_on=["missing2"])
+
+    result = select_task([t1, t2], done_task_ids=set(), active_tasks=[])
+    assert result is None
+
+
+def test_no_touches():
+    """Tasks without touches field work fine (treated as empty set)."""
+    t = make_task("t1", touches=[])
+    active = make_task("active", touches=["file_a.py"], status=TaskStatus.ACTIVE)
+
+    result = select_task([t], done_task_ids=set(), active_tasks=[active])
+    assert result is t
+
+
+def test_multiple_active_scopes():
+    """Multiple active tasks' touches are unioned for overlap checking."""
+    active1 = make_task("a1", touches=["file_a.py"], status=TaskStatus.ACTIVE)
+    active2 = make_task("a2", touches=["file_b.py"], status=TaskStatus.ACTIVE)
+
+    overlaps_a = make_task("t_a", touches=["file_a.py"], priority=1)
+    overlaps_b = make_task("t_b", touches=["file_b.py"], priority=2)
+    clean = make_task("t_clean", touches=["file_c.py"], priority=10)
+
+    result = select_task(
+        [overlaps_a, overlaps_b, clean],
+        done_task_ids=set(),
+        active_tasks=[active1, active2],
+    )
+    # clean has no overlap, so it wins despite lower priority
+    assert result is clean


### PR DESCRIPTION
## Summary
- Implements `select_task()` in `antfarm/core/scheduler.py` with dependency checking, scope-preference, priority, and FIFO ordering
- 10 tests covering all scheduling policy cases

closes #7