### PR TITLE
feat(cli): add antfarm import command

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -777,5 +777,60 @@ def deploy(
         click.echo(f"[{icon}] {r.node_id} ({r.host}) worker-{r.worker_index}: {r.message}")
 
 
+# ---------------------------------------------------------------------------
+# import
+# ---------------------------------------------------------------------------
+
+
+@main.command("import")
+@click.option("--from", "source", required=True, type=click.Choice(["github", "json"]))
+@click.option("--repo", default=None)
+@click.option("--file", "file_path", default=None)
+@click.option("--github-token", default=None, envvar="GITHUB_TOKEN")
+@click.option("--label", default=None, help="GitHub label filter")
+@click.option("--dry-run", is_flag=True)
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def import_cmd(
+    source: str,
+    repo: str | None,
+    file_path: str | None,
+    github_token: str | None,
+    label: str | None,
+    dry_run: bool,
+    colony_url: str,
+    token: str | None,
+):
+    """Import tasks from an external source into the colony."""
+    from antfarm.core.importers.github import GitHubImporter
+    from antfarm.core.importers.json_file import JsonFileImporter
+
+    if source == "github":
+        if not repo:
+            raise click.UsageError("--repo is required when --from=github")
+        importer = GitHubImporter(repo=repo, token=github_token, label=label)
+    else:
+        if not file_path:
+            raise click.UsageError("--file is required when --from=json")
+        importer = JsonFileImporter(file_path=file_path)
+
+    tasks = importer.import_tasks()
+
+    if not tasks:
+        click.echo("No tasks found.")
+        return
+
+    for task in tasks:
+        if dry_run:
+            click.echo(json.dumps(task, indent=2))
+        else:
+            if "id" not in task:
+                task["id"] = f"task-{int(time.time() * 1000)}"
+            result = _post(colony_url, "/tasks", task, token=token)
+            click.echo(f"Imported: {result}")
+
+    click.echo(f"{'[dry-run] Would import' if dry_run else 'Imported'} {len(tasks)} task(s).")
+
+
 if __name__ == "__main__":
     main()

--- a/antfarm/core/importers/__init__.py
+++ b/antfarm/core/importers/__init__.py
@@ -1,0 +1,11 @@
+"""Task importers for Antfarm.
+
+Provides pluggable importers (GitHub Issues, JSON file) that produce
+task dicts compatible with the /tasks POST endpoint.
+"""
+
+from antfarm.core.importers.base import TaskImporter
+from antfarm.core.importers.github import GitHubImporter
+from antfarm.core.importers.json_file import JsonFileImporter
+
+__all__ = ["TaskImporter", "GitHubImporter", "JsonFileImporter"]

--- a/antfarm/core/importers/base.py
+++ b/antfarm/core/importers/base.py
@@ -1,0 +1,25 @@
+"""Base class for Antfarm task importers.
+
+All importers must subclass TaskImporter and implement import_tasks(),
+returning a list of task dicts compatible with the colony /tasks endpoint.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class TaskImporter(ABC):
+    """Abstract base class for task importers.
+
+    Subclasses pull tasks from an external source and return them as
+    dicts ready to POST to the colony /tasks endpoint.
+    """
+
+    @abstractmethod
+    def import_tasks(self) -> list[dict]:
+        """Fetch and return tasks from the source.
+
+        Returns:
+            List of task dicts with at minimum 'title' and 'spec' keys.
+        """

--- a/antfarm/core/importers/github.py
+++ b/antfarm/core/importers/github.py
@@ -1,0 +1,65 @@
+"""GitHub Issues importer for Antfarm.
+
+Lists open issues from a GitHub repository and maps them to task dicts.
+Uses the GitHub REST API v3 via httpx.
+"""
+
+from __future__ import annotations
+
+import httpx
+
+from antfarm.core.importers.base import TaskImporter
+
+
+class GitHubImporter(TaskImporter):
+    """Import open issues from a GitHub repository as tasks.
+
+    Args:
+        repo: Repository in 'owner/name' format (e.g. 'antfarm-ai/antfarm').
+        token: GitHub personal access token (optional for public repos).
+        label: Filter issues by label (optional).
+    """
+
+    def __init__(
+        self,
+        repo: str,
+        token: str | None = None,
+        label: str | None = None,
+    ) -> None:
+        self.repo = repo
+        self.token = token
+        self.label = label
+
+    def import_tasks(self) -> list[dict]:
+        """Fetch open GitHub issues and map them to task dicts.
+
+        Returns:
+            List of task dicts with title, spec, and touches from labels.
+        """
+        headers = {"Accept": "application/vnd.github+json"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+
+        params: dict = {"state": "open", "per_page": 100}
+        if self.label:
+            params["labels"] = self.label
+
+        url = f"https://api.github.com/repos/{self.repo}/issues"
+        response = httpx.get(url, headers=headers, params=params)
+        response.raise_for_status()
+
+        tasks = []
+        for issue in response.json():
+            # Skip pull requests (GitHub returns them in issues endpoint)
+            if "pull_request" in issue:
+                continue
+
+            touches = [lbl["name"] for lbl in issue.get("labels", [])]
+            body = issue.get("body") or ""
+            tasks.append({
+                "title": issue["title"],
+                "spec": body,
+                "touches": touches,
+            })
+
+        return tasks

--- a/antfarm/core/importers/json_file.py
+++ b/antfarm/core/importers/json_file.py
@@ -1,0 +1,41 @@
+"""JSON file importer for Antfarm.
+
+Reads a JSON array of task dicts from a local file and returns them
+ready to POST to the colony /tasks endpoint.
+"""
+
+from __future__ import annotations
+
+import json
+
+from antfarm.core.importers.base import TaskImporter
+
+
+class JsonFileImporter(TaskImporter):
+    """Import tasks from a JSON file containing an array of task dicts.
+
+    Args:
+        file_path: Path to the JSON file.
+    """
+
+    def __init__(self, file_path: str) -> None:
+        self.file_path = file_path
+
+    def import_tasks(self) -> list[dict]:
+        """Read and return task dicts from the JSON file.
+
+        Returns:
+            List of task dicts as parsed from the file.
+
+        Raises:
+            ValueError: If the file does not contain a JSON array.
+        """
+        with open(self.file_path) as f:
+            data = json.load(f)
+
+        if not isinstance(data, list):
+            raise ValueError(
+                f"Expected a JSON array in {self.file_path!r}, got {type(data).__name__}"
+            )
+
+        return data

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,261 @@
+"""Tests for the import command and task importers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from antfarm.core.cli import main
+from antfarm.core.importers.github import GitHubImporter
+from antfarm.core.importers.json_file import JsonFileImporter
+
+# ---------------------------------------------------------------------------
+# GitHubImporter unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_issue(number: int, title: str, body: str, labels: list[str], is_pr: bool = False) -> dict:
+    issue: dict = {
+        "number": number,
+        "title": title,
+        "body": body,
+        "labels": [{"name": lbl} for lbl in labels],
+    }
+    if is_pr:
+        issue["pull_request"] = {"url": "https://example.com"}
+    return issue
+
+
+def test_github_importer_basic():
+    """GitHubImporter maps open issues to task dicts."""
+    issues = [
+        _make_issue(1, "Fix bug", "Steps to reproduce", ["bug"]),
+        _make_issue(2, "Add feature", "Feature description", ["enhancement", "api"]),
+    ]
+    mock_response = MagicMock()
+    mock_response.json.return_value = issues
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.get", return_value=mock_response) as mock_get:
+        importer = GitHubImporter(repo="owner/repo", token="ghp_test")
+        tasks = importer.import_tasks()
+
+    assert len(tasks) == 2
+    assert tasks[0] == {"title": "Fix bug", "spec": "Steps to reproduce", "touches": ["bug"]}
+    assert tasks[1] == {
+        "title": "Add feature",
+        "spec": "Feature description",
+        "touches": ["enhancement", "api"],
+    }
+
+    call_args = mock_get.call_args
+    assert "Authorization" in call_args.kwargs["headers"]
+    assert call_args.kwargs["headers"]["Authorization"] == "Bearer ghp_test"
+
+
+def test_github_importer_skips_pull_requests():
+    """GitHubImporter filters out pull requests from the issue list."""
+    issues = [
+        _make_issue(1, "Real issue", "body", []),
+        _make_issue(2, "A PR", "pr body", [], is_pr=True),
+    ]
+    mock_response = MagicMock()
+    mock_response.json.return_value = issues
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.get", return_value=mock_response):
+        importer = GitHubImporter(repo="owner/repo")
+        tasks = importer.import_tasks()
+
+    assert len(tasks) == 1
+    assert tasks[0]["title"] == "Real issue"
+
+
+def test_github_importer_label_filter():
+    """GitHubImporter passes label filter in query params."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = []
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.get", return_value=mock_response) as mock_get:
+        importer = GitHubImporter(repo="owner/repo", label="bug")
+        importer.import_tasks()
+
+    params = mock_get.call_args.kwargs["params"]
+    assert params["labels"] == "bug"
+
+
+def test_github_importer_no_token():
+    """GitHubImporter works without a token (public repos)."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = []
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.get", return_value=mock_response) as mock_get:
+        importer = GitHubImporter(repo="owner/repo")
+        importer.import_tasks()
+
+    headers = mock_get.call_args.kwargs["headers"]
+    assert "Authorization" not in headers
+
+
+def test_github_importer_null_body():
+    """GitHubImporter maps null issue body to empty string."""
+    issues = [_make_issue(1, "No body issue", None, [])]
+    mock_response = MagicMock()
+    mock_response.json.return_value = issues
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("httpx.get", return_value=mock_response):
+        importer = GitHubImporter(repo="owner/repo")
+        tasks = importer.import_tasks()
+
+    assert tasks[0]["spec"] == ""
+
+
+# ---------------------------------------------------------------------------
+# JsonFileImporter unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_json_file_importer_basic(tmp_path: Path):
+    """JsonFileImporter reads a JSON array from file."""
+    task_list = [
+        {"title": "Task A", "spec": "Do A"},
+        {"title": "Task B", "spec": "Do B", "touches": ["api"]},
+    ]
+    f = tmp_path / "tasks.json"
+    f.write_text(json.dumps(task_list))
+
+    importer = JsonFileImporter(file_path=str(f))
+    tasks = importer.import_tasks()
+
+    assert tasks == task_list
+
+
+def test_json_file_importer_not_a_list(tmp_path: Path):
+    """JsonFileImporter raises ValueError if file is not a JSON array."""
+    f = tmp_path / "bad.json"
+    f.write_text(json.dumps({"title": "not a list"}))
+
+    importer = JsonFileImporter(file_path=str(f))
+    with pytest.raises(ValueError, match="Expected a JSON array"):
+        importer.import_tasks()
+
+
+def test_json_file_importer_empty(tmp_path: Path):
+    """JsonFileImporter returns empty list for empty array."""
+    f = tmp_path / "empty.json"
+    f.write_text("[]")
+
+    importer = JsonFileImporter(file_path=str(f))
+    assert importer.import_tasks() == []
+
+
+# ---------------------------------------------------------------------------
+# CLI import command tests
+# ---------------------------------------------------------------------------
+
+
+def test_import_cmd_github_dry_run():
+    """import --from github --dry-run prints tasks without posting."""
+    tasks = [{"title": "Issue 1", "spec": "body", "touches": ["bug"]}]
+
+    with patch("antfarm.core.importers.github.GitHubImporter.import_tasks", return_value=tasks):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["import", "--from", "github", "--repo", "owner/repo", "--dry-run"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Issue 1" in result.output
+    assert "[dry-run]" in result.output
+
+
+def test_import_cmd_json_dry_run(tmp_path: Path):
+    """import --from json --dry-run prints tasks without posting."""
+    task_list = [{"title": "T1", "spec": "spec1"}]
+    f = tmp_path / "tasks.json"
+    f.write_text(json.dumps(task_list))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["import", "--from", "json", "--file", str(f), "--dry-run"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "T1" in result.output
+    assert "[dry-run]" in result.output
+
+
+def test_import_cmd_github_posts_tasks():
+    """import --from github without --dry-run POSTs each task to colony."""
+    tasks = [{"title": "Issue 1", "spec": "body", "touches": []}]
+
+    with (
+        patch("antfarm.core.importers.github.GitHubImporter.import_tasks", return_value=tasks),
+        patch("antfarm.core.cli._post", return_value={"id": "task-123"}) as mock_post,
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["import", "--from", "github", "--repo", "owner/repo"],
+        )
+
+    assert result.exit_code == 0, result.output
+    mock_post.assert_called_once()
+    call_args = mock_post.call_args
+    assert call_args.args[1] == "/tasks"
+    assert call_args.args[2]["title"] == "Issue 1"
+    assert "Imported 1 task(s)." in result.output
+
+
+def test_import_cmd_github_missing_repo():
+    """import --from github without --repo exits with error."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["import", "--from", "github"])
+    assert result.exit_code != 0
+    assert "--repo is required" in result.output
+
+
+def test_import_cmd_json_missing_file():
+    """import --from json without --file exits with error."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["import", "--from", "json"])
+    assert result.exit_code != 0
+    assert "--file is required" in result.output
+
+
+def test_import_cmd_no_tasks():
+    """import command prints 'No tasks found.' when source returns empty list."""
+    with patch("antfarm.core.importers.github.GitHubImporter.import_tasks", return_value=[]):
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            ["import", "--from", "github", "--repo", "owner/repo"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "No tasks found." in result.output
+
+
+def test_import_cmd_github_token_passed():
+    """import --github-token is forwarded to GitHubImporter."""
+    with patch(
+        "antfarm.core.importers.github.GitHubImporter.__init__", return_value=None
+    ) as mock_init, patch(
+        "antfarm.core.importers.github.GitHubImporter.import_tasks", return_value=[]
+    ):
+        runner = CliRunner()
+        runner.invoke(
+            main,
+            ["import", "--from", "github", "--repo", "owner/repo", "--github-token", "tok123"],
+        )
+
+    mock_init.assert_called_once_with(repo="owner/repo", token="tok123", label=None)


### PR DESCRIPTION
## Summary

- Adds `antfarm import` CLI command supporting `--from github` and `--from json` sources
- Implements `TaskImporter` ABC in `antfarm/core/importers/base.py`
- `GitHubImporter`: lists open issues via GitHub REST API, maps title/body/labels → task dict, filters PRs, supports label filter and bearer token
- `JsonFileImporter`: reads a JSON array of task dicts from a local file
- `--dry-run` flag prints tasks without POSTing to colony
- 15 new tests in `tests/test_import.py`

## Test plan

- [x] `pytest tests/test_import.py` — 15 tests pass
- [x] `pytest tests/ --ignore=tests/test_redis_backend.py` — 287 tests pass
- [x] `ruff check` — no lint errors

Closes #66