### PR TITLE
feat(server): add colony API server

### DIFF
--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -1,0 +1,308 @@
+"""Colony API server for Antfarm.
+
+FastAPI application exposing the colony's task queue, worker registry, guard locks,
+and status over HTTP. Workers use this API to register, forage for tasks, append
+trail/signal entries, and harvest completed work.
+
+Dependency injection via get_app(backend, data_dir) supports isolated testing.
+Mutation-critical paths (pull, guard, trail, signal) are protected by _lock.
+"""
+
+from __future__ import annotations
+
+import threading
+from datetime import UTC, datetime
+
+from fastapi import FastAPI, HTTPException, Query, Response
+from pydantic import BaseModel
+
+from antfarm.core.backends.base import TaskBackend
+
+# Module-level state — set by get_app()
+_lock = threading.Lock()
+_backend: TaskBackend | None = None
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# Request models
+# ---------------------------------------------------------------------------
+
+
+class CarryRequest(BaseModel):
+    id: str
+    title: str
+    spec: str
+    complexity: str = "M"
+    priority: int = 10
+    depends_on: list[str] = []
+    touches: list[str] = []
+    created_by: str = "api"
+
+
+class NodeRequest(BaseModel):
+    node_id: str
+
+
+class WorkerRegisterRequest(BaseModel):
+    worker_id: str
+    node_id: str
+    agent_type: str
+    workspace_root: str
+
+
+class HeartbeatRequest(BaseModel):
+    status: dict | None = None
+
+
+class PullRequest(BaseModel):
+    worker_id: str
+
+
+class TrailRequest(BaseModel):
+    worker_id: str
+    message: str
+
+
+class SignalRequest(BaseModel):
+    worker_id: str
+    message: str
+
+
+class HarvestRequest(BaseModel):
+    attempt_id: str
+    pr: str
+    branch: str
+
+
+class KickbackRequest(BaseModel):
+    reason: str
+
+
+class MergeRequest(BaseModel):
+    attempt_id: str
+
+
+class GuardRequest(BaseModel):
+    owner: str
+
+
+# ---------------------------------------------------------------------------
+# App factory
+# ---------------------------------------------------------------------------
+
+
+def get_app(backend: TaskBackend | None = None, data_dir: str = ".antfarm") -> FastAPI:
+    """Create and return the FastAPI application.
+
+    Args:
+        backend: TaskBackend instance to use. If None, a FileBackend rooted at
+                 data_dir is created automatically.
+        data_dir: Path to .antfarm directory (only used when backend is None).
+
+    Returns:
+        Configured FastAPI application.
+    """
+    global _backend
+
+    if backend is not None:
+        _backend = backend
+    else:
+        from antfarm.core.backends.file import FileBackend
+
+        _backend = FileBackend(root=data_dir)
+
+    app = FastAPI(title="Antfarm Colony")
+
+    # ------------------------------------------------------------------
+    # Nodes
+    # ------------------------------------------------------------------
+
+    @app.post("/nodes", status_code=200)
+    def register_node(req: NodeRequest):
+        """Register a node. Idempotent — re-registering updates last_seen."""
+        now = _now_iso()
+        node = {"node_id": req.node_id, "joined_at": now, "last_seen": now}
+        _backend.register_node(node)
+        return {"node_id": req.node_id}
+
+    # ------------------------------------------------------------------
+    # Workers
+    # ------------------------------------------------------------------
+
+    @app.post("/workers/register", status_code=201)
+    def register_worker(req: WorkerRegisterRequest):
+        """Register a worker. Returns 409 if a live worker with the same ID exists."""
+        now = _now_iso()
+        worker = {
+            "worker_id": req.worker_id,
+            "node_id": req.node_id,
+            "agent_type": req.agent_type,
+            "workspace_root": req.workspace_root,
+            "status": "idle",
+            "registered_at": now,
+            "last_heartbeat": now,
+        }
+        try:
+            _backend.register_worker(worker)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        return {"worker_id": req.worker_id}
+
+    @app.post("/workers/{worker_id:path}/heartbeat", status_code=200)
+    def worker_heartbeat(worker_id: str, req: HeartbeatRequest):
+        """Update worker heartbeat. Accepts optional status dict."""
+        _backend.heartbeat(worker_id, req.status or {})
+        return {"ok": True}
+
+    @app.delete("/workers/{worker_id:path}", status_code=200)
+    def deregister_worker(worker_id: str):
+        """Deregister a worker. Idempotent — unknown worker returns 200."""
+        _backend.deregister_worker(worker_id)
+        return {"ok": True}
+
+    # ------------------------------------------------------------------
+    # Tasks
+    # ------------------------------------------------------------------
+
+    @app.post("/tasks", status_code=201)
+    def carry_task(req: CarryRequest):
+        """Carry (enqueue) a task. Returns 409 if a task with this ID already exists."""
+        now = _now_iso()
+        task = {
+            "id": req.id,
+            "title": req.title,
+            "spec": req.spec,
+            "complexity": req.complexity,
+            "priority": req.priority,
+            "depends_on": req.depends_on,
+            "touches": req.touches,
+            "created_by": req.created_by,
+            "status": "ready",
+            "current_attempt": None,
+            "attempts": [],
+            "trail": [],
+            "signals": [],
+            "created_at": now,
+            "updated_at": now,
+        }
+        try:
+            task_id = _backend.carry(task)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        return {"task_id": task_id}
+
+    @app.post("/tasks/pull")
+    def forage(req: PullRequest, response: Response):
+        """Pull the next eligible task for a worker. Returns 204 if queue is empty."""
+        with _lock:
+            task = _backend.pull(req.worker_id)
+        if task is None:
+            response.status_code = 204
+            return None
+        return task
+
+    @app.post("/tasks/{task_id}/trail", status_code=200)
+    def append_trail(task_id: str, req: TrailRequest):
+        """Append a trail entry to a task (read-modify-write under lock)."""
+        entry = {"ts": _now_iso(), "worker_id": req.worker_id, "message": req.message}
+        with _lock:
+            try:
+                _backend.append_trail(task_id, entry)
+            except FileNotFoundError as exc:
+                raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return {"ok": True}
+
+    @app.post("/tasks/{task_id}/signal", status_code=200)
+    def append_signal(task_id: str, req: SignalRequest):
+        """Append a signal entry to a task (read-modify-write under lock)."""
+        entry = {"ts": _now_iso(), "worker_id": req.worker_id, "message": req.message}
+        with _lock:
+            try:
+                _backend.append_signal(task_id, entry)
+            except FileNotFoundError as exc:
+                raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return {"ok": True}
+
+    @app.post("/tasks/{task_id}/harvest", status_code=200)
+    def harvest_task(task_id: str, req: HarvestRequest):
+        """Mark a task as harvested (done). Idempotent for same attempt.
+
+        Returns 409 for wrong attempt.
+        """
+        try:
+            _backend.mark_harvested(task_id, req.attempt_id, req.pr, req.branch)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return {"ok": True}
+
+    @app.post("/tasks/{task_id}/kickback", status_code=200)
+    def kickback_task(task_id: str, req: KickbackRequest):
+        """Return a task to ready state with the given reason."""
+        try:
+            _backend.kickback(task_id, req.reason)
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return {"ok": True}
+
+    @app.post("/tasks/{task_id}/merge", status_code=200)
+    def merge_task(task_id: str, req: MergeRequest):
+        """Mark a task attempt as merged. Soldier only."""
+        try:
+            _backend.mark_merged(task_id, req.attempt_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return {"ok": True}
+
+    @app.get("/tasks", status_code=200)
+    def list_tasks(status: str | None = Query(default=None)):
+        """List tasks with optional ?status= filter."""
+        return _backend.list_tasks(status=status)
+
+    @app.get("/tasks/{task_id}", status_code=200)
+    def get_task(task_id: str):
+        """Get a task by ID. Returns 404 if not found."""
+        task = _backend.get_task(task_id)
+        if task is None:
+            raise HTTPException(status_code=404, detail=f"Task '{task_id}' not found")
+        return task
+
+    # ------------------------------------------------------------------
+    # Guards
+    # ------------------------------------------------------------------
+
+    @app.post("/guards/{resource:path}", status_code=200)
+    def acquire_guard(resource: str, req: GuardRequest):
+        """Try to acquire an exclusive guard on a resource."""
+        with _lock:
+            acquired = _backend.guard(resource, req.owner)
+        return {"acquired": acquired}
+
+    @app.delete("/guards/{resource:path}", status_code=200)
+    def release_guard(resource: str, owner: str = Query(...)):
+        """Release a guard. Only the owner can release. Returns 403 on mismatch."""
+        try:
+            _backend.release_guard(resource, owner)
+        except PermissionError as exc:
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return {"ok": True}
+
+    # ------------------------------------------------------------------
+    # Status
+    # ------------------------------------------------------------------
+
+    @app.get("/status", status_code=200)
+    def colony_status():
+        """Return colony status summary."""
+        return _backend.status()
+
+    return app

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1,0 +1,223 @@
+"""Tests for the Colony API server (antfarm.core.serve).
+
+Uses FastAPI TestClient with a fresh FileBackend per test via tmp_path fixture.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from antfarm.core.serve import get_app
+
+
+@pytest.fixture
+def client(tmp_path):
+    from antfarm.core.backends.file import FileBackend
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend)
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _carry(client, task_id="task-001", title="Test Task", spec="Do the thing"):
+    return client.post(
+        "/tasks",
+        json={"id": task_id, "title": title, "spec": spec},
+    )
+
+
+def _register_worker(client, worker_id="worker-1"):
+    return client.post(
+        "/workers/register",
+        json={
+            "worker_id": worker_id,
+            "node_id": "node-1",
+            "agent_type": "claude-code",
+            "workspace_root": "/tmp/ws",
+        },
+    )
+
+
+def _forage(client, worker_id="worker-1"):
+    return client.post("/tasks/pull", json={"worker_id": worker_id})
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_carry_and_list(client):
+    r = _carry(client)
+    assert r.status_code == 201
+    assert r.json()["task_id"] == "task-001"
+
+    r = client.get("/tasks")
+    assert r.status_code == 200
+    tasks = r.json()
+    assert len(tasks) == 1
+    assert tasks[0]["id"] == "task-001"
+
+
+def test_carry_duplicate_returns_409(client):
+    _carry(client)
+    r = _carry(client)
+    assert r.status_code == 409
+
+
+def test_forage_returns_task(client):
+    _carry(client)
+    r = _forage(client)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["id"] == "task-001"
+    assert data["status"] == "active"
+
+
+def test_forage_empty_returns_204(client):
+    r = _forage(client)
+    assert r.status_code == 204
+
+
+def test_forage_creates_attempt(client):
+    _carry(client)
+    r = _forage(client)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["current_attempt"] is not None
+    assert len(data["attempts"]) == 1
+    assert data["attempts"][0]["status"] == "active"
+
+
+def test_trail_appends(client):
+    _carry(client)
+    task = _forage(client).json()
+    task_id = task["id"]
+
+    r = client.post(
+        f"/tasks/{task_id}/trail",
+        json={"worker_id": "worker-1", "message": "halfway done"},
+    )
+    assert r.status_code == 200
+
+    r = client.get(f"/tasks/{task_id}")
+    assert r.status_code == 200
+    trail = r.json()["trail"]
+    assert len(trail) == 1
+    assert trail[0]["message"] == "halfway done"
+    assert trail[0]["worker_id"] == "worker-1"
+
+
+def test_harvest_transitions(client):
+    _carry(client)
+    task = _forage(client).json()
+    task_id = task["id"]
+    attempt_id = task["current_attempt"]
+
+    r = client.post(
+        f"/tasks/{task_id}/harvest",
+        json={
+            "attempt_id": attempt_id,
+            "pr": "https://github.com/x/y/pull/1",
+            "branch": "feat/task-001",
+        },
+    )
+    assert r.status_code == 200
+
+    r = client.get(f"/tasks/{task_id}")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] == "done"
+    assert data["attempts"][0]["status"] == "done"
+    assert data["attempts"][0]["pr"] == "https://github.com/x/y/pull/1"
+
+
+def test_harvest_wrong_attempt_returns_409(client):
+    _carry(client)
+    task = _forage(client).json()
+    task_id = task["id"]
+
+    r = client.post(
+        f"/tasks/{task_id}/harvest",
+        json={"attempt_id": "wrong-attempt-id", "pr": "pr-url", "branch": "feat/x"},
+    )
+    assert r.status_code == 409
+
+
+def test_heartbeat_updates_worker(client):
+    _register_worker(client)
+    r = client.post(
+        "/workers/worker-1/heartbeat",
+        json={"status": {"state": "working"}},
+    )
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+
+
+def test_status_returns_summary(client):
+    _carry(client)
+    r = client.get("/status")
+    assert r.status_code == 200
+    data = r.json()
+    assert "tasks" in data
+    assert data["tasks"]["ready"] == 1
+    assert data["tasks"]["active"] == 0
+    assert data["tasks"]["done"] == 0
+
+
+def test_guard_acquire_and_release(client):
+    r = client.post("/guards/repo/main", json={"owner": "node-1/worker-1"})
+    assert r.status_code == 200
+    assert r.json()["acquired"] is True
+
+    # Second acquire from different owner should fail
+    r = client.post("/guards/repo/main", json={"owner": "node-1/worker-2"})
+    assert r.status_code == 200
+    assert r.json()["acquired"] is False
+
+    # Release by owner
+    r = client.delete("/guards/repo/main", params={"owner": "node-1/worker-1"})
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+
+    # Now re-acquire should succeed
+    r = client.post("/guards/repo/main", json={"owner": "node-1/worker-2"})
+    assert r.status_code == 200
+    assert r.json()["acquired"] is True
+
+
+def test_register_node_idempotent(client):
+    r = client.post("/nodes", json={"node_id": "node-1"})
+    assert r.status_code == 200
+
+    # Second registration should also succeed (idempotent)
+    r = client.post("/nodes", json={"node_id": "node-1"})
+    assert r.status_code == 200
+
+    r = client.get("/status")
+    assert r.json()["nodes"] == 1
+
+
+def test_signal_appends(client):
+    _carry(client)
+    task = _forage(client).json()
+    task_id = task["id"]
+
+    r = client.post(
+        f"/tasks/{task_id}/signal",
+        json={"worker_id": "worker-1", "message": "task needs re-scoping"},
+    )
+    assert r.status_code == 200
+
+    r = client.get(f"/tasks/{task_id}")
+    assert r.status_code == 200
+    signals = r.json()["signals"]
+    assert len(signals) == 1
+    assert signals[0]["message"] == "task needs re-scoping"
+    assert signals[0]["worker_id"] == "worker-1"


### PR DESCRIPTION
## Summary
- Adds `antfarm/core/serve.py`: FastAPI app with `get_app(backend, data_dir)` factory, 17 endpoints covering nodes, workers, tasks, guards, and status
- Adds `tests/test_serve.py`: 13 tests using TestClient with isolated FileBackend per test via tmp_path
- All mutations protected by `threading.Lock()` where required (pull, trail, signal, guard)

closes #8

## Test plan
- [x] All 13 serve tests pass (`python3.12 -m pytest tests/test_serve.py -x -q`)
- [x] Full suite passes (62 tests, `python3.12 -m pytest tests/ -x -q`)
- [x] Lint passes (`ruff check antfarm/core/serve.py tests/test_serve.py`)