### PR TITLE
feat(cli): add --watch and --interval flags to scout command

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -234,17 +234,60 @@ def carry(
 # scout
 # ---------------------------------------------------------------------------
 
+_WATCHED_FIELDS = (
+    "tasks_ready",
+    "tasks_active",
+    "tasks_done",
+    "tasks_paused",
+    "tasks_blocked",
+    "workers",
+    "nodes",
+)
 
-@main.command()
-@COLONY_URL_OPTION
-@TOKEN_OPTION
-def scout(colony_url: str, token: str | None):
-    """Show colony status as a table."""
-    status = _get(colony_url, "/status", token=token)
+
+def _render_scout(status: dict, prev: dict | None) -> None:
+    """Render a status table, highlighting changes vs prev snapshot."""
     click.echo(f"{'Field':<25} {'Value'}")
     click.echo("-" * 40)
     for key, value in status.items():
-        click.echo(f"{key:<25} {value}")
+        value_str = str(value)
+        if prev is not None and key in prev:
+            prev_val = prev[key]
+            if isinstance(value, (int, float)) and isinstance(prev_val, (int, float)):
+                if value > prev_val:
+                    value_str = click.style(value_str, fg="green")
+                elif value < prev_val:
+                    value_str = click.style(value_str, fg="red")
+        click.echo(f"{key:<25} {value_str}")
+
+
+@main.command()
+@click.option("--watch", is_flag=True, default=False, help="Re-poll continuously.")
+@click.option(
+    "--interval",
+    default=5,
+    show_default=True,
+    help="Seconds between polls (with --watch).",
+)
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def scout(watch: bool, interval: int, colony_url: str, token: str | None):
+    """Show colony status as a table."""
+    if not watch:
+        status = _get(colony_url, "/status", token=token)
+        _render_scout(status, None)
+        return
+
+    prev_status = None
+    try:
+        while True:
+            click.clear()
+            status = _get(colony_url, "/status", token=token)
+            _render_scout(status, prev_status)
+            prev_status = status
+            time.sleep(interval)
+    except KeyboardInterrupt:
+        pass
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -180,6 +180,57 @@ def test_cli_scout_uses_env_url(monkeypatch):
         assert "my-colony:8000" in call_url
 
 
+def test_scout_watch_basic():
+    """--watch polls repeatedly; KeyboardInterrupt after first sleep exits cleanly."""
+    runner = CliRunner()
+
+    status_data = {
+        "tasks_ready": 3,
+        "tasks_active": 1,
+        "tasks_done": 7,
+        "workers": 2,
+        "nodes": 1,
+    }
+
+    with (
+        patch("antfarm.core.cli.httpx.get") as mock_get,
+        patch("antfarm.core.cli.time.sleep", side_effect=KeyboardInterrupt),
+    ):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = status_data
+        mock_get.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            ["scout", "--watch", "--interval", "1", "--colony-url", "http://localhost:7433"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "tasks_ready" in result.output
+        assert "3" in result.output
+        mock_get.assert_called_once()
+
+
+def test_scout_oneshot_unchanged():
+    """Without --watch, scout performs exactly one GET and exits."""
+    runner = CliRunner()
+
+    status_data = {"nodes": 2, "workers": 3, "tasks_ready": 5}
+
+    with patch("antfarm.core.cli.httpx.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = status_data
+        mock_get.return_value = mock_resp
+
+        result = runner.invoke(main, ["scout", "--colony-url", "http://localhost:7433"])
+
+        assert result.exit_code == 0, result.output
+        assert "nodes" in result.output
+        mock_get.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # doctor
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `--watch` flag to `scout` command for continuous re-polling
- Adds `--interval` option (default 5s) to control poll frequency
- Highlights field changes: green for increases, red for decreases
- Handles `KeyboardInterrupt` cleanly to exit watch loop

## Tests
- `test_scout_watch_basic`: verifies watch mode polls, renders output, exits on KeyboardInterrupt
- `test_scout_oneshot_unchanged`: verifies one-shot mode still works unchanged

closes #39