### PR TITLE
feat(core): add ColonyClient httpx wrapper

### DIFF
--- a/antfarm/core/colony_client.py
+++ b/antfarm/core/colony_client.py
@@ -1,0 +1,104 @@
+"""Thin synchronous httpx wrapper for the Antfarm Colony API."""
+
+
+import httpx
+
+
+class ColonyClient:
+    """HTTP client for communicating with the Colony API server."""
+
+    def __init__(self, base_url: str, client: httpx.Client | None = None):
+        """Initialize client.
+
+        Args:
+            base_url: Colony server URL (e.g., "http://localhost:7433")
+            client: Optional httpx.Client for dependency injection in tests.
+        """
+        self.base_url = base_url.rstrip("/")
+        self._client = client or httpx.Client(base_url=self.base_url, timeout=30.0)
+        self._owns_client = client is None  # only close if we created it
+
+    def register_node(self, node_id: str) -> dict:
+        r = self._client.post("/nodes", json={"node_id": node_id})
+        r.raise_for_status()
+        return r.json()
+
+    def register_worker(
+        self, worker_id: str, node_id: str, agent_type: str, workspace_root: str
+    ) -> dict:
+        r = self._client.post("/workers/register", json={
+            "worker_id": worker_id,
+            "node_id": node_id,
+            "agent_type": agent_type,
+            "workspace_root": workspace_root,
+        })
+        r.raise_for_status()
+        return r.json()
+
+    def deregister_worker(self, worker_id: str) -> None:
+        r = self._client.delete(f"/workers/{worker_id}")
+        r.raise_for_status()
+
+    def heartbeat(self, worker_id: str, status: dict | None = None) -> None:
+        r = self._client.post(f"/workers/{worker_id}/heartbeat", json={"status": status or {}})
+        r.raise_for_status()
+
+    def forage(self, worker_id: str) -> dict | None:
+        """Claim next task. Returns task dict or None if queue empty (204)."""
+        r = self._client.post("/tasks/pull", json={"worker_id": worker_id})
+        if r.status_code == 204:
+            return None
+        r.raise_for_status()
+        return r.json()
+
+    def trail(self, task_id: str, worker_id: str, message: str) -> None:
+        r = self._client.post(f"/tasks/{task_id}/trail", json={
+            "worker_id": worker_id,
+            "message": message,
+        })
+        r.raise_for_status()
+
+    def signal(self, task_id: str, worker_id: str, message: str) -> None:
+        r = self._client.post(f"/tasks/{task_id}/signal", json={
+            "worker_id": worker_id,
+            "message": message,
+        })
+        r.raise_for_status()
+
+    def harvest(self, task_id: str, attempt_id: str, pr: str, branch: str) -> None:
+        r = self._client.post(f"/tasks/{task_id}/harvest", json={
+            "attempt_id": attempt_id,
+            "pr": pr,
+            "branch": branch,
+        })
+        r.raise_for_status()
+
+    def kickback(self, task_id: str, reason: str) -> None:
+        r = self._client.post(f"/tasks/{task_id}/kickback", json={"reason": reason})
+        r.raise_for_status()
+
+    def mark_merged(self, task_id: str, attempt_id: str) -> None:
+        r = self._client.post(f"/tasks/{task_id}/merge", json={"attempt_id": attempt_id})
+        r.raise_for_status()
+
+    def list_tasks(self, status: str | None = None) -> list[dict]:
+        params = {"status": status} if status else {}
+        r = self._client.get("/tasks", params=params)
+        r.raise_for_status()
+        return r.json()
+
+    def get_task(self, task_id: str) -> dict | None:
+        r = self._client.get(f"/tasks/{task_id}")
+        if r.status_code == 404:
+            return None
+        r.raise_for_status()
+        return r.json()
+
+    def status(self) -> dict:
+        r = self._client.get("/status")
+        r.raise_for_status()
+        return r.json()
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()


### PR DESCRIPTION
Prerequisite for #10 and #12. Thin httpx wrapper for colony API.

## What
- Adds `antfarm/core/colony_client.py` — a synchronous httpx wrapper for the Colony API
- Accepts optional `httpx.Client` for test injection via MockTransport
- `forage()` returns `None` on 204 (empty queue); `get_task()` returns `None` on 404
- `_owns_client` flag ensures we only close clients we created