### PR TITLE
Add version command

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -15,6 +15,8 @@ import time
 import click
 import httpx
 
+from antfarm.core import __version__
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -76,6 +78,17 @@ def _delete(
 @click.group()
 def main():
     """Antfarm — lightweight orchestration for AI coding agents."""
+
+
+# ---------------------------------------------------------------------------
+# version
+# ---------------------------------------------------------------------------
+
+
+@main.command()
+def version():
+    """Print the antfarm version."""
+    click.echo(f"antfarm v{__version__}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,21 @@ from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
+from antfarm.core import __version__
 from antfarm.core.cli import main
+
+# ---------------------------------------------------------------------------
+# version
+# ---------------------------------------------------------------------------
+
+
+def test_version_command():
+    """Version command prints the current antfarm version."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["version"])
+    assert result.exit_code == 0
+    assert f"antfarm v{__version__}" in result.output
+
 
 # ---------------------------------------------------------------------------
 # colony


### PR DESCRIPTION
Add a simple antfarm version CLI command that prints the version. File: antfarm/core/cli.py. Add: @main.command() then def version(): click.echo(f'antfarm v{__version__}'). Import __version__ from antfarm.core. Test: test_version_command in tests/test_cli.py. Branch: feat/add-version. Commit: feat(cli): add version command.