### PR TITLE
feat(core): add bearer token authentication

### DIFF
--- a/antfarm/core/auth.py
+++ b/antfarm/core/auth.py
@@ -1,0 +1,81 @@
+"""Bearer token authentication for the Antfarm Colony API.
+
+Provides HMAC-based token generation and FastAPI middleware for verifying
+Authorization: Bearer <token> headers. When enabled, all endpoints except
+GET /status require a valid token.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+
+def generate_token(secret: str) -> str:
+    """Generate a bearer token from a shared secret.
+
+    Uses HMAC-SHA256 with the secret as both key and message,
+    producing a deterministic hex token. This is intentionally simple —
+    the token is a static credential derived from the secret, not a
+    time-limited JWT.
+
+    Args:
+        secret: Shared secret string.
+
+    Returns:
+        Hex-encoded HMAC-SHA256 token.
+    """
+    return hmac.new(secret.encode(), secret.encode(), hashlib.sha256).hexdigest()
+
+
+def verify_token(token: str, secret: str) -> bool:
+    """Verify a bearer token against a shared secret.
+
+    Args:
+        token: The token from the Authorization header.
+        secret: The shared secret used to generate valid tokens.
+
+    Returns:
+        True if the token is valid.
+    """
+    expected = generate_token(secret)
+    return hmac.compare_digest(token, expected)
+
+
+def create_auth_middleware(secret: str):
+    """Create a FastAPI middleware that enforces bearer token auth.
+
+    GET /status is exempt — it is the only unauthenticated endpoint.
+
+    Args:
+        secret: The shared secret for token verification.
+
+    Returns:
+        An async middleware function.
+    """
+
+    async def auth_middleware(request: Request, call_next):
+        # GET /status is always public
+        if request.method == "GET" and request.url.path == "/status":
+            return await call_next(request)
+
+        auth_header = request.headers.get("authorization", "")
+        if not auth_header.startswith("Bearer "):
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Missing or invalid Authorization header"},
+            )
+
+        token = auth_header[7:]  # strip "Bearer "
+        if not verify_token(token, secret):
+            return JSONResponse(
+                status_code=401,
+                content={"detail": "Invalid bearer token"},
+            )
+
+        return await call_next(request)
+
+    return auth_middleware

--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -27,23 +27,44 @@ COLONY_URL_OPTION = click.option(
     help="Colony server URL.",
 )
 
+TOKEN_OPTION = click.option(
+    "--token",
+    default=None,
+    envvar="ANTFARM_TOKEN",
+    help="Bearer token for colony authentication.",
+)
 
-def _post(colony_url: str, path: str, payload: dict) -> dict | None:
-    r = httpx.post(f"{colony_url.rstrip('/')}{path}", json=payload)
+
+def _auth_headers(token: str | None) -> dict:
+    if token:
+        return {"Authorization": f"Bearer {token}"}
+    return {}
+
+
+def _post(
+    colony_url: str, path: str, payload: dict, token: str | None = None
+) -> dict | None:
+    r = httpx.post(
+        f"{colony_url.rstrip('/')}{path}", json=payload, headers=_auth_headers(token)
+    )
     r.raise_for_status()
     if r.status_code == 204:
         return None
     return r.json()
 
 
-def _get(colony_url: str, path: str) -> dict:
-    r = httpx.get(f"{colony_url.rstrip('/')}{path}")
+def _get(colony_url: str, path: str, token: str | None = None) -> dict:
+    r = httpx.get(f"{colony_url.rstrip('/')}{path}", headers=_auth_headers(token))
     r.raise_for_status()
     return r.json()
 
 
-def _delete(colony_url: str, path: str, params: dict | None = None) -> None:
-    r = httpx.delete(f"{colony_url.rstrip('/')}{path}", params=params or {})
+def _delete(
+    colony_url: str, path: str, params: dict | None = None, token: str | None = None
+) -> None:
+    r = httpx.delete(
+        f"{colony_url.rstrip('/')}{path}", params=params or {}, headers=_auth_headers(token)
+    )
     r.raise_for_status()
 
 
@@ -66,7 +87,13 @@ def main():
 @click.option("--port", default=7433, show_default=True, help="Port to listen on.")
 @click.option("--host", default="0.0.0.0", show_default=True, help="Host to bind.")
 @click.option("--data-dir", default=".antfarm", show_default=True, help="Data directory.")
-def colony(port: int, host: str, data_dir: str):
+@click.option(
+    "--auth-token",
+    default=None,
+    envvar="ANTFARM_AUTH_TOKEN",
+    help="Shared secret for bearer token auth. Enables auth on all endpoints except GET /status.",
+)
+def colony(port: int, host: str, data_dir: str, auth_token: str | None):
     """Start the colony server."""
     import uvicorn
 
@@ -74,7 +101,11 @@ def colony(port: int, host: str, data_dir: str):
     from antfarm.core.serve import get_app
 
     backend = FileBackend(data_dir)
-    app = get_app(backend)
+    app = get_app(backend, auth_secret=auth_token)
+    if auth_token:
+        from antfarm.core.auth import generate_token
+
+        click.echo(f"Auth enabled. Bearer token: {generate_token(auth_token)}")
     uvicorn.run(app, host=host, port=port)
 
 
@@ -86,9 +117,10 @@ def colony(port: int, host: str, data_dir: str):
 @main.command()
 @click.option("--node", required=True, help="Node ID to register.")
 @COLONY_URL_OPTION
-def join(node: str, colony_url: str):
+@TOKEN_OPTION
+def join(node: str, colony_url: str, token: str | None):
     """Register this node with the colony."""
-    result = _post(colony_url, "/nodes", {"node_id": node})
+    result = _post(colony_url, "/nodes", {"node_id": node}, token=token)
     click.echo(f"Joined colony as node '{node}': {result}")
 
 
@@ -108,8 +140,9 @@ def worker():
 @click.option("--workspace-root", default=None, help="Root directory for worktrees.")
 @click.option("--node", required=True, help="Node ID this worker belongs to.")
 @click.option("--repo-path", default=".", show_default=True, help="Path to git repo.")
-@click.option("--integration-branch", default="dev", show_default=True, help="Branch to create worktrees from.")
+@click.option("--integration-branch", default="dev", show_default=True, help="Integration branch.")
 @COLONY_URL_OPTION
+@TOKEN_OPTION
 def worker_start(
     agent: str,
     name: str | None,
@@ -118,6 +151,7 @@ def worker_start(
     repo_path: str,
     integration_branch: str,
     colony_url: str,
+    token: str | None,
 ):
     """Start a worker and enter the forage loop."""
     from antfarm.core.worker import WorkerRuntime
@@ -133,6 +167,7 @@ def worker_start(
         workspace_root=ws_root,
         repo_path=repo_path,
         integration_branch=integration_branch,
+        token=token,
     )
     runtime.run()
 
@@ -158,6 +193,7 @@ def worker_start(
 @click.option("--file", "file_path", default=None, help="JSON file with task payload.")
 @click.option("--id", "task_id", default=None, help="Task ID (auto-generated if omitted).")
 @COLONY_URL_OPTION
+@TOKEN_OPTION
 def carry(
     title: str | None,
     spec: str | None,
@@ -168,6 +204,7 @@ def carry(
     file_path: str | None,
     task_id: str | None,
     colony_url: str,
+    token: str | None,
 ):
     """Submit a task to the colony."""
     if file_path:
@@ -189,7 +226,7 @@ def carry(
         task_id = f"task-{int(time.time() * 1000)}"
     payload["id"] = task_id
 
-    result = _post(colony_url, "/tasks", payload)
+    result = _post(colony_url, "/tasks", payload, token=token)
     click.echo(f"Task created: {result}")
 
 
@@ -200,9 +237,10 @@ def carry(
 
 @main.command()
 @COLONY_URL_OPTION
-def scout(colony_url: str):
+@TOKEN_OPTION
+def scout(colony_url: str, token: str | None):
     """Show colony status as a table."""
-    status = _get(colony_url, "/status")
+    status = _get(colony_url, "/status", token=token)
     click.echo(f"{'Field':<25} {'Value'}")
     click.echo("-" * 40)
     for key, value in status.items():
@@ -246,7 +284,15 @@ def doctor(fix: bool, data_dir: str):
 @click.option("--agent", required=True, help="Agent type.")
 @click.option("--workspace-root", default=None, help="Workspace root directory.")
 @COLONY_URL_OPTION
-def hatch(name: str | None, node: str, agent: str, workspace_root: str | None, colony_url: str):
+@TOKEN_OPTION
+def hatch(
+    name: str | None,
+    node: str,
+    agent: str,
+    workspace_root: str | None,
+    colony_url: str,
+    token: str | None,
+):
     """Register a worker with the colony (low-level)."""
     worker_name = name or agent
     ws_root = workspace_root or f".antfarm/workspaces/{worker_name}"
@@ -256,16 +302,17 @@ def hatch(name: str | None, node: str, agent: str, workspace_root: str | None, c
         "node_id": node,
         "agent_type": agent,
         "workspace_root": ws_root,
-    })
+    }, token=token)
     click.echo(f"Worker registered: {result}")
 
 
 @main.command()
 @click.option("--worker-id", required=True, help="Worker ID.")
 @COLONY_URL_OPTION
-def forage(worker_id: str, colony_url: str):
+@TOKEN_OPTION
+def forage(worker_id: str, colony_url: str, token: str | None):
     """Pull the next available task (low-level)."""
-    result = _post(colony_url, "/tasks/pull", {"worker_id": worker_id})
+    result = _post(colony_url, "/tasks/pull", {"worker_id": worker_id}, token=token)
     if result is None:
         click.echo("No tasks available")
     else:
@@ -277,12 +324,13 @@ def forage(worker_id: str, colony_url: str):
 @click.argument("message")
 @click.option("--worker-id", required=True, help="Worker ID.")
 @COLONY_URL_OPTION
-def trail(task_id: str, message: str, worker_id: str, colony_url: str):
+@TOKEN_OPTION
+def trail(task_id: str, message: str, worker_id: str, colony_url: str, token: str | None):
     """Append a trail entry to a task (low-level)."""
     result = _post(colony_url, f"/tasks/{task_id}/trail", {
         "worker_id": worker_id,
         "message": message,
-    })
+    }, token=token)
     click.echo(f"Trail appended: {result}")
 
 
@@ -292,14 +340,18 @@ def trail(task_id: str, message: str, worker_id: str, colony_url: str):
 @click.option("--attempt", default=None, help="Attempt ID.")
 @click.option("--branch", default=None, help="Branch name.")
 @COLONY_URL_OPTION
-def harvest(task_id: str, pr: str, attempt: str | None, branch: str | None, colony_url: str):
+@TOKEN_OPTION
+def harvest(
+    task_id: str, pr: str, attempt: str | None, branch: str | None, colony_url: str,
+    token: str | None,
+):
     """Mark a task as harvested (completed) with a PR (low-level)."""
     payload: dict = {"pr": pr}
     if attempt:
         payload["attempt_id"] = attempt
     if branch:
         payload["branch"] = branch
-    result = _post(colony_url, f"/tasks/{task_id}/harvest", payload)
+    result = _post(colony_url, f"/tasks/{task_id}/harvest", payload, token=token)
     click.echo(f"Task harvested: {result}")
 
 
@@ -307,9 +359,10 @@ def harvest(task_id: str, pr: str, attempt: str | None, branch: str | None, colo
 @click.argument("resource")
 @click.option("--owner", required=True, help="Owner identifier for this guard.")
 @COLONY_URL_OPTION
-def guard(resource: str, owner: str, colony_url: str):
+@TOKEN_OPTION
+def guard(resource: str, owner: str, colony_url: str, token: str | None):
     """Acquire an exclusive guard lock on a resource (low-level)."""
-    result = _post(colony_url, f"/guards/{resource}", {"owner": owner})
+    result = _post(colony_url, f"/guards/{resource}", {"owner": owner}, token=token)
     click.echo(f"Guard acquired: {result}")
 
 
@@ -317,9 +370,10 @@ def guard(resource: str, owner: str, colony_url: str):
 @click.argument("resource")
 @click.option("--owner", required=True, help="Owner identifier releasing the guard.")
 @COLONY_URL_OPTION
-def release(resource: str, owner: str, colony_url: str):
+@TOKEN_OPTION
+def release(resource: str, owner: str, colony_url: str, token: str | None):
     """Release a guard lock on a resource (low-level)."""
-    _delete(colony_url, f"/guards/{resource}", params={"owner": owner})
+    _delete(colony_url, f"/guards/{resource}", params={"owner": owner}, token=token)
     click.echo(f"Guard released: {resource}")
 
 
@@ -328,12 +382,13 @@ def release(resource: str, owner: str, colony_url: str):
 @click.argument("message")
 @click.option("--worker-id", required=True, help="Worker ID.")
 @COLONY_URL_OPTION
-def signal(task_id: str, message: str, worker_id: str, colony_url: str):
+@TOKEN_OPTION
+def signal(task_id: str, message: str, worker_id: str, colony_url: str, token: str | None):
     """Send a signal message to a task (low-level)."""
     result = _post(colony_url, f"/tasks/{task_id}/signal", {
         "worker_id": worker_id,
         "message": message,
-    })
+    }, token=token)
     click.echo(f"Signal sent: {result}")
 
 

--- a/antfarm/core/colony_client.py
+++ b/antfarm/core/colony_client.py
@@ -7,15 +7,26 @@ import httpx
 class ColonyClient:
     """HTTP client for communicating with the Colony API server."""
 
-    def __init__(self, base_url: str, client: httpx.Client | None = None):
+    def __init__(
+        self,
+        base_url: str,
+        client: httpx.Client | None = None,
+        token: str | None = None,
+    ):
         """Initialize client.
 
         Args:
             base_url: Colony server URL (e.g., "http://localhost:7433")
             client: Optional httpx.Client for dependency injection in tests.
+            token: Optional bearer token for authentication.
         """
         self.base_url = base_url.rstrip("/")
-        self._client = client or httpx.Client(base_url=self.base_url, timeout=30.0)
+        headers = {}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        self._client = client or httpx.Client(
+            base_url=self.base_url, timeout=30.0, headers=headers
+        )
         self._owns_client = client is None  # only close if we created it
 
     def register_node(self, node_id: str) -> dict:

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -95,13 +95,19 @@ class GuardRequest(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def get_app(backend: TaskBackend | None = None, data_dir: str = ".antfarm") -> FastAPI:
+def get_app(
+    backend: TaskBackend | None = None,
+    data_dir: str = ".antfarm",
+    auth_secret: str | None = None,
+) -> FastAPI:
     """Create and return the FastAPI application.
 
     Args:
         backend: TaskBackend instance to use. If None, a FileBackend rooted at
                  data_dir is created automatically.
         data_dir: Path to .antfarm directory (only used when backend is None).
+        auth_secret: Optional shared secret for bearer token auth. When set,
+                     all endpoints except GET /status require a valid token.
 
     Returns:
         Configured FastAPI application.
@@ -116,6 +122,11 @@ def get_app(backend: TaskBackend | None = None, data_dir: str = ".antfarm") -> F
         _backend = FileBackend(root=data_dir)
 
     app = FastAPI(title="Antfarm Colony")
+
+    if auth_secret:
+        from antfarm.core.auth import create_auth_middleware
+
+        app.middleware("http")(create_auth_middleware(auth_secret))
 
     # ------------------------------------------------------------------
     # Nodes

--- a/antfarm/core/worker.py
+++ b/antfarm/core/worker.py
@@ -57,6 +57,7 @@ class WorkerRuntime:
         integration_branch: Branch new worktrees are created from.
         heartbeat_interval: Seconds between heartbeat posts (default 30).
         client: Optional httpx.Client for dependency injection in tests.
+        token: Optional bearer token for colony authentication.
     """
 
     def __init__(
@@ -70,14 +71,16 @@ class WorkerRuntime:
         integration_branch: str = "dev",
         heartbeat_interval: float = 30.0,
         client: httpx.Client | None = None,
+        token: str | None = None,
     ):
         self.worker_id = f"{node_id}/{name}"
         self.node_id = node_id
         self.agent_type = agent_type
         self.workspace_root = workspace_root
         self.heartbeat_interval = heartbeat_interval
+        self._token = token
 
-        self.colony = ColonyClient(colony_url, client=client)
+        self.colony = ColonyClient(colony_url, client=client, token=token)
         self.workspace_mgr = WorkspaceManager(workspace_root, repo_path, integration_branch)
 
         self._heartbeat_event = threading.Event()
@@ -222,6 +225,8 @@ class WorkerRuntime:
             "ANTFARM_URL": self.colony.base_url,
             "WORKER_ID": self.worker_id,
         }
+        if self._token:
+            env["ANTFARM_TOKEN"] = self._token
 
         proc = subprocess.run(
             cmd,

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,220 @@
+"""Tests for bearer token authentication (antfarm.core.auth + serve integration)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from antfarm.core.auth import generate_token, verify_token
+from antfarm.core.serve import get_app  # noqa: I001
+
+SECRET = "test-secret-key"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for auth module
+# ---------------------------------------------------------------------------
+
+
+def test_generate_token_deterministic():
+    t1 = generate_token(SECRET)
+    t2 = generate_token(SECRET)
+    assert t1 == t2
+    assert len(t1) == 64  # SHA-256 hex digest
+
+
+def test_generate_token_different_secrets():
+    assert generate_token("secret-a") != generate_token("secret-b")
+
+
+def test_verify_token_valid():
+    token = generate_token(SECRET)
+    assert verify_token(token, SECRET) is True
+
+
+def test_verify_token_invalid():
+    assert verify_token("bad-token", SECRET) is False
+
+
+def test_verify_token_wrong_secret():
+    token = generate_token("other-secret")
+    assert verify_token(token, SECRET) is False
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def auth_client(tmp_path):
+    """TestClient with auth enabled."""
+    from antfarm.core.backends.file import FileBackend
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend, auth_secret=SECRET)
+    return TestClient(app)
+
+
+@pytest.fixture
+def noauth_client(tmp_path):
+    """TestClient without auth (baseline)."""
+    from antfarm.core.backends.file import FileBackend
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend)
+    return TestClient(app)
+
+
+@pytest.fixture
+def valid_token():
+    return generate_token(SECRET)
+
+
+@pytest.fixture
+def auth_headers(valid_token):
+    return {"Authorization": f"Bearer {valid_token}"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _carry(client, headers=None, task_id="task-001"):
+    return client.post(
+        "/tasks",
+        json={"id": task_id, "title": "Test Task", "spec": "Do the thing"},
+        headers=headers,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: auth enabled
+# ---------------------------------------------------------------------------
+
+
+class TestAuthEnabled:
+    def test_status_requires_no_auth(self, auth_client):
+        """GET /status is always public, even with auth enabled."""
+        r = auth_client.get("/status")
+        assert r.status_code == 200
+
+    def test_carry_without_token_returns_401(self, auth_client):
+        r = _carry(auth_client)
+        assert r.status_code == 401
+        assert "Authorization" in r.json()["detail"]
+
+    def test_carry_with_invalid_token_returns_401(self, auth_client):
+        r = _carry(auth_client, headers={"Authorization": "Bearer wrong-token"})
+        assert r.status_code == 401
+
+    def test_carry_with_valid_token_succeeds(self, auth_client, auth_headers):
+        r = _carry(auth_client, headers=auth_headers)
+        assert r.status_code == 201
+
+    def test_list_tasks_without_token_returns_401(self, auth_client):
+        r = auth_client.get("/tasks")
+        assert r.status_code == 401
+
+    def test_list_tasks_with_valid_token_succeeds(self, auth_client, auth_headers):
+        _carry(auth_client, headers=auth_headers)
+        r = auth_client.get("/tasks", headers=auth_headers)
+        assert r.status_code == 200
+        assert len(r.json()) == 1
+
+    def test_forage_without_token_returns_401(self, auth_client):
+        r = auth_client.post("/tasks/pull", json={"worker_id": "w-1"})
+        assert r.status_code == 401
+
+    def test_forage_with_valid_token_succeeds(self, auth_client, auth_headers):
+        _carry(auth_client, headers=auth_headers)
+        r = auth_client.post("/tasks/pull", json={"worker_id": "w-1"}, headers=auth_headers)
+        assert r.status_code == 200
+
+    def test_register_node_requires_auth(self, auth_client, auth_headers):
+        r = auth_client.post("/nodes", json={"node_id": "node-1"})
+        assert r.status_code == 401
+
+        r = auth_client.post("/nodes", json={"node_id": "node-1"}, headers=auth_headers)
+        assert r.status_code == 200
+
+    def test_register_worker_requires_auth(self, auth_client, auth_headers):
+        payload = {
+            "worker_id": "w-1",
+            "node_id": "n-1",
+            "agent_type": "generic",
+            "workspace_root": "/tmp/ws",
+        }
+        r = auth_client.post("/workers/register", json=payload)
+        assert r.status_code == 401
+
+        r = auth_client.post("/workers/register", json=payload, headers=auth_headers)
+        assert r.status_code == 201
+
+    def test_guard_requires_auth(self, auth_client, auth_headers):
+        r = auth_client.post("/guards/repo", json={"owner": "w-1"})
+        assert r.status_code == 401
+
+        r = auth_client.post("/guards/repo", json={"owner": "w-1"}, headers=auth_headers)
+        assert r.status_code == 200
+
+    def test_delete_guard_requires_auth(self, auth_client, auth_headers):
+        auth_client.post("/guards/repo", json={"owner": "w-1"}, headers=auth_headers)
+        r = auth_client.delete("/guards/repo", params={"owner": "w-1"})
+        assert r.status_code == 401
+
+        r = auth_client.delete(
+            "/guards/repo", params={"owner": "w-1"}, headers=auth_headers
+        )
+        assert r.status_code == 200
+
+    def test_malformed_auth_header_returns_401(self, auth_client):
+        r = _carry(auth_client, headers={"Authorization": "Basic abc123"})
+        assert r.status_code == 401
+
+    def test_full_lifecycle_with_auth(self, auth_client, auth_headers):
+        """Carry → forage → trail → harvest works end-to-end with auth."""
+        # Carry
+        r = _carry(auth_client, headers=auth_headers)
+        assert r.status_code == 201
+
+        # Forage
+        r = auth_client.post(
+            "/tasks/pull", json={"worker_id": "w-1"}, headers=auth_headers
+        )
+        assert r.status_code == 200
+        task = r.json()
+        attempt_id = task["current_attempt"]
+
+        # Trail
+        r = auth_client.post(
+            f"/tasks/{task['id']}/trail",
+            json={"worker_id": "w-1", "message": "working"},
+            headers=auth_headers,
+        )
+        assert r.status_code == 200
+
+        # Harvest
+        r = auth_client.post(
+            f"/tasks/{task['id']}/harvest",
+            json={"attempt_id": attempt_id, "pr": "pr-1", "branch": "feat/x"},
+            headers=auth_headers,
+        )
+        assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: auth disabled (no regression)
+# ---------------------------------------------------------------------------
+
+
+class TestAuthDisabled:
+    def test_carry_works_without_auth(self, noauth_client):
+        """When no auth_secret is set, endpoints work without tokens."""
+        r = _carry(noauth_client)
+        assert r.status_code == 201
+
+    def test_status_works_without_auth(self, noauth_client):
+        r = noauth_client.get("/status")
+        assert r.status_code == 200


### PR DESCRIPTION
## Summary

- New `antfarm/core/auth.py`: HMAC-SHA256 token generation + FastAPI middleware (`GET /status` exempt)
- `serve.py`: `get_app()` accepts optional `auth_secret`; mounts middleware when set
- `colony_client.py`: `ColonyClient` accepts optional `token`; injects `Authorization` header on all requests
- `worker.py`: `WorkerRuntime` accepts optional `token`; passes to `ColonyClient` and propagates `ANTFARM_TOKEN` into spawned agent subprocess env (bug fix)
- `cli.py`: all commands accept `--token` / `ANTFARM_TOKEN`; `colony` command accepts `--auth-token` / `ANTFARM_AUTH_TOKEN` and prints derived bearer token on startup
- `tests/test_auth.py`: 21 tests — unit + full carry→forage→trail→harvest lifecycle with auth

## Test plan

- [x] `python3.12 -m ruff check .` — clean
- [x] `python3.12 -m pytest tests/test_auth.py -x -q` — 21 passed
- [x] `python3.12 -m pytest tests/ -x -q` — 155 passed

closes #42