### PR TITLE
feat(scheduler): add capability-aware scheduling

### DIFF
--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -173,6 +173,16 @@ class FileBackend(TaskBackend):
                 p.stem for p in (self._root / "tasks" / "done").iterdir() if p.suffix == ".json"
             }
 
+            # Read worker capabilities if worker file exists
+            worker_capabilities: set[str] | None = None
+            worker_path = self._worker_path(worker_id)
+            if worker_path.exists():
+                try:
+                    worker_data = self._read_json(worker_path)
+                    worker_capabilities = set(worker_data.get("capabilities", []))
+                except (json.JSONDecodeError, KeyError):
+                    pass
+
             # Load all ready tasks
             ready_dir = self._root / "tasks" / "ready"
             candidates: list[Task] = []
@@ -187,6 +197,14 @@ class FileBackend(TaskBackend):
 
             # Select using inline scheduling policy
             eligible = [t for t in candidates if all(dep in done_task_ids for dep in t.depends_on)]
+
+            # Filter by capability requirements
+            if worker_capabilities is not None:
+                eligible = [
+                    t for t in eligible
+                    if set(t.capabilities_required).issubset(worker_capabilities)
+                ]
+
             if not eligible:
                 return None
 

--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -141,6 +141,7 @@ def worker():
 @click.option("--node", required=True, help="Node ID this worker belongs to.")
 @click.option("--repo-path", default=".", show_default=True, help="Path to git repo.")
 @click.option("--integration-branch", default="dev", show_default=True, help="Integration branch.")
+@click.option("--capabilities", default=None, help="Comma-separated worker capabilities (e.g. gpu,docker).")  # noqa: E501
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def worker_start(
@@ -150,6 +151,7 @@ def worker_start(
     node: str,
     repo_path: str,
     integration_branch: str,
+    capabilities: str | None,
     colony_url: str,
     token: str | None,
 ):
@@ -158,6 +160,7 @@ def worker_start(
 
     worker_name = name or agent
     ws_root = workspace_root or f".antfarm/workspaces/{worker_name}"
+    caps = [c.strip() for c in capabilities.split(",")] if capabilities else []
 
     runtime = WorkerRuntime(
         colony_url=colony_url,
@@ -167,6 +170,7 @@ def worker_start(
         workspace_root=ws_root,
         repo_path=repo_path,
         integration_branch=integration_branch,
+        capabilities=caps,
         token=token,
     )
     runtime.run()
@@ -182,6 +186,7 @@ def worker_start(
 @click.option("--spec", default=None, help="Task specification.")
 @click.option("--depends-on", multiple=True, help="Task IDs this task depends on.")
 @click.option("--touches", default=None, help="Comma-separated scope tags (e.g. api,db).")
+@click.option("--capabilities", default=None, help="Comma-separated capabilities required (e.g. gpu,docker).")  # noqa: E501
 @click.option("--priority", type=int, default=10, show_default=True, help="Priority (lower=higher).")  # noqa: E501
 @click.option(
     "--complexity",
@@ -199,6 +204,7 @@ def carry(
     spec: str | None,
     depends_on: tuple,
     touches: str | None,
+    capabilities: str | None,
     priority: int,
     complexity: str,
     file_path: str | None,
@@ -218,6 +224,7 @@ def carry(
             "spec": spec,
             "depends_on": list(depends_on),
             "touches": [t.strip() for t in touches.split(",")] if touches else [],
+            "capabilities_required": [c.strip() for c in capabilities.split(",")] if capabilities else [],  # noqa: E501
             "priority": priority,
             "complexity": complexity,
         }
@@ -283,6 +290,7 @@ def doctor(fix: bool, data_dir: str):
 @click.option("--node", required=True, help="Node ID.")
 @click.option("--agent", required=True, help="Agent type.")
 @click.option("--workspace-root", default=None, help="Workspace root directory.")
+@click.option("--capabilities", default=None, help="Comma-separated worker capabilities (e.g. gpu,docker).")  # noqa: E501
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def hatch(
@@ -290,6 +298,7 @@ def hatch(
     node: str,
     agent: str,
     workspace_root: str | None,
+    capabilities: str | None,
     colony_url: str,
     token: str | None,
 ):
@@ -297,11 +306,13 @@ def hatch(
     worker_name = name or agent
     ws_root = workspace_root or f".antfarm/workspaces/{worker_name}"
     worker_id = f"{node}/{worker_name}"
+    caps = [c.strip() for c in capabilities.split(",")] if capabilities else []
     result = _post(colony_url, "/workers/register", {
         "worker_id": worker_id,
         "node_id": node,
         "agent_type": agent,
         "workspace_root": ws_root,
+        "capabilities": caps,
     }, token=token)
     click.echo(f"Worker registered: {result}")
 

--- a/antfarm/core/colony_client.py
+++ b/antfarm/core/colony_client.py
@@ -35,13 +35,19 @@ class ColonyClient:
         return r.json()
 
     def register_worker(
-        self, worker_id: str, node_id: str, agent_type: str, workspace_root: str
+        self,
+        worker_id: str,
+        node_id: str,
+        agent_type: str,
+        workspace_root: str,
+        capabilities: list[str] | None = None,
     ) -> dict:
         r = self._client.post("/workers/register", json={
             "worker_id": worker_id,
             "node_id": node_id,
             "agent_type": agent_type,
             "workspace_root": workspace_root,
+            "capabilities": capabilities or [],
         })
         r.raise_for_status()
         return r.json()

--- a/antfarm/core/models.py
+++ b/antfarm/core/models.py
@@ -143,6 +143,7 @@ class Task:
     priority: int = field(default=10)
     depends_on: list[str] = field(default_factory=list)
     touches: list[str] = field(default_factory=list)
+    capabilities_required: list[str] = field(default_factory=list)
     status: TaskStatus = TaskStatus.READY
     current_attempt: str | None = None
     attempts: list[Attempt] = field(default_factory=list)
@@ -158,6 +159,7 @@ class Task:
             "priority": self.priority,
             "depends_on": list(self.depends_on),
             "touches": list(self.touches),
+            "capabilities_required": list(self.capabilities_required),
             "status": self.status.value,
             "current_attempt": self.current_attempt,
             "attempts": [a.to_dict() for a in self.attempts],
@@ -178,6 +180,7 @@ class Task:
             priority=data.get("priority", 10),
             depends_on=list(data.get("depends_on", [])),
             touches=list(data.get("touches", [])),
+            capabilities_required=list(data.get("capabilities_required", [])),
             status=TaskStatus(data.get("status", TaskStatus.READY)),
             current_attempt=data.get("current_attempt"),
             attempts=[Attempt.from_dict(a) for a in data.get("attempts", [])],
@@ -203,6 +206,7 @@ class Worker:
     registered_at: str
     last_heartbeat: str
     status: WorkerStatus = WorkerStatus.IDLE
+    capabilities: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return {
@@ -211,6 +215,7 @@ class Worker:
             "agent_type": self.agent_type,
             "workspace_root": self.workspace_root,
             "status": self.status.value,
+            "capabilities": list(self.capabilities),
             "registered_at": self.registered_at,
             "last_heartbeat": self.last_heartbeat,
         }
@@ -223,6 +228,7 @@ class Worker:
             agent_type=data["agent_type"],
             workspace_root=data["workspace_root"],
             status=WorkerStatus(data.get("status", WorkerStatus.IDLE)),
+            capabilities=list(data.get("capabilities", [])),
             registered_at=data["registered_at"],
             last_heartbeat=data["last_heartbeat"],
         )

--- a/antfarm/core/scheduler.py
+++ b/antfarm/core/scheduler.py
@@ -12,19 +12,23 @@ def select_task(
     ready_tasks: list[Task],
     done_task_ids: set[str],
     active_tasks: list[Task],
+    worker_capabilities: set[str] | None = None,
 ) -> Task | None:
     """Select next task using v0.1 scheduling policy.
 
     Policy (applied in order):
     1. Dependency check — skip if depends_on not all in done_task_ids
-    2. Scope preference — prefer non-overlapping touches with active tasks
-    3. Priority — lower number = higher priority
-    4. FIFO — oldest created_at first among equals
+    2. Capability check — skip if capabilities_required not a subset of worker_capabilities
+    3. Scope preference — prefer non-overlapping touches with active tasks
+    4. Priority — lower number = higher priority
+    5. FIFO — oldest created_at first among equals
 
     Args:
         ready_tasks: Tasks with status READY that are candidates for scheduling.
         done_task_ids: Set of task IDs that have been completed.
         active_tasks: Tasks currently being executed by workers.
+        worker_capabilities: Set of capabilities the worker has. If None, capability
+            filtering is skipped (backward compatible).
 
     Returns:
         The selected Task, or None if no eligible task exists.
@@ -34,6 +38,13 @@ def select_task(
         t for t in ready_tasks
         if all(dep in done_task_ids for dep in t.depends_on)
     ]
+
+    # Step 2: Filter by capability requirements (skip if worker_capabilities is None)
+    if worker_capabilities is not None:
+        eligible = [
+            t for t in eligible
+            if set(t.capabilities_required).issubset(worker_capabilities)
+        ]
 
     if not eligible:
         return None

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -40,6 +40,7 @@ class CarryRequest(BaseModel):
     priority: int = 10
     depends_on: list[str] = []
     touches: list[str] = []
+    capabilities_required: list[str] = []
     created_by: str = "api"
 
 
@@ -52,6 +53,7 @@ class WorkerRegisterRequest(BaseModel):
     node_id: str
     agent_type: str
     workspace_root: str
+    capabilities: list[str] = []
 
 
 class HeartbeatRequest(BaseModel):
@@ -161,6 +163,7 @@ def get_app(
             "node_id": req.node_id,
             "agent_type": req.agent_type,
             "workspace_root": req.workspace_root,
+            "capabilities": req.capabilities,
             "status": "idle",
             "registered_at": now,
             "last_heartbeat": now,
@@ -199,6 +202,7 @@ def get_app(
             "priority": req.priority,
             "depends_on": req.depends_on,
             "touches": req.touches,
+            "capabilities_required": req.capabilities_required,
             "created_by": req.created_by,
             "status": "ready",
             "current_attempt": None,

--- a/antfarm/core/worker.py
+++ b/antfarm/core/worker.py
@@ -70,6 +70,7 @@ class WorkerRuntime:
         repo_path: str,
         integration_branch: str = "dev",
         heartbeat_interval: float = 30.0,
+        capabilities: list[str] | None = None,
         client: httpx.Client | None = None,
         token: str | None = None,
     ):
@@ -78,6 +79,7 @@ class WorkerRuntime:
         self.agent_type = agent_type
         self.workspace_root = workspace_root
         self.heartbeat_interval = heartbeat_interval
+        self.capabilities = capabilities or []
         self._token = token
 
         self.colony = ColonyClient(colony_url, client=client, token=token)
@@ -101,6 +103,7 @@ class WorkerRuntime:
             self.node_id,
             self.agent_type,
             self.workspace_root,
+            capabilities=self.capabilities,
         )
         logger.info("worker registered worker_id=%s", self.worker_id)
 

--- a/tests/test_file_backend.py
+++ b/tests/test_file_backend.py
@@ -434,3 +434,70 @@ def test_kickback_requires_done_not_active(backend: FileBackend) -> None:
     data = backend.get_task("task-1")
     assert data is not None
     assert data["status"] == TaskStatus.READY.value
+
+
+# ---------------------------------------------------------------------------
+# Capability filtering in pull()
+# ---------------------------------------------------------------------------
+
+
+def _make_task_with_caps(task_id: str, capabilities_required: list) -> dict:
+    now = datetime.now(UTC).isoformat()
+    return {
+        "id": task_id,
+        "title": f"Task {task_id}",
+        "spec": "Do something",
+        "complexity": "M",
+        "priority": 10,
+        "depends_on": [],
+        "touches": [],
+        "capabilities_required": capabilities_required,
+        "created_at": now,
+        "updated_at": now,
+        "created_by": "test",
+    }
+
+
+def test_pull_skips_tasks_with_unmet_capabilities(backend: FileBackend, tmp_path: Path) -> None:
+    """pull() skips a task requiring capabilities the worker doesn't have."""
+    # Register a worker with no capabilities
+    worker_data = {
+        "worker_id": "worker-1",
+        "node_id": "node-1",
+        "agent_type": "generic",
+        "workspace_root": "/tmp",
+        "capabilities": [],
+        "status": "idle",
+        "registered_at": datetime.now(UTC).isoformat(),
+        "last_heartbeat": datetime.now(UTC).isoformat(),
+    }
+    backend.register_worker(worker_data)
+
+    # Carry a task requiring "gpu"
+    backend.carry(_make_task_with_caps("task-gpu", ["gpu"]))
+
+    # Worker without gpu should get nothing
+    result = backend.pull("worker-1")
+    assert result is None
+
+
+def test_pull_matches_tasks_with_met_capabilities(backend: FileBackend, tmp_path: Path) -> None:
+    """pull() returns a task when worker has all required capabilities."""
+    worker_data = {
+        "worker_id": "worker-2",
+        "node_id": "node-1",
+        "agent_type": "generic",
+        "workspace_root": "/tmp",
+        "capabilities": ["gpu", "docker"],
+        "status": "idle",
+        "registered_at": datetime.now(UTC).isoformat(),
+        "last_heartbeat": datetime.now(UTC).isoformat(),
+    }
+    backend.register_worker(worker_data)
+
+    backend.carry(_make_task_with_caps("task-gpu", ["gpu"]))
+
+    result = backend.pull("worker-2")
+    assert result is not None
+    assert result["id"] == "task-gpu"
+

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -10,6 +10,7 @@ def make_task(
     created_at: str = "2026-01-01T00:00:00Z",
     depends_on: list[str] | None = None,
     touches: list[str] | None = None,
+    capabilities_required: list[str] | None = None,
     status: TaskStatus = TaskStatus.READY,
 ) -> Task:
     return Task(
@@ -22,6 +23,7 @@ def make_task(
         priority=priority,
         depends_on=depends_on or [],
         touches=touches or [],
+        capabilities_required=capabilities_required or [],
         status=status,
     )
 
@@ -125,3 +127,51 @@ def test_multiple_active_scopes():
     )
     # clean has no overlap, so it wins despite lower priority
     assert result is clean
+
+
+def test_capability_match_allows_task():
+    """Task is eligible when worker has all required capabilities."""
+    t = make_task("t1", capabilities_required=["gpu", "docker"])
+    result = select_task(
+        [t],
+        done_task_ids=set(),
+        active_tasks=[],
+        worker_capabilities={"gpu", "docker", "extra"},
+    )
+    assert result is t
+
+
+def test_capability_mismatch_skips_task():
+    """Task is skipped when worker is missing a required capability."""
+    t = make_task("t1", capabilities_required=["gpu"])
+    result = select_task(
+        [t],
+        done_task_ids=set(),
+        active_tasks=[],
+        worker_capabilities={"docker"},
+    )
+    assert result is None
+
+
+def test_no_capabilities_required_always_eligible():
+    """Task with no capabilities_required is eligible regardless of worker_capabilities."""
+    t = make_task("t1", capabilities_required=[])
+    result = select_task(
+        [t],
+        done_task_ids=set(),
+        active_tasks=[],
+        worker_capabilities=set(),
+    )
+    assert result is t
+
+
+def test_worker_capabilities_none_skips_filter():
+    """When worker_capabilities is None, capability filtering is skipped (backward compatible)."""
+    t = make_task("t1", capabilities_required=["gpu"])
+    result = select_task(
+        [t],
+        done_task_ids=set(),
+        active_tasks=[],
+        worker_capabilities=None,
+    )
+    assert result is t

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -221,3 +221,59 @@ def test_signal_appends(client):
     assert len(signals) == 1
     assert signals[0]["message"] == "task needs re-scoping"
     assert signals[0]["worker_id"] == "worker-1"
+
+
+def test_carry_with_capabilities_and_pull_with_capable_worker(tmp_path):
+    """carry accepts capabilities_required; capable worker gets the task, incapable gets none."""
+    from antfarm.core.backends.file import FileBackend
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend)
+    client = TestClient(app)
+
+    # Submit a task requiring "gpu"
+    r = client.post(
+        "/tasks",
+        json={
+            "id": "task-gpu",
+            "title": "GPU task",
+            "spec": "needs gpu",
+            "capabilities_required": ["gpu"],
+        },
+    )
+    assert r.status_code == 201
+
+    # Register a capable worker
+    r = client.post(
+        "/workers/register",
+        json={
+            "worker_id": "worker-gpu",
+            "node_id": "node-1",
+            "agent_type": "generic",
+            "workspace_root": "/tmp",
+            "capabilities": ["gpu"],
+        },
+    )
+    assert r.status_code == 201
+
+    # Register a non-capable worker
+    r = client.post(
+        "/workers/register",
+        json={
+            "worker_id": "worker-cpu",
+            "node_id": "node-1",
+            "agent_type": "generic",
+            "workspace_root": "/tmp",
+            "capabilities": [],
+        },
+    )
+    assert r.status_code == 201
+
+    # Non-capable worker gets nothing
+    r = client.post("/tasks/pull", json={"worker_id": "worker-cpu"})
+    assert r.status_code == 204
+
+    # Capable worker gets the task
+    r = client.post("/tasks/pull", json={"worker_id": "worker-gpu"})
+    assert r.status_code == 200
+    assert r.json()["id"] == "task-gpu"


### PR DESCRIPTION
## Summary

- Adds `capabilities_required: list[str]` to `Task` and `capabilities: list[str]` to `Worker` (models, serialization, deserialization)
- `select_task()` in `scheduler.py` accepts `worker_capabilities: set[str] | None`; filters tasks whose `capabilities_required` is not a subset of worker capabilities — `None` preserves backward compatibility
- `FileBackend.pull()` reads the worker file to extract capabilities and applies the capability filter
- `CarryRequest` gains `capabilities_required`, `WorkerRegisterRequest` gains `capabilities`; both threaded through their handlers in `serve.py`
- `carry` CLI gains `--capabilities` (comma-separated); `worker start` and `hatch` gain `--capabilities`
- `ColonyClient.register_worker()` accepts optional `capabilities` kwarg
- `WorkerRuntime` accepts `capabilities` and passes it to `register_worker`

## Tests

- 4 scheduler tests (caps matched, caps not matched, no caps required, None skips filter)
- 2 file backend tests (pull skips unmet caps, pull matches met caps)
- 1 serve integration test (carry with caps + pull with capable/incapable workers)

closes #45