### PR TITLE
Add GET /tasks/count endpoint

### DIFF
--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -453,6 +453,11 @@ def get_app(
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         return {"ok": True}
 
+    @app.get("/tasks/count", status_code=200)
+    def task_count():
+        """Return task counts by status without full task data."""
+        return _backend.status()["tasks"]
+
     @app.get("/tasks", status_code=200)
     def list_tasks(status: str | None = Query(default=None)):
         """List tasks with optional ?status= filter."""

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -174,6 +174,19 @@ def test_status_returns_summary(client):
     assert data["tasks"]["done"] == 0
 
 
+def test_task_count_endpoint(client):
+    """GET /tasks/count returns counts by status."""
+    _carry(client, task_id="task-001")
+    _carry(client, task_id="task-002")
+
+    r = client.get("/tasks/count")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["ready"] == 2
+    assert data["active"] == 0
+    assert data["done"] == 0
+
+
 def test_guard_acquire_and_release(client):
     r = client.post("/guards/repo/main", json={"owner": "node-1/worker-1"})
     assert r.status_code == 200


### PR DESCRIPTION
Add a lightweight endpoint that returns task counts without full task data.

FILE: antfarm/core/serve.py
Add inside get_app():
@app.get('/tasks/count', status_code=200)
def task_count():
    return _backend.status()['tasks']

TEST: Add test in tests/test_serve.py: test_task_count_endpoint — carry 2 tasks, verify count returns ready=2.
BRANCH: feat/add-task-count
COMMIT: feat(serve): add GET /tasks/count endpoint