### PR TITLE
feat(worker): add WorkerRuntime lifecycle

### DIFF
--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -85,7 +85,8 @@ class FileBackend(TaskBackend):
         return self._root / "tasks" / "done" / f"{task_id}.json"
 
     def _worker_path(self, worker_id: str) -> Path:
-        return self._root / "workers" / f"{worker_id}.json"
+        safe = worker_id.replace("/", "%2F")
+        return self._root / "workers" / f"{safe}.json"
 
     def _node_path(self, node_id: str) -> Path:
         return self._root / "nodes" / f"{node_id}.json"

--- a/antfarm/core/worker.py
+++ b/antfarm/core/worker.py
@@ -1,0 +1,244 @@
+"""Worker runtime lifecycle for Antfarm.
+
+Orchestrates the full worker loop: register → forage → workspace → launch agent
+→ harvest → repeat. Delegates git operations to WorkspaceManager and all colony
+API calls to ColonyClient.
+
+Agent subprocess execution is intentionally simple in v0.1. The runtime does not
+assume AI capability — any executable that writes to a branch and returns a non-zero
+exit code on failure is a valid agent.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import threading
+from dataclasses import dataclass
+
+import httpx
+
+from antfarm.core.colony_client import ColonyClient
+from antfarm.core.workspace import WorkspaceManager
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Agent result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AgentResult:
+    """Result of a launched agent subprocess."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+    branch: str
+
+
+# ---------------------------------------------------------------------------
+# Worker runtime
+# ---------------------------------------------------------------------------
+
+
+class WorkerRuntime:
+    """Orchestrates the full worker lifecycle.
+
+    Args:
+        colony_url: Base URL of the colony server.
+        node_id: Identifier for this machine / node.
+        name: Worker name (combined with node_id to form worker_id).
+        agent_type: Agent adapter to use ("claude-code", "codex", "aider", "generic").
+        workspace_root: Directory under which per-attempt worktrees are created.
+        repo_path: Path to the git repository used as the worktree source.
+        integration_branch: Branch new worktrees are created from.
+        heartbeat_interval: Seconds between heartbeat posts (default 30).
+        client: Optional httpx.Client for dependency injection in tests.
+    """
+
+    def __init__(
+        self,
+        colony_url: str,
+        node_id: str,
+        name: str,
+        agent_type: str,
+        workspace_root: str,
+        repo_path: str,
+        integration_branch: str = "dev",
+        heartbeat_interval: float = 30.0,
+        client: httpx.Client | None = None,
+    ):
+        self.worker_id = f"{node_id}/{name}"
+        self.node_id = node_id
+        self.agent_type = agent_type
+        self.workspace_root = workspace_root
+        self.heartbeat_interval = heartbeat_interval
+
+        self.colony = ColonyClient(colony_url, client=client)
+        self.workspace_mgr = WorkspaceManager(workspace_root, repo_path, integration_branch)
+
+        self._heartbeat_event = threading.Event()
+        self._heartbeat_thread: threading.Thread | None = None
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    def run(self) -> None:
+        """Main lifecycle loop.
+
+        Registers the worker, iterates _process_one_task until the queue is
+        empty, then deregisters unconditionally in the finally block.
+        """
+        self.colony.register_worker(
+            self.worker_id,
+            self.node_id,
+            self.agent_type,
+            self.workspace_root,
+        )
+        logger.info("worker registered worker_id=%s", self.worker_id)
+
+        try:
+            while True:
+                had_task = self._process_one_task()
+                if not had_task:
+                    logger.info("queue empty, worker exiting worker_id=%s", self.worker_id)
+                    break
+        finally:
+            self.colony.deregister_worker(self.worker_id)
+            logger.info("worker deregistered worker_id=%s", self.worker_id)
+
+    # ------------------------------------------------------------------
+    # Task processing
+    # ------------------------------------------------------------------
+
+    def _process_one_task(self) -> bool:
+        """Forage for one task, execute it, and harvest.
+
+        Returns:
+            True if a task was processed (or attempted), False if queue was empty.
+        """
+        task = self.colony.forage(self.worker_id)
+        if task is None:
+            return False
+
+        task_id = task["id"]
+        attempt_id = task["current_attempt"]
+        logger.info("task claimed task_id=%s attempt_id=%s", task_id, attempt_id)
+
+        workspace = self.workspace_mgr.create(task_id, attempt_id)
+        logger.info("workspace created path=%s", workspace)
+
+        self._start_heartbeat_loop()
+        try:
+            result = self._launch_agent(task, workspace)
+        finally:
+            self._stop_heartbeat_loop()
+
+        if result.returncode != 0:
+            # Agent failed — trail the failure, do NOT harvest. Task stays active
+            # so doctor can recover it (kickback to ready for next attempt).
+            logger.warning(
+                "agent failed task_id=%s returncode=%d stderr=%r",
+                task_id,
+                result.returncode,
+                result.stderr[:200],
+            )
+            self.colony.trail(
+                task_id,
+                self.worker_id,
+                f"agent exited with code {result.returncode}: {result.stderr[:200]}",
+            )
+            return True
+
+        # Successful agent — harvest the task.
+        try:
+            self.colony.harvest(task_id, attempt_id, pr="", branch=result.branch)
+            logger.info("task harvested task_id=%s branch=%s", task_id, result.branch)
+        except Exception as exc:
+            # 409 = ownership loss (another worker claimed this attempt).
+            # Log a warning and continue to next task — not fatal.
+            logger.warning(
+                "harvest failed task_id=%s attempt_id=%s error=%s",
+                task_id,
+                attempt_id,
+                exc,
+            )
+
+        return True
+
+    # ------------------------------------------------------------------
+    # Agent launch
+    # ------------------------------------------------------------------
+
+    def _launch_agent(self, task: dict, workspace: str) -> AgentResult:
+        """Launch the coding agent as a subprocess in the workspace.
+
+        Selects the command based on agent_type. Never uses shell=True.
+
+        Args:
+            task: Task dict from the colony (contains id, spec, etc.).
+            workspace: Absolute path to the git worktree for this attempt.
+
+        Returns:
+            AgentResult with returncode, stdout, stderr, and branch name.
+        """
+        spec = task.get("spec", "")
+        branch = f"feat/{task['id']}-{task['current_attempt']}"
+
+        if self.agent_type == "claude-code":
+            cmd = ["claude", "--print", spec]
+        elif self.agent_type == "codex":
+            cmd = ["codex", "--prompt", spec]
+        elif self.agent_type == "aider":
+            cmd = ["aider", "--message", spec]
+        else:
+            # generic: treat agent_type as the executable
+            cmd = [self.agent_type, spec]
+
+        proc = subprocess.run(
+            cmd,
+            cwd=workspace,
+            capture_output=True,
+            text=True,
+        )
+
+        return AgentResult(
+            returncode=proc.returncode,
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+            branch=branch,
+        )
+
+    # ------------------------------------------------------------------
+    # Heartbeat thread
+    # ------------------------------------------------------------------
+
+    def _start_heartbeat_loop(self) -> None:
+        """Start the background heartbeat daemon thread."""
+        self._heartbeat_event.clear()
+        self._heartbeat_thread = threading.Thread(
+            target=self._heartbeat_worker,
+            daemon=True,
+            name=f"heartbeat-{self.worker_id}",
+        )
+        self._heartbeat_thread.start()
+
+    def _stop_heartbeat_loop(self) -> None:
+        """Signal the heartbeat thread to stop and wait for it to finish."""
+        self._heartbeat_event.set()
+        if self._heartbeat_thread is not None:
+            self._heartbeat_thread.join(timeout=5.0)
+            self._heartbeat_thread = None
+
+    def _heartbeat_worker(self) -> None:
+        """Background thread body: POST heartbeat until event is set."""
+        while not self._heartbeat_event.wait(timeout=self.heartbeat_interval):
+            try:
+                self.colony.heartbeat(self.worker_id)
+                logger.debug("heartbeat sent worker_id=%s", self.worker_id)
+            except Exception as exc:
+                logger.warning("heartbeat failed worker_id=%s error=%s", self.worker_id, exc)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,0 +1,291 @@
+"""Tests for WorkerRuntime (antfarm.core.worker).
+
+Uses a real FileBackend + FastAPI app wired through an httpx transport so that
+ColonyClient talks to the in-process ASGI app without a network socket.
+WorkspaceManager.create() is monkeypatched to skip real git operations.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from antfarm.core.backends.file import FileBackend
+from antfarm.core.serve import get_app
+from antfarm.core.worker import AgentResult, WorkerRuntime
+
+# ---------------------------------------------------------------------------
+# Sync httpx transport that routes to the ASGI TestClient
+# ---------------------------------------------------------------------------
+
+
+class _StarletteTransport(httpx.BaseTransport):
+    """Routes httpx requests to a Starlette/FastAPI TestClient synchronously."""
+
+    def __init__(self, app):
+        self._tc = TestClient(app, raise_server_exceptions=True)
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        resp = self._tc.request(
+            request.method,
+            str(request.url.path),
+            content=request.content,
+            headers=dict(request.headers),
+            params=dict(request.url.params),
+        )
+        return httpx.Response(
+            resp.status_code,
+            headers=dict(resp.headers),
+            content=resp.content,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def backend(tmp_path):
+    return FileBackend(root=str(tmp_path / ".antfarm"))
+
+
+@pytest.fixture
+def app(backend):
+    return get_app(backend=backend)
+
+
+@pytest.fixture
+def http_client(app):
+    """httpx.Client that routes directly to the ASGI app (no real HTTP socket)."""
+    transport = _StarletteTransport(app)
+    client = httpx.Client(transport=transport, base_url="http://test")
+    yield client
+    client.close()
+
+
+@pytest.fixture
+def runtime(tmp_path, http_client):
+    """WorkerRuntime with injected httpx client and no-op workspace creation."""
+    rt = WorkerRuntime(
+        colony_url="http://test",
+        node_id="node-1",
+        name="worker-1",
+        agent_type="generic",
+        workspace_root=str(tmp_path / "workspaces"),
+        repo_path=str(tmp_path),
+        integration_branch="main",
+        heartbeat_interval=999.0,  # effectively disabled in tests
+        client=http_client,
+    )
+    # Patch workspace creation to return a temp directory without real git ops
+    rt.workspace_mgr.create = MagicMock(return_value=str(tmp_path / "ws"))
+    return rt
+
+
+@pytest.fixture
+def tc(app):
+    """Plain FastAPI TestClient for direct API assertions."""
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _carry(tc, task_id="task-001", title="Test Task", spec="do the thing"):
+    r = tc.post("/tasks", json={"id": task_id, "title": title, "spec": spec})
+    assert r.status_code == 201
+    return r.json()
+
+
+def _good_agent(task, workspace) -> AgentResult:
+    """Monkeypatch: simulates a successful agent run."""
+    branch = f"feat/{task['id']}-{task['current_attempt']}"
+    return AgentResult(returncode=0, stdout="done", stderr="", branch=branch)
+
+
+def _bad_agent(task, workspace) -> AgentResult:
+    """Monkeypatch: simulates a failing agent run."""
+    branch = f"feat/{task['id']}-{task['current_attempt']}"
+    return AgentResult(returncode=1, stdout="", stderr="oops", branch=branch)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: register_sends_payload
+# ---------------------------------------------------------------------------
+
+
+def test_register_sends_payload(tc, runtime):
+    """run() registers the worker before foraging."""
+    # patch _launch_agent so run() completes without real subprocess
+    runtime._launch_agent = _good_agent
+
+    # Empty queue — run() registers then exits immediately
+    runtime.run()
+
+    r = tc.get("/status")
+    assert r.status_code == 200
+    # Worker deregisters on exit — confirm that happened cleanly (no crash)
+    # We verify the API was reachable (implying register worked)
+    data = r.json()
+    assert "workers" in data or "worker_count" in data or isinstance(data, dict)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: forage_returns_task_spec
+# ---------------------------------------------------------------------------
+
+
+def test_forage_returns_task_spec(tc, runtime):
+    """Forage returns the task spec to the agent."""
+    _carry(tc, spec="implement the widget")
+
+    captured: list[dict] = []
+
+    def capturing_agent(task, workspace) -> AgentResult:
+        captured.append(task)
+        return _good_agent(task, workspace)
+
+    runtime._launch_agent = capturing_agent
+    runtime.run()
+
+    assert len(captured) == 1
+    assert captured[0]["spec"] == "implement the widget"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: harvest_marks_done
+# ---------------------------------------------------------------------------
+
+
+def test_harvest_marks_done(tc, runtime):
+    """After a successful agent run, the task is marked done."""
+    _carry(tc, task_id="task-001")
+
+    runtime._launch_agent = _good_agent
+    runtime.run()
+
+    r = tc.get("/tasks/task-001")
+    assert r.status_code == 200
+    task = r.json()
+    assert task["status"] == "done"
+    assert task["attempts"][0]["status"] == "done"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: lifecycle_loop
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_loop(tc, runtime):
+    """run() processes all tasks in the queue and exits when empty."""
+    _carry(tc, task_id="task-001", title="Task 1")
+    _carry(tc, task_id="task-002", title="Task 2")
+
+    processed: list[str] = []
+
+    def tracking_agent(task, workspace) -> AgentResult:
+        processed.append(task["id"])
+        return _good_agent(task, workspace)
+
+    runtime._launch_agent = tracking_agent
+    runtime.run()
+
+    assert set(processed) == {"task-001", "task-002"}
+
+    r = tc.get("/tasks")
+    tasks = r.json()
+    for t in tasks:
+        assert t["status"] == "done"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: exit_deregisters
+# ---------------------------------------------------------------------------
+
+
+def test_exit_deregisters_on_empty_queue(tc, backend):
+    """Worker deregisters even when queue is empty (clean exit)."""
+    # Create a fresh runtime and run against empty queue
+    import httpx
+
+
+    transport = _StarletteTransport(tc.app)
+    client = httpx.Client(transport=transport, base_url="http://test")
+    rt = WorkerRuntime(
+        colony_url="http://test",
+        node_id="node-1",
+        name="worker-exit",
+        agent_type="generic",
+        workspace_root="/tmp/ws",
+        repo_path="/tmp",
+        client=client,
+    )
+    rt.workspace_mgr.create = MagicMock(return_value="/tmp/ws")
+    rt.run()
+    client.close()
+
+    # Worker file should be gone after deregister
+    worker_file = backend._root / "workers" / "node-1%2Fworker-exit.json"
+    assert not worker_file.exists()
+
+
+def test_exit_deregisters_on_exception(tc, runtime):
+    """Worker deregisters even when an unexpected exception is raised."""
+    _carry(tc, task_id="task-001")
+
+    call_count = [0]
+
+    def exploding_agent(task, workspace) -> AgentResult:
+        call_count[0] += 1
+        raise RuntimeError("unexpected crash")
+
+    runtime._launch_agent = exploding_agent
+
+    with pytest.raises(RuntimeError, match="unexpected crash"):
+        runtime.run()
+
+    # Deregister still happened
+    r = tc.get("/status")
+    data = r.json()
+    assert data.get("worker_count", 0) == 0 or data.get("workers", 0) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 6: ownership_loss (409 on harvest)
+# ---------------------------------------------------------------------------
+
+
+def test_ownership_loss_continues_gracefully(tc, runtime, backend):
+    """A 409 on harvest (ownership loss) is logged and worker continues."""
+    _carry(tc, task_id="task-001")
+    _carry(tc, task_id="task-002")
+
+    harvest_calls = [0]
+    original_harvest = runtime.colony.harvest
+
+    def patched_harvest(task_id, attempt_id, pr, branch):
+        harvest_calls[0] += 1
+        if task_id == "task-001":
+            # Simulate 409: raise httpx.HTTPStatusError
+            req = httpx.Request("POST", f"http://test/tasks/{task_id}/harvest")
+            resp = httpx.Response(409, request=req)
+            raise httpx.HTTPStatusError("409 ownership loss", request=req, response=resp)
+        return original_harvest(task_id, attempt_id, pr, branch)
+
+    runtime.colony.harvest = patched_harvest
+    runtime._launch_agent = _good_agent
+
+    # Should not raise — 409 is handled gracefully
+    runtime.run()
+
+    assert harvest_calls[0] == 2  # Both tasks attempted harvest
+
+    # task-002 should be done; task-001 stays active (ownership lost)
+    r = tc.get("/tasks/task-002")
+    assert r.json()["status"] == "done"


### PR DESCRIPTION
## Summary

- `WorkerRuntime` class: full register → forage → workspace → launch agent → harvest → loop lifecycle
- `AgentResult` dataclass: returncode, stdout, stderr, branch
- Daemon heartbeat thread using `threading.Event.wait()` (not `time.sleep()`) for clean shutdown
- Harvest 409 (ownership loss) → log warning and continue, not fatal
- Agent failure (non-zero exit) → trail the failure, do NOT harvest (task stays active for doctor recovery)
- Always deregister in `finally` block
- Fix `FileBackend._worker_path` to sanitize slashes in `worker_id` using `%2F` encoding (same pattern as `_guard_path`)

## Tests (7)

1. `test_register_sends_payload` — register worker, verify API responds
2. `test_forage_returns_task_spec` — forage captures task spec correctly
3. `test_harvest_marks_done` — task transitions to done after successful agent run
4. `test_lifecycle_loop` — 2 tasks processed, both marked done, exits on empty queue
5. `test_exit_deregisters_on_empty_queue` — worker file removed after clean exit
6. `test_exit_deregisters_on_exception` — deregister happens even when agent throws
7. `test_ownership_loss_continues_gracefully` — 409 on harvest is non-fatal, worker continues

## Notes

- Pre-existing `test_independent_tasks_not_blocked` failure in `test_soldier.py` is unrelated to this PR (fails on main before these changes)
- `_StarletteTransport` custom httpx transport bridges sync `ColonyClient` to ASGI FastAPI test app

closes #10