### PR TITLE
feat(cli): add rich TUI dashboard

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -376,16 +376,37 @@ def _render_scout(status: dict, prev: dict | None) -> None:
 
 @main.command()
 @click.option("--watch", is_flag=True, default=False, help="Re-poll continuously.")
+@click.option("--tui", is_flag=True, default=False, help="Launch rich TUI dashboard.")
 @click.option(
     "--interval",
     default=5,
     show_default=True,
     help="Seconds between polls (with --watch).",
 )
+@click.option(
+    "--refresh",
+    default=2.0,
+    show_default=True,
+    help="Seconds between TUI refreshes (with --tui).",
+)
 @COLONY_URL_OPTION
 @TOKEN_OPTION
-def scout(watch: bool, interval: int, colony_url: str, token: str | None):
+def scout(
+    watch: bool,
+    tui: bool,
+    interval: int,
+    refresh: float,
+    colony_url: str,
+    token: str | None,
+):
     """Show colony status as a table."""
+    if tui:
+        from antfarm.core.tui import AntfarmTUI
+
+        dashboard = AntfarmTUI(colony_url=colony_url, token=token, refresh_interval=refresh)
+        dashboard.run()
+        return
+
     if not watch:
         status = _get(colony_url, "/status", token=token)
         _render_scout(status, None)

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -486,6 +486,21 @@ def get_app(
         """Return colony status summary."""
         return _backend.status()
 
+    @app.get("/status/full", status_code=200)
+    def colony_status_full():
+        """Return colony status, all tasks, and all workers in one call.
+
+        Reduces polling overhead for TUI clients that need all three.
+
+        Returns:
+            Dict with 'status', 'tasks', and 'workers' keys.
+        """
+        return {
+            "status": _backend.status(),
+            "tasks": _backend.list_tasks(),
+            "workers": _backend.list_workers(),
+        }
+
     # ------------------------------------------------------------------
     # Backup status
     # ------------------------------------------------------------------

--- a/antfarm/core/tui.py
+++ b/antfarm/core/tui.py
@@ -1,0 +1,295 @@
+"""Rich TUI dashboard for Antfarm colony monitoring.
+
+Provides a live-updating terminal dashboard showing colony summary,
+active tasks, ready queue, merge queue, and worker status.
+
+Usage:
+    tui = AntfarmTUI(colony_url="http://localhost:7433", token=None)
+    tui.run()
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+from rich.layout import Layout
+from rich.live import Live
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+
+class AntfarmTUI:
+    """Live TUI dashboard for an Antfarm colony.
+
+    Args:
+        colony_url: Base URL of the colony server.
+        token: Optional bearer token for authentication.
+        refresh_interval: Seconds between display refreshes.
+    """
+
+    def __init__(
+        self,
+        colony_url: str,
+        token: str | None = None,
+        refresh_interval: float = 2.0,
+    ):
+        self.colony_url = colony_url.rstrip("/")
+        self.token = token
+        self.refresh_interval = refresh_interval
+
+    def run(self) -> None:
+        """Main loop using rich.live.Live."""
+        with Live(self._build_display(), refresh_per_second=1) as live:
+            try:
+                while True:
+                    live.update(self._build_display())
+                    time.sleep(self.refresh_interval)
+            except KeyboardInterrupt:
+                pass
+
+    def _build_display(self) -> Layout:
+        """Fetch status + tasks + workers and build the display.
+
+        Returns:
+            A rich Layout containing all dashboard panels.
+        """
+        try:
+            full = self._fetch("/status/full")
+            status = full.get("status", {})
+            tasks = full.get("tasks", [])
+            workers = full.get("workers", [])
+        except Exception as exc:
+            layout = Layout()
+            layout.update(Panel(f"[red]Connection error: {exc}[/red]", title="Antfarm TUI"))
+            return layout
+
+        active_tasks = [t for t in tasks if t.get("status") == "active"]
+        ready_tasks = [t for t in tasks if t.get("status") == "ready"]
+        done_tasks = [t for t in tasks if t.get("status") == "done"]
+
+        layout = Layout()
+        layout.split_column(
+            Layout(name="top", size=7),
+            Layout(name="middle", size=12),
+            Layout(name="bottom"),
+        )
+
+        layout["top"].update(
+            Panel(self._render_summary(status), title="[bold blue]Antfarm Colony[/bold blue]")
+        )
+
+        layout["middle"].update(
+            Panel(
+                self._render_tasks(active_tasks, "Active Tasks", ["active"]),
+                title="[bold yellow]Active[/bold yellow]",
+            )
+        )
+
+        layout["bottom"].split_row(
+            Layout(name="bottom_left"),
+            Layout(name="bottom_right"),
+        )
+
+        layout["bottom"]["bottom_left"].split_column(
+            Layout(name="ready"),
+            Layout(name="merge"),
+        )
+
+        layout["bottom"]["bottom_left"]["ready"].update(
+            Panel(
+                self._render_tasks(ready_tasks, "Ready Queue", ["ready"]),
+                title="[bold blue]Ready Queue[/bold blue]",
+            )
+        )
+        layout["bottom"]["bottom_left"]["merge"].update(
+            Panel(
+                self._render_tasks(done_tasks, "Merge Queue", ["done"]),
+                title="[bold green]Merge Queue (Done)[/bold green]",
+            )
+        )
+
+        layout["bottom"]["bottom_right"].update(
+            Panel(
+                self._render_workers(workers),
+                title="[bold cyan]Workers[/bold cyan]",
+            )
+        )
+
+        return layout
+
+    def _fetch(self, path: str) -> dict | list:
+        """Fetch JSON from the colony API.
+
+        Args:
+            path: API path to fetch (e.g. "/status/full").
+
+        Returns:
+            Parsed JSON response as dict or list.
+
+        Raises:
+            httpx.HTTPError: On non-2xx responses.
+        """
+        headers = {"Authorization": f"Bearer {self.token}"} if self.token else {}
+        r = httpx.get(f"{self.colony_url}{path}", headers=headers, timeout=5)
+        r.raise_for_status()
+        return r.json()
+
+    def _render_summary(self, status: dict) -> Table:
+        """Render the colony summary as a rich Table.
+
+        Args:
+            status: Status dict from /status or /status/full.
+
+        Returns:
+            A rich Table with key colony metrics.
+        """
+        table = Table(show_header=False, box=None, padding=(0, 2))
+        table.add_column("Metric", style="bold")
+        table.add_column("Value")
+
+        field_labels = [
+            ("nodes", "Nodes"),
+            ("workers", "Workers"),
+            ("tasks_ready", "Ready"),
+            ("tasks_active", "Active"),
+            ("tasks_done", "Done"),
+            ("tasks_paused", "Paused"),
+            ("tasks_blocked", "Blocked"),
+        ]
+
+        for field, label in field_labels:
+            val = status.get(field, 0)
+            if field == "tasks_active" and isinstance(val, int) and val > 0:
+                value_text = Text(str(val), style="bold yellow")
+            elif field == "tasks_done" and isinstance(val, int) and val > 0:
+                value_text = Text(str(val), style="bold green")
+            elif field == "tasks_blocked" and isinstance(val, int) and val > 0:
+                value_text = Text(str(val), style="bold red")
+            elif field == "tasks_ready" and isinstance(val, int) and val > 0:
+                value_text = Text(str(val), style="bold blue")
+            else:
+                value_text = Text(str(val))
+            table.add_row(label, value_text)
+
+        return table
+
+    def _render_tasks(self, tasks: list, title: str, statuses: list) -> Table:
+        """Render a list of tasks as a rich Table.
+
+        Args:
+            tasks: List of task dicts to display.
+            title: Display title for the table (unused — panels handle titles).
+            statuses: List of statuses being shown (for color context).
+
+        Returns:
+            A rich Table showing task ID, title, worker, and last trail message.
+        """
+        table = Table(show_header=True, header_style="bold", box=None, padding=(0, 1))
+        table.add_column("ID", max_width=20, no_wrap=True)
+        table.add_column("Title", max_width=30, no_wrap=True)
+        table.add_column("Worker", max_width=20, no_wrap=True)
+        table.add_column("Last Trail", max_width=40, no_wrap=True)
+
+        if not tasks:
+            table.add_row("[dim]—[/dim]", "[dim]empty[/dim]", "", "")
+            return table
+
+        for task in tasks:
+            task_id = task.get("id", "")
+            task_title = task.get("title", "")
+            status = task.get("status", "")
+
+            # Get worker from current attempt
+            current_attempt = task.get("current_attempt") or {}
+            if isinstance(current_attempt, dict):
+                worker_id = current_attempt.get("worker_id", "")
+            else:
+                worker_id = ""
+
+            # Get last trail message
+            trail = task.get("trail", [])
+            last_trail = trail[-1].get("message", "") if trail else ""
+            if len(last_trail) > 38:
+                last_trail = last_trail[:35] + "..."
+
+            # Color by status
+            if status == "done":
+                id_style = "green"
+                title_style = "green"
+            elif status == "active":
+                id_style = "yellow"
+                title_style = "yellow"
+            elif status == "blocked":
+                id_style = "red"
+                title_style = "red"
+            elif status == "ready":
+                id_style = "blue"
+                title_style = "blue"
+            elif status == "paused":
+                id_style = "dim"
+                title_style = "dim"
+            else:
+                id_style = ""
+                title_style = ""
+
+            table.add_row(
+                Text(task_id[:18], style=id_style),
+                Text(task_title[:28], style=title_style),
+                Text(worker_id[:18] if worker_id else "—", style="dim"),
+                Text(last_trail, style="dim"),
+            )
+
+        return table
+
+    def _render_workers(self, workers: list) -> Table:
+        """Render worker list as a rich Table.
+
+        Args:
+            workers: List of worker dicts, each optionally including rate limit fields.
+
+        Returns:
+            A rich Table showing worker ID, status, node, and rate limit state.
+        """
+        table = Table(show_header=True, header_style="bold", box=None, padding=(0, 1))
+        table.add_column("Worker", max_width=22, no_wrap=True)
+        table.add_column("Status", max_width=10, no_wrap=True)
+        table.add_column("Node", max_width=15, no_wrap=True)
+        table.add_column("Rate Limit", max_width=20, no_wrap=True)
+
+        if not workers:
+            table.add_row("[dim]—[/dim]", "[dim]no workers[/dim]", "", "")
+            return table
+
+        for worker in workers:
+            worker_id = worker.get("worker_id", "")
+            w_status = worker.get("status", "unknown")
+            node_id = worker.get("node_id", "")
+
+            # Rate limit info
+            rate_limited = worker.get("rate_limited", False)
+            rate_limit_until = worker.get("rate_limit_until", None)
+            if rate_limited and rate_limit_until:
+                rate_text = Text(f"limited until {rate_limit_until[:16]}", style="red")
+            elif rate_limited:
+                rate_text = Text("rate limited", style="red")
+            else:
+                rate_text = Text("ok", style="green")
+
+            # Status color
+            if w_status == "idle":
+                status_text = Text("idle", style="dim")
+            elif w_status == "busy":
+                status_text = Text("busy", style="yellow")
+            else:
+                status_text = Text(w_status, style="dim")
+
+            table.add_row(
+                Text(worker_id[:20], style="cyan"),
+                status_text,
+                Text(node_id[:13], style="dim"),
+                rate_text,
+            )
+
+        return table

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "uvicorn>=0.20",
     "click>=8.0",
     "httpx>=0.24",
+    "rich>=13.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1,0 +1,210 @@
+"""Tests for the AntfarmTUI render helpers.
+
+Tests _render_summary, _render_tasks, and _render_workers in isolation
+without any live terminal or network I/O.
+"""
+
+from rich.table import Table
+
+from antfarm.core.tui import AntfarmTUI
+
+
+def _make_tui() -> AntfarmTUI:
+    return AntfarmTUI(colony_url="http://localhost:7433", token=None)
+
+
+# ---------------------------------------------------------------------------
+# _render_summary
+# ---------------------------------------------------------------------------
+
+
+def test_render_summary_returns_table():
+    tui = _make_tui()
+    status = {
+        "nodes": 2,
+        "workers": 3,
+        "tasks_ready": 1,
+        "tasks_active": 2,
+        "tasks_done": 5,
+        "tasks_paused": 0,
+        "tasks_blocked": 0,
+    }
+    result = tui._render_summary(status)
+    assert isinstance(result, Table)
+
+
+def test_render_summary_empty_status():
+    tui = _make_tui()
+    result = tui._render_summary({})
+    assert isinstance(result, Table)
+
+
+def test_render_summary_partial_status():
+    tui = _make_tui()
+    result = tui._render_summary({"nodes": 1, "workers": 1})
+    assert isinstance(result, Table)
+
+
+# ---------------------------------------------------------------------------
+# _render_tasks
+# ---------------------------------------------------------------------------
+
+
+def test_render_tasks_empty_list():
+    tui = _make_tui()
+    result = tui._render_tasks([], "Active Tasks", ["active"])
+    assert isinstance(result, Table)
+    # Should have one row with empty indicator
+    assert result.row_count == 1
+
+
+def test_render_tasks_with_active_task():
+    tui = _make_tui()
+    tasks = [
+        {
+            "id": "task-001",
+            "title": "Implement feature X",
+            "status": "active",
+            "current_attempt": {"worker_id": "node1/worker-a"},
+            "trail": [
+                {"ts": "2026-01-01T00:00:00", "worker_id": "node1/worker-a",
+                 "message": "Working on it"},
+            ],
+        }
+    ]
+    result = tui._render_tasks(tasks, "Active", ["active"])
+    assert isinstance(result, Table)
+    assert result.row_count == 1
+
+
+def test_render_tasks_with_done_task():
+    tui = _make_tui()
+    tasks = [
+        {
+            "id": "task-002",
+            "title": "Fix bug Y",
+            "status": "done",
+            "current_attempt": None,
+            "trail": [],
+        }
+    ]
+    result = tui._render_tasks(tasks, "Done", ["done"])
+    assert isinstance(result, Table)
+    assert result.row_count == 1
+
+
+def test_render_tasks_no_trail():
+    tui = _make_tui()
+    tasks = [
+        {
+            "id": "task-003",
+            "title": "Empty trail task",
+            "status": "ready",
+            "current_attempt": None,
+            "trail": [],
+        }
+    ]
+    result = tui._render_tasks(tasks, "Ready", ["ready"])
+    assert isinstance(result, Table)
+
+
+def test_render_tasks_long_trail_message_truncated():
+    tui = _make_tui()
+    long_msg = "A" * 100
+    tasks = [
+        {
+            "id": "task-004",
+            "title": "Long message task",
+            "status": "active",
+            "current_attempt": {"worker_id": "w1"},
+            "trail": [
+                {"ts": "2026-01-01T00:00:00", "worker_id": "w1", "message": long_msg},
+            ],
+        }
+    ]
+    result = tui._render_tasks(tasks, "Active", ["active"])
+    assert isinstance(result, Table)
+
+
+def test_render_tasks_multiple_tasks():
+    tui = _make_tui()
+    tasks = [
+        {
+            "id": f"task-{i}", "title": f"Task {i}", "status": "ready",
+            "current_attempt": None, "trail": [],
+        }
+        for i in range(5)
+    ]
+    result = tui._render_tasks(tasks, "Ready", ["ready"])
+    assert isinstance(result, Table)
+    assert result.row_count == 5
+
+
+# ---------------------------------------------------------------------------
+# _render_workers
+# ---------------------------------------------------------------------------
+
+
+def test_render_workers_empty_list():
+    tui = _make_tui()
+    result = tui._render_workers([])
+    assert isinstance(result, Table)
+    assert result.row_count == 1  # empty indicator row
+
+
+def test_render_workers_idle_worker():
+    tui = _make_tui()
+    workers = [
+        {
+            "worker_id": "node1/worker-a",
+            "status": "idle",
+            "node_id": "node1",
+            "rate_limited": False,
+            "rate_limit_until": None,
+        }
+    ]
+    result = tui._render_workers(workers)
+    assert isinstance(result, Table)
+    assert result.row_count == 1
+
+
+def test_render_workers_rate_limited():
+    tui = _make_tui()
+    workers = [
+        {
+            "worker_id": "node2/worker-b",
+            "status": "idle",
+            "node_id": "node2",
+            "rate_limited": True,
+            "rate_limit_until": "2026-04-04T10:30:00",
+        }
+    ]
+    result = tui._render_workers(workers)
+    assert isinstance(result, Table)
+    assert result.row_count == 1
+
+
+def test_render_workers_rate_limited_no_until():
+    tui = _make_tui()
+    workers = [
+        {
+            "worker_id": "node3/worker-c",
+            "status": "busy",
+            "node_id": "node3",
+            "rate_limited": True,
+            "rate_limit_until": None,
+        }
+    ]
+    result = tui._render_workers(workers)
+    assert isinstance(result, Table)
+
+
+def test_render_workers_multiple():
+    tui = _make_tui()
+    workers = [
+        {"worker_id": f"node1/w{i}", "status": "idle", "node_id": "node1", "rate_limited": False}
+        for i in range(3)
+    ]
+    result = tui._render_workers(workers)
+    assert isinstance(result, Table)
+    assert result.row_count == 3


### PR DESCRIPTION
## Summary

- Add `antfarm/core/tui.py`: `AntfarmTUI` class using `rich.live.Live` with a 4-panel layout — colony summary, active tasks, ready/merge queue, and workers with rate limit status
- Add `GET /status/full` endpoint to `serve.py` returning status + tasks + workers in one call (reduces polling overhead for TUI)
- Add `--tui` and `--refresh` flags to `scout` command in `cli.py`
- Add `rich>=13.0` to `pyproject.toml` dependencies
- Add `tests/test_tui.py`: 14 tests covering all render helpers in isolation

## Test plan

- [x] `python -m pytest tests/ --ignore=tests/test_redis_backend.py -x -q` → 272 passed
- [x] `ruff check .` → All checks passed
- [ ] Manual: `antfarm scout --tui` against a live colony

closes #53