### PR TITLE
feat(core): add human override commands (pause/resume/reassign/block/unblock)

### DIFF
--- a/antfarm/core/backends/base.py
+++ b/antfarm/core/backends/base.py
@@ -104,6 +104,73 @@ class TaskBackend(ABC):
         ...
 
     @abstractmethod
+    def pause_task(self, task_id: str) -> None:
+        """Pause an active task. Moves task to PAUSED state.
+
+        Args:
+            task_id: ID of the task to pause.
+
+        Raises:
+            FileNotFoundError: If the task is not found.
+            ValueError: If the task is not in ACTIVE state.
+        """
+        ...
+
+    @abstractmethod
+    def resume_task(self, task_id: str) -> None:
+        """Resume a paused task. Moves task back to READY state.
+
+        Args:
+            task_id: ID of the task to resume.
+
+        Raises:
+            FileNotFoundError: If the task is not found.
+            ValueError: If the task is not in PAUSED state.
+        """
+        ...
+
+    @abstractmethod
+    def reassign_task(self, task_id: str, worker_id: str) -> None:
+        """Reassign an active task. Supersedes current attempt, returns to READY.
+
+        Args:
+            task_id: ID of the task to reassign.
+            worker_id: New worker ID (recorded in trail for context).
+
+        Raises:
+            FileNotFoundError: If the task is not found.
+            ValueError: If the task is not in ACTIVE state.
+        """
+        ...
+
+    @abstractmethod
+    def block_task(self, task_id: str, reason: str) -> None:
+        """Block a task. Moves task to BLOCKED state with a reason.
+
+        Args:
+            task_id: ID of the task to block.
+            reason: Human-readable reason for blocking.
+
+        Raises:
+            FileNotFoundError: If the task is not found.
+            ValueError: If the task is not in READY state.
+        """
+        ...
+
+    @abstractmethod
+    def unblock_task(self, task_id: str) -> None:
+        """Unblock a blocked task. Moves task back to READY state.
+
+        Args:
+            task_id: ID of the task to unblock.
+
+        Raises:
+            FileNotFoundError: If the task is not found.
+            ValueError: If the task is not in BLOCKED state.
+        """
+        ...
+
+    @abstractmethod
     def list_tasks(self, status: str | None = None) -> list[dict]:
         """List tasks, optionally filtered by status.
 

--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -69,6 +69,8 @@ class FileBackend(TaskBackend):
             "tasks/ready",
             "tasks/active",
             "tasks/done",
+            "tasks/paused",
+            "tasks/blocked",
             "workers",
             "nodes",
             "guards",
@@ -83,6 +85,12 @@ class FileBackend(TaskBackend):
 
     def _done_path(self, task_id: str) -> Path:
         return self._root / "tasks" / "done" / f"{task_id}.json"
+
+    def _paused_path(self, task_id: str) -> Path:
+        return self._root / "tasks" / "paused" / f"{task_id}.json"
+
+    def _blocked_path(self, task_id: str) -> Path:
+        return self._root / "tasks" / "blocked" / f"{task_id}.json"
 
     def _worker_path(self, worker_id: str) -> Path:
         safe = worker_id.replace("/", "%2F")
@@ -106,7 +114,13 @@ class FileBackend(TaskBackend):
 
     def _find_task_path(self, task_id: str) -> Path | None:
         """Return the path to a task file regardless of which folder it lives in."""
-        for p in [self._ready_path(task_id), self._active_path(task_id), self._done_path(task_id)]:
+        for p in [
+            self._ready_path(task_id),
+            self._active_path(task_id),
+            self._done_path(task_id),
+            self._paused_path(task_id),
+            self._blocked_path(task_id),
+        ]:
             if p.exists():
                 return p
         return None
@@ -325,6 +339,128 @@ class FileBackend(TaskBackend):
             data["updated_at"] = _now_iso()
             self._write_json(done_path, data)
 
+    def pause_task(self, task_id: str) -> None:
+        """Pause an active task. Moves from active/ to paused/."""
+        with self._lock:
+            active_path = self._active_path(task_id)
+            if not active_path.exists():
+                if self._find_task_path(task_id) is None:
+                    raise FileNotFoundError(f"Task '{task_id}' not found")
+                raise ValueError(f"Task '{task_id}' is not in ACTIVE state")
+
+            data = self._read_json(active_path)
+            now = _now_iso()
+            data["status"] = TaskStatus.PAUSED.value
+            data["updated_at"] = now
+
+            self._write_json(active_path, data)
+            os.rename(active_path, self._paused_path(task_id))
+
+    def resume_task(self, task_id: str) -> None:
+        """Resume a paused task. Moves from paused/ to ready/.
+
+        Supersedes the current attempt so the task re-enters the queue cleanly.
+        """
+        with self._lock:
+            paused_path = self._paused_path(task_id)
+            if not paused_path.exists():
+                if self._find_task_path(task_id) is None:
+                    raise FileNotFoundError(f"Task '{task_id}' not found")
+                raise ValueError(f"Task '{task_id}' is not in PAUSED state")
+
+            data = self._read_json(paused_path)
+            now = _now_iso()
+
+            # Supersede current attempt so next pull creates a fresh one
+            current_attempt_id = data.get("current_attempt")
+            if current_attempt_id:
+                for a in data["attempts"]:
+                    if a["attempt_id"] == current_attempt_id:
+                        a["status"] = AttemptStatus.SUPERSEDED.value
+                        a["completed_at"] = now
+                        break
+                data["current_attempt"] = None
+
+            data["status"] = TaskStatus.READY.value
+            data["updated_at"] = now
+
+            self._write_json(paused_path, data)
+            os.rename(paused_path, self._ready_path(task_id))
+
+    def reassign_task(self, task_id: str, worker_id: str) -> None:
+        """Reassign an active task. Supersedes current attempt, returns to ready/."""
+        with self._lock:
+            active_path = self._active_path(task_id)
+            if not active_path.exists():
+                if self._find_task_path(task_id) is None:
+                    raise FileNotFoundError(f"Task '{task_id}' not found")
+                raise ValueError(f"Task '{task_id}' is not in ACTIVE state")
+
+            data = self._read_json(active_path)
+            now = _now_iso()
+
+            current_attempt_id = data.get("current_attempt")
+            if current_attempt_id:
+                for a in data["attempts"]:
+                    if a["attempt_id"] == current_attempt_id:
+                        a["status"] = AttemptStatus.SUPERSEDED.value
+                        a["completed_at"] = now
+                        break
+
+            trail_entry = TrailEntry(
+                ts=now,
+                worker_id="system",
+                message=f"Reassigned to {worker_id}",
+            )
+            data.setdefault("trail", [])
+            data["trail"].append(trail_entry.to_dict())
+
+            data["status"] = TaskStatus.READY.value
+            data["current_attempt"] = None
+            data["updated_at"] = now
+
+            self._write_json(active_path, data)
+            os.rename(active_path, self._ready_path(task_id))
+
+    def block_task(self, task_id: str, reason: str) -> None:
+        """Block a ready task. Moves from ready/ to blocked/."""
+        with self._lock:
+            ready_path = self._ready_path(task_id)
+            if not ready_path.exists():
+                if self._find_task_path(task_id) is None:
+                    raise FileNotFoundError(f"Task '{task_id}' not found")
+                raise ValueError(f"Task '{task_id}' is not in READY state")
+
+            data = self._read_json(ready_path)
+            now = _now_iso()
+
+            trail_entry = TrailEntry(ts=now, worker_id="system", message=f"Blocked: {reason}")
+            data.setdefault("trail", [])
+            data["trail"].append(trail_entry.to_dict())
+
+            data["status"] = TaskStatus.BLOCKED.value
+            data["updated_at"] = now
+
+            self._write_json(ready_path, data)
+            os.rename(ready_path, self._blocked_path(task_id))
+
+    def unblock_task(self, task_id: str) -> None:
+        """Unblock a blocked task. Moves from blocked/ to ready/."""
+        with self._lock:
+            blocked_path = self._blocked_path(task_id)
+            if not blocked_path.exists():
+                if self._find_task_path(task_id) is None:
+                    raise FileNotFoundError(f"Task '{task_id}' not found")
+                raise ValueError(f"Task '{task_id}' is not in BLOCKED state")
+
+            data = self._read_json(blocked_path)
+            now = _now_iso()
+            data["status"] = TaskStatus.READY.value
+            data["updated_at"] = now
+
+            self._write_json(blocked_path, data)
+            os.rename(blocked_path, self._ready_path(task_id))
+
     # ------------------------------------------------------------------
     # Query
     # ------------------------------------------------------------------
@@ -335,6 +471,8 @@ class FileBackend(TaskBackend):
             ("ready", self._root / "tasks" / "ready"),
             ("active", self._root / "tasks" / "active"),
             ("done", self._root / "tasks" / "done"),
+            ("paused", self._root / "tasks" / "paused"),
+            ("blocked", self._root / "tasks" / "blocked"),
         ]
         results = []
         for folder_status, folder in folders:
@@ -482,11 +620,19 @@ class FileBackend(TaskBackend):
         ready = len(list((self._root / "tasks" / "ready").glob("*.json")))
         active = len(list((self._root / "tasks" / "active").glob("*.json")))
         done = len(list((self._root / "tasks" / "done").glob("*.json")))
+        paused = len(list((self._root / "tasks" / "paused").glob("*.json")))
+        blocked = len(list((self._root / "tasks" / "blocked").glob("*.json")))
         workers = len(list((self._root / "workers").glob("*.json")))
         nodes = len(list((self._root / "nodes").glob("*.json")))
         guards = len(list((self._root / "guards").glob("*.lock")))
         return {
-            "tasks": {"ready": ready, "active": active, "done": done},
+            "tasks": {
+                "ready": ready,
+                "active": active,
+                "done": done,
+                "paused": paused,
+                "blocked": blocked,
+            },
             "workers": workers,
             "nodes": nodes,
             "guards": guards,

--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -392,5 +392,62 @@ def signal(task_id: str, message: str, worker_id: str, colony_url: str, token: s
     click.echo(f"Signal sent: {result}")
 
 
+# ---------------------------------------------------------------------------
+# Human override commands
+# ---------------------------------------------------------------------------
+
+
+@main.command()
+@click.argument("task_id")
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def pause(task_id: str, colony_url: str, token: str | None):
+    """Pause an active task."""
+    result = _post(colony_url, f"/tasks/{task_id}/pause", {}, token=token)
+    click.echo(f"Task paused: {result}")
+
+
+@main.command()
+@click.argument("task_id")
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def resume(task_id: str, colony_url: str, token: str | None):
+    """Resume a paused task."""
+    result = _post(colony_url, f"/tasks/{task_id}/resume", {}, token=token)
+    click.echo(f"Task resumed: {result}")
+
+
+@main.command()
+@click.argument("task_id")
+@click.argument("worker_id")
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def reassign(task_id: str, worker_id: str, colony_url: str, token: str | None):
+    """Reassign an active task to a different worker."""
+    result = _post(colony_url, f"/tasks/{task_id}/reassign", {"worker_id": worker_id}, token=token)
+    click.echo(f"Task reassigned: {result}")
+
+
+@main.command()
+@click.argument("task_id")
+@click.argument("reason")
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def block(task_id: str, reason: str, colony_url: str, token: str | None):
+    """Block a ready task with a reason."""
+    result = _post(colony_url, f"/tasks/{task_id}/block", {"reason": reason}, token=token)
+    click.echo(f"Task blocked: {result}")
+
+
+@main.command()
+@click.argument("task_id")
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def unblock(task_id: str, colony_url: str, token: str | None):
+    """Unblock a blocked task."""
+    result = _post(colony_url, f"/tasks/{task_id}/unblock", {}, token=token)
+    click.echo(f"Task unblocked: {result}")
+
+
 if __name__ == "__main__":
     main()

--- a/antfarm/core/models.py
+++ b/antfarm/core/models.py
@@ -21,6 +21,8 @@ class TaskStatus(StrEnum):
     READY = "ready"
     ACTIVE = "active"
     DONE = "done"
+    PAUSED = "paused"
+    BLOCKED = "blocked"
 
 
 class AttemptStatus(StrEnum):

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -86,6 +86,14 @@ class MergeRequest(BaseModel):
     attempt_id: str
 
 
+class ReassignRequest(BaseModel):
+    worker_id: str
+
+
+class BlockRequest(BaseModel):
+    reason: str
+
+
 class GuardRequest(BaseModel):
     owner: str
 
@@ -270,6 +278,61 @@ def get_app(
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return {"ok": True}
+
+    @app.post("/tasks/{task_id}/pause", status_code=200)
+    def pause_task(task_id: str):
+        """Pause an active task."""
+        try:
+            _backend.pause_task(task_id)
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        return {"ok": True}
+
+    @app.post("/tasks/{task_id}/resume", status_code=200)
+    def resume_task(task_id: str):
+        """Resume a paused task."""
+        try:
+            _backend.resume_task(task_id)
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        return {"ok": True}
+
+    @app.post("/tasks/{task_id}/reassign", status_code=200)
+    def reassign_task(task_id: str, req: ReassignRequest):
+        """Reassign an active task to a different worker."""
+        try:
+            _backend.reassign_task(task_id, req.worker_id)
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        return {"ok": True}
+
+    @app.post("/tasks/{task_id}/block", status_code=200)
+    def block_task(task_id: str, req: BlockRequest):
+        """Block a ready task with a reason."""
+        try:
+            _backend.block_task(task_id, req.reason)
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        return {"ok": True}
+
+    @app.post("/tasks/{task_id}/unblock", status_code=200)
+    def unblock_task(task_id: str):
+        """Unblock a blocked task."""
+        try:
+            _backend.unblock_task(task_id)
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
         return {"ok": True}
 
     @app.get("/tasks", status_code=200)

--- a/tests/test_human_overrides.py
+++ b/tests/test_human_overrides.py
@@ -1,0 +1,405 @@
+"""Tests for human override commands: pause, resume, reassign, block, unblock.
+
+Covers FileBackend methods and API endpoints.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from antfarm.core.backends.file import FileBackend
+from antfarm.core.models import AttemptStatus, TaskStatus
+from antfarm.core.serve import get_app
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_task(task_id: str = "task-1", priority: int = 10, depends_on: list | None = None) -> dict:
+    now = datetime.now(UTC).isoformat()
+    return {
+        "id": task_id,
+        "title": f"Task {task_id}",
+        "spec": "Do something",
+        "complexity": "M",
+        "priority": priority,
+        "depends_on": depends_on or [],
+        "touches": ["src/foo.py"],
+        "created_at": now,
+        "updated_at": now,
+        "created_by": "test",
+    }
+
+
+@pytest.fixture()
+def backend(tmp_path: Path) -> FileBackend:
+    return FileBackend(root=tmp_path / ".antfarm")
+
+
+@pytest.fixture()
+def client(tmp_path):
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend)
+    return TestClient(app)
+
+
+def _carry(client, task_id="task-001", title="Test Task", spec="Do the thing"):
+    return client.post("/tasks", json={"id": task_id, "title": title, "spec": spec})
+
+
+def _register_worker(client, worker_id="worker-1"):
+    return client.post(
+        "/workers/register",
+        json={
+            "worker_id": worker_id,
+            "node_id": "node-1",
+            "agent_type": "claude-code",
+            "workspace_root": "/tmp/ws",
+        },
+    )
+
+
+def _forage(client, worker_id="worker-1"):
+    return client.post("/tasks/pull", json={"worker_id": worker_id})
+
+
+# ---------------------------------------------------------------------------
+# FileBackend: pause_task
+# ---------------------------------------------------------------------------
+
+
+class TestPauseTask:
+    def test_pause_active_task(self, backend):
+        backend.carry(_make_task("t1"))
+        backend.pull("w1")
+        backend.pause_task("t1")
+
+        task = backend.get_task("t1")
+        assert task["status"] == TaskStatus.PAUSED.value
+        assert backend._paused_path("t1").exists()
+        assert not backend._active_path("t1").exists()
+
+    def test_pause_non_active_raises(self, backend):
+        backend.carry(_make_task("t1"))
+        with pytest.raises(ValueError, match="not in ACTIVE state"):
+            backend.pause_task("t1")
+
+    def test_pause_not_found_raises(self, backend):
+        with pytest.raises(FileNotFoundError):
+            backend.pause_task("nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# FileBackend: resume_task
+# ---------------------------------------------------------------------------
+
+
+class TestResumeTask:
+    def test_resume_paused_task(self, backend):
+        backend.carry(_make_task("t1"))
+        pulled = backend.pull("w1")
+        attempt_id = pulled["current_attempt"]
+
+        backend.pause_task("t1")
+        backend.resume_task("t1")
+
+        task = backend.get_task("t1")
+        assert task["status"] == TaskStatus.READY.value
+        assert task["current_attempt"] is None
+        assert backend._ready_path("t1").exists()
+
+        # Original attempt should be superseded
+        for a in task["attempts"]:
+            if a["attempt_id"] == attempt_id:
+                assert a["status"] == AttemptStatus.SUPERSEDED.value
+
+    def test_resume_non_paused_raises(self, backend):
+        backend.carry(_make_task("t1"))
+        with pytest.raises(ValueError, match="not in PAUSED state"):
+            backend.resume_task("t1")
+
+    def test_resume_not_found_raises(self, backend):
+        with pytest.raises(FileNotFoundError):
+            backend.resume_task("nonexistent")
+
+    def test_resumed_task_can_be_pulled(self, backend):
+        backend.carry(_make_task("t1"))
+        backend.pull("w1")
+        backend.pause_task("t1")
+        backend.resume_task("t1")
+
+        pulled = backend.pull("w2")
+        assert pulled is not None
+        assert pulled["id"] == "t1"
+        assert pulled["current_attempt"] is not None
+
+
+# ---------------------------------------------------------------------------
+# FileBackend: reassign_task
+# ---------------------------------------------------------------------------
+
+
+class TestReassignTask:
+    def test_reassign_active_task(self, backend):
+        backend.carry(_make_task("t1"))
+        pulled = backend.pull("w1")
+        old_attempt = pulled["current_attempt"]
+
+        backend.reassign_task("t1", "w2")
+
+        task = backend.get_task("t1")
+        assert task["status"] == TaskStatus.READY.value
+        assert task["current_attempt"] is None
+        assert backend._ready_path("t1").exists()
+
+        # Old attempt superseded
+        for a in task["attempts"]:
+            if a["attempt_id"] == old_attempt:
+                assert a["status"] == AttemptStatus.SUPERSEDED.value
+
+        # Trail entry recorded
+        trail_messages = [t["message"] for t in task["trail"]]
+        assert any("Reassigned to w2" in m for m in trail_messages)
+
+    def test_reassign_non_active_raises(self, backend):
+        backend.carry(_make_task("t1"))
+        with pytest.raises(ValueError, match="not in ACTIVE state"):
+            backend.reassign_task("t1", "w2")
+
+    def test_reassign_not_found_raises(self, backend):
+        with pytest.raises(FileNotFoundError):
+            backend.reassign_task("nonexistent", "w2")
+
+    def test_reassigned_task_can_be_pulled(self, backend):
+        backend.carry(_make_task("t1"))
+        backend.pull("w1")
+        backend.reassign_task("t1", "w2")
+
+        pulled = backend.pull("w2")
+        assert pulled is not None
+        assert pulled["id"] == "t1"
+
+
+# ---------------------------------------------------------------------------
+# FileBackend: block_task
+# ---------------------------------------------------------------------------
+
+
+class TestBlockTask:
+    def test_block_ready_task(self, backend):
+        backend.carry(_make_task("t1"))
+        backend.block_task("t1", "needs clarification")
+
+        task = backend.get_task("t1")
+        assert task["status"] == TaskStatus.BLOCKED.value
+        assert backend._blocked_path("t1").exists()
+        assert not backend._ready_path("t1").exists()
+
+        trail_messages = [t["message"] for t in task["trail"]]
+        assert any("Blocked: needs clarification" in m for m in trail_messages)
+
+    def test_block_non_ready_raises(self, backend):
+        backend.carry(_make_task("t1"))
+        backend.pull("w1")
+        with pytest.raises(ValueError, match="not in READY state"):
+            backend.block_task("t1", "reason")
+
+    def test_block_not_found_raises(self, backend):
+        with pytest.raises(FileNotFoundError):
+            backend.block_task("nonexistent", "reason")
+
+    def test_blocked_task_not_pullable(self, backend):
+        backend.carry(_make_task("t1"))
+        backend.block_task("t1", "reason")
+
+        pulled = backend.pull("w1")
+        assert pulled is None
+
+
+# ---------------------------------------------------------------------------
+# FileBackend: unblock_task
+# ---------------------------------------------------------------------------
+
+
+class TestUnblockTask:
+    def test_unblock_blocked_task(self, backend):
+        backend.carry(_make_task("t1"))
+        backend.block_task("t1", "reason")
+        backend.unblock_task("t1")
+
+        task = backend.get_task("t1")
+        assert task["status"] == TaskStatus.READY.value
+        assert backend._ready_path("t1").exists()
+        assert not backend._blocked_path("t1").exists()
+
+    def test_unblock_non_blocked_raises(self, backend):
+        backend.carry(_make_task("t1"))
+        with pytest.raises(ValueError, match="not in BLOCKED state"):
+            backend.unblock_task("t1")
+
+    def test_unblock_not_found_raises(self, backend):
+        with pytest.raises(FileNotFoundError):
+            backend.unblock_task("nonexistent")
+
+    def test_unblocked_task_can_be_pulled(self, backend):
+        backend.carry(_make_task("t1"))
+        backend.block_task("t1", "reason")
+        backend.unblock_task("t1")
+
+        pulled = backend.pull("w1")
+        assert pulled is not None
+        assert pulled["id"] == "t1"
+
+
+# ---------------------------------------------------------------------------
+# FileBackend: status includes new states
+# ---------------------------------------------------------------------------
+
+
+class TestStatusCounts:
+    def test_status_includes_paused_and_blocked(self, backend):
+        backend.carry(_make_task("t1"))
+        backend.carry(_make_task("t2"))
+        backend.carry(_make_task("t3"))
+
+        backend.pull("w1")  # t1 → active
+        backend.block_task("t2", "blocked")  # t2 → blocked
+
+        # Pull t3 and pause it
+        backend.pull("w2")  # t3 → active
+        backend.pause_task("t3")  # t3 → paused
+
+        status = backend.status()
+        assert status["tasks"]["active"] == 1
+        assert status["tasks"]["blocked"] == 1
+        assert status["tasks"]["paused"] == 1
+        assert status["tasks"]["ready"] == 0
+
+
+# ---------------------------------------------------------------------------
+# FileBackend: list_tasks filters new statuses
+# ---------------------------------------------------------------------------
+
+
+class TestListTasksFilter:
+    def test_list_paused_tasks(self, backend):
+        backend.carry(_make_task("t1"))
+        backend.pull("w1")
+        backend.pause_task("t1")
+
+        paused = backend.list_tasks(status="paused")
+        assert len(paused) == 1
+        assert paused[0]["id"] == "t1"
+
+    def test_list_blocked_tasks(self, backend):
+        backend.carry(_make_task("t1"))
+        backend.block_task("t1", "reason")
+
+        blocked = backend.list_tasks(status="blocked")
+        assert len(blocked) == 1
+        assert blocked[0]["id"] == "t1"
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestPauseEndpoint:
+    def test_pause_active_task(self, client):
+        _carry(client, "t1")
+        _register_worker(client)
+        _forage(client)
+
+        r = client.post("/tasks/t1/pause")
+        assert r.status_code == 200
+
+        task = client.get("/tasks/t1").json()
+        assert task["status"] == "paused"
+
+    def test_pause_not_active_returns_409(self, client):
+        _carry(client, "t1")
+        r = client.post("/tasks/t1/pause")
+        assert r.status_code == 409
+
+    def test_pause_not_found_returns_404(self, client):
+        r = client.post("/tasks/nonexistent/pause")
+        assert r.status_code == 404
+
+
+class TestResumeEndpoint:
+    def test_resume_paused_task(self, client):
+        _carry(client, "t1")
+        _register_worker(client)
+        _forage(client)
+        client.post("/tasks/t1/pause")
+
+        r = client.post("/tasks/t1/resume")
+        assert r.status_code == 200
+
+        task = client.get("/tasks/t1").json()
+        assert task["status"] == "ready"
+
+    def test_resume_not_paused_returns_409(self, client):
+        _carry(client, "t1")
+        r = client.post("/tasks/t1/resume")
+        assert r.status_code == 409
+
+
+class TestReassignEndpoint:
+    def test_reassign_active_task(self, client):
+        _carry(client, "t1")
+        _register_worker(client)
+        _forage(client)
+
+        r = client.post("/tasks/t1/reassign", json={"worker_id": "worker-2"})
+        assert r.status_code == 200
+
+        task = client.get("/tasks/t1").json()
+        assert task["status"] == "ready"
+
+    def test_reassign_not_active_returns_409(self, client):
+        _carry(client, "t1")
+        r = client.post("/tasks/t1/reassign", json={"worker_id": "w2"})
+        assert r.status_code == 409
+
+
+class TestBlockEndpoint:
+    def test_block_ready_task(self, client):
+        _carry(client, "t1")
+
+        r = client.post("/tasks/t1/block", json={"reason": "needs spec"})
+        assert r.status_code == 200
+
+        task = client.get("/tasks/t1").json()
+        assert task["status"] == "blocked"
+
+    def test_block_not_ready_returns_409(self, client):
+        _carry(client, "t1")
+        _register_worker(client)
+        _forage(client)
+
+        r = client.post("/tasks/t1/block", json={"reason": "reason"})
+        assert r.status_code == 409
+
+
+class TestUnblockEndpoint:
+    def test_unblock_blocked_task(self, client):
+        _carry(client, "t1")
+        client.post("/tasks/t1/block", json={"reason": "needs spec"})
+
+        r = client.post("/tasks/t1/unblock")
+        assert r.status_code == 200
+
+        task = client.get("/tasks/t1").json()
+        assert task["status"] == "ready"
+
+    def test_unblock_not_blocked_returns_409(self, client):
+        _carry(client, "t1")
+        r = client.post("/tasks/t1/unblock")
+        assert r.status_code == 409


### PR DESCRIPTION
## Summary

- Add `PAUSED` and `BLOCKED` to `TaskStatus` enum
- Add 5 abstract methods to `TaskBackend`: `pause_task`, `resume_task`, `reassign_task`, `block_task`, `unblock_task`
- Implement all 5 in `FileBackend` with `paused/` and `blocked/` directories; update `_find_task_path`, `list_tasks`, `status`
- Add `ReassignRequest` / `BlockRequest` pydantic models + 5 POST endpoints to `serve.py` (auth middleware from #47 preserved)
- Add `pause`, `resume`, `reassign`, `block`, `unblock` CLI commands with `@TOKEN_OPTION` + `token` param
- Add `tests/test_human_overrides.py` (44 tests covering backend methods and API endpoints)

Manually merged on top of bearer auth (#47) — no `cli.py` or `serve.py` conflicts.

closes #43

## Test plan

- [x] `python3.12 -m ruff check .` — all checks passed
- [x] `python3.12 -m pytest tests/ -x -q --ignore=tests/test_redis_backend.py` — 166 passed