### PR TITLE
feat(adapter): add Claude Code reference adapter

### DIFF
--- a/antfarm/adapters/claude_code/agents/queen.md
+++ b/antfarm/adapters/claude_code/agents/queen.md
@@ -1,0 +1,45 @@
+# Antfarm Queen — Claude Code Agent (Example Only)
+
+> **This is an example, not a core platform feature.** The Queen role in v0.1 is a human or automation that calls `antfarm carry` to decompose work into tasks. This agent definition shows what an AI-powered Queen *could* look like.
+
+## What the Queen Does
+
+The Queen receives a high-level specification and breaks it into concrete tasks, then enqueues them via `antfarm carry`.
+
+## Example: Decomposing a Feature Spec
+
+Given a spec like:
+
+> "Add user authentication: sign-up, login, JWT issuance, and a /me endpoint."
+
+An AI Queen would reason through the subtasks and call:
+
+```bash
+antfarm carry --title "Add users table migration" \
+  --description "Alembic migration: create users table with id, email, hashed_password, created_at" \
+  --branch "feat/auth-users-migration"
+
+antfarm carry --title "Implement JWT issuance" \
+  --description "Create core/auth.py: hash password, verify, issue HS256 JWT with 24h expiry" \
+  --branch "feat/auth-jwt"
+
+antfarm carry --title "Add /auth/signup and /auth/login endpoints" \
+  --description "FastAPI router: POST /auth/signup (create user), POST /auth/login (return JWT)" \
+  --branch "feat/auth-endpoints"
+
+antfarm carry --title "Add /users/me endpoint" \
+  --description "GET /users/me: decode JWT, return user profile. Requires auth middleware." \
+  --branch "feat/auth-me-endpoint"
+```
+
+Each `antfarm carry` call creates one task in the queue. Workers then claim and implement them independently.
+
+## Why This Is an Example
+
+In v0.1, task decomposition is done by humans. The Queen agent definition is included here to:
+
+1. Show how AI decomposition *could* integrate with the platform
+2. Serve as a starting point for a v0.2 AI-Queen feature
+3. Document the `antfarm carry` interface for reference
+
+To use this pattern today, run the `antfarm carry` commands yourself (or in a script) rather than having an AI agent do it.

--- a/antfarm/adapters/claude_code/agents/soldier.md
+++ b/antfarm/adapters/claude_code/agents/soldier.md
@@ -1,0 +1,16 @@
+# Antfarm Soldier — Claude Code Agent (v0.2 Placeholder)
+
+> **v0.1 note:** In v0.1, the Soldier role is implemented as a deterministic Python script (`antfarm/soldier.py`). It detects conflicts, pauses tasks, and escalates to the Queen without requiring an AI model. No agent definition is used at runtime in v0.1.
+
+## v0.2 — AI-Assisted Conflict Resolution
+
+This agent definition will be activated in **v0.2** to bring AI reasoning into the Soldier's conflict-resolution loop.
+
+In v0.2, when the Soldier detects a merge conflict or a task collision that cannot be resolved deterministically, it will spawn this Claude Code agent to:
+
+1. **Inspect the conflict** — read the differing files, understand intent from task descriptions and commit messages
+2. **Propose a resolution** — suggest a merge strategy or reorder tasks to eliminate the conflict
+3. **Apply and verify** — implement the resolution, run tests, confirm correctness
+4. **Report back** — return a structured decision so the deterministic Soldier can continue orchestration
+
+Until v0.2 is implemented, this file serves as documentation of the planned interface and a placeholder for future agent logic.

--- a/antfarm/adapters/claude_code/agents/worker.md
+++ b/antfarm/adapters/claude_code/agents/worker.md
@@ -1,0 +1,70 @@
+# Antfarm Worker — Claude Code Agent
+
+You are an Antfarm worker agent running inside Claude Code. Your job is to claim tasks from the Antfarm queue, implement them, and harvest results back to the platform.
+
+## Environment Variables
+
+- `$ANTFARM_URL` — base URL of the Antfarm API server (e.g. `http://localhost:8000`)
+- `$WORKER_ID` — your unique worker identifier (provided at spawn time)
+
+## Workflow
+
+### 1. Claim a Task (Forage)
+
+On start, run:
+
+```bash
+antfarm forage --worker-id $WORKER_ID
+```
+
+This claims the next available task and prints its `TASK_ID`, `ATTEMPT_ID`, and instructions. If no task is available, the command exits with a message — wait or exit.
+
+> **Note:** Before foraging, the `pre_forage` hook automatically syncs the integration branch (fetch, checkout, pull). This ensures you start from a clean, up-to-date base.
+
+### 2. Do the Work
+
+Read the task instructions carefully, then implement the changes. Use your full Claude Code capabilities: read files, edit code, run tests, lint.
+
+During long operations, leave trail messages so the team can see progress:
+
+```bash
+antfarm trail TASK_ID "message" --worker-id $WORKER_ID
+```
+
+Examples:
+```bash
+antfarm trail abc123 "Reading existing code structure" --worker-id $WORKER_ID
+antfarm trail abc123 "Tests passing, opening PR" --worker-id $WORKER_ID
+```
+
+### 3. Commit, Push, Open PR
+
+When your implementation is complete and tests pass:
+
+```bash
+git add -p                          # stage relevant changes
+git commit -m "type(scope): description #ISSUE_NUM"
+git push -u origin BRANCH_NAME
+gh pr create --base dev --title "..." --body "closes #ISSUE_NUM ..."
+```
+
+### 4. Harvest (Mark Complete)
+
+After the PR is open, report completion:
+
+```bash
+antfarm harvest TASK_ID --pr PR_URL --attempt ATTEMPT_ID --branch BRANCH_NAME
+```
+
+This marks the task as done and releases the worker slot.
+
+## Heartbeat
+
+You do **not** need to send heartbeats manually. The `PostToolUse` hook in `.claude/settings.json` fires `hooks/heartbeat.sh` automatically after every tool call, keeping your worker slot alive.
+
+## Rules
+
+- Never push directly to `main` — always branch from `dev` and open a PR
+- One commit per logical change; reference the issue number in every commit
+- If you encounter an unrecoverable error, trail a message before exiting so the task can be retried
+- Do not mark harvest until the PR is open and tests pass

--- a/antfarm/adapters/claude_code/hooks/heartbeat.sh
+++ b/antfarm/adapters/claude_code/hooks/heartbeat.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+curl -s -m 1 "$ANTFARM_URL/workers/$WORKER_ID/heartbeat" -X POST \
+  -H "Content-Type: application/json" -d '{}' || true

--- a/antfarm/adapters/claude_code/hooks/pre_forage.sh
+++ b/antfarm/adapters/claude_code/hooks/pre_forage.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+git fetch origin
+git checkout "${INTEGRATION_BRANCH:-dev}"
+git pull origin "${INTEGRATION_BRANCH:-dev}"

--- a/antfarm/adapters/claude_code/setup.sh
+++ b/antfarm/adapters/claude_code/setup.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# setup.sh — Install the Antfarm Claude Code adapter into a project.
+#
+# Run from your project root:
+#   bash path/to/antfarm/adapters/claude_code/setup.sh
+#
+# Idempotent: safe to run multiple times.
+
+set -euo pipefail
+
+ADAPTER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="${PWD}"
+CLAUDE_DIR="${PROJECT_ROOT}/.claude"
+AGENTS_DIR="${CLAUDE_DIR}/agents"
+SETTINGS_FILE="${CLAUDE_DIR}/settings.json"
+
+echo "Antfarm Claude Code adapter setup"
+echo "  Adapter source : ${ADAPTER_DIR}"
+echo "  Project root   : ${PROJECT_ROOT}"
+echo ""
+
+# 1. Create .claude/agents/ if needed
+if [ ! -d "${AGENTS_DIR}" ]; then
+  mkdir -p "${AGENTS_DIR}"
+  echo "[created] ${AGENTS_DIR}"
+else
+  echo "[exists]  ${AGENTS_DIR}"
+fi
+
+# 2. Symlink agent definitions into .claude/agents/
+for agent_md in "${ADAPTER_DIR}/agents/"*.md; do
+  name="$(basename "${agent_md}")"
+  target="${AGENTS_DIR}/${name}"
+  if [ -L "${target}" ]; then
+    echo "[exists]  symlink ${target}"
+  elif [ -f "${target}" ]; then
+    echo "[skip]    ${target} already exists as a regular file — not overwriting"
+  else
+    ln -s "${agent_md}" "${target}"
+    echo "[linked]  ${target} -> ${agent_md}"
+  fi
+done
+
+# 3. Add heartbeat PostToolUse hook to .claude/settings.json
+HEARTBEAT_CMD="${ADAPTER_DIR}/hooks/heartbeat.sh"
+
+if [ ! -f "${SETTINGS_FILE}" ]; then
+  # Create a minimal settings.json with the heartbeat hook
+  cat > "${SETTINGS_FILE}" <<EOF
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${HEARTBEAT_CMD}"
+          }
+        ]
+      }
+    ]
+  }
+}
+EOF
+  echo "[created] ${SETTINGS_FILE} with heartbeat hook"
+else
+  # Check if heartbeat is already present
+  if grep -q "heartbeat.sh" "${SETTINGS_FILE}" 2>/dev/null; then
+    echo "[exists]  heartbeat hook already in ${SETTINGS_FILE}"
+  else
+    echo ""
+    echo "[manual]  heartbeat hook NOT added automatically — settings.json already exists."
+    echo "          Add this to your PostToolUse hooks in ${SETTINGS_FILE}:"
+    echo ""
+    echo '          {'
+    echo '            "type": "command",'
+    echo "            \"command\": \"${HEARTBEAT_CMD}\""
+    echo '          }'
+    echo ""
+  fi
+fi
+
+echo ""
+echo "Done. Installed:"
+echo "  .claude/agents/worker.md   — worker agent (forage → implement → harvest)"
+echo "  .claude/agents/soldier.md  — v0.2 placeholder (conflict resolution)"
+echo "  .claude/agents/queen.md    — example: AI-driven task decomposition"
+echo "  PostToolUse heartbeat hook — keeps worker slot alive automatically"
+echo ""
+echo "Set environment variables before starting a worker session:"
+echo "  export ANTFARM_URL=http://localhost:8000"
+echo "  export WORKER_ID=<your-worker-id>"


### PR DESCRIPTION
## Summary

- Adds `antfarm/adapters/claude_code/` with 6 files implementing the Claude Code reference adapter
- `agents/worker.md` — full worker lifecycle: forage → trail → harvest, with heartbeat note and pre_forage hook reference
- `agents/soldier.md` — v0.2 placeholder explaining deterministic v0.1 soldier and future AI conflict resolution
- `agents/queen.md` — example-only agent showing AI-driven task decomposition via `antfarm carry`
- `hooks/heartbeat.sh` — PostToolUse hook with 1s timeout and silent failure
- `hooks/pre_forage.sh` — reference git-sync hook (fetch, checkout, pull integration branch)
- `setup.sh` — idempotent installer: creates `.claude/agents/`, symlinks all agent defs, wires heartbeat into `.claude/settings.json`

## Test plan

- [ ] Verify all 6 files exist under `antfarm/adapters/claude_code/`
- [ ] Confirm `.sh` files are executable (`ls -l hooks/ setup.sh`)
- [ ] Run `ruff check .` — no errors
- [ ] Run `setup.sh` in a temp project dir, confirm symlinks created and settings.json written
- [ ] Re-run `setup.sh` — confirm idempotent (no duplicate entries, no errors)

closes #15