### PR TITLE
Add task count endpoint

### DIFF
--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -512,6 +512,11 @@ def get_app(
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         return {"ok": True}
 
+    @app.get("/tasks/count", status_code=200)
+    def task_count():
+        """Return task counts by status."""
+        return _backend.status()["tasks"]
+
     @app.get("/tasks", status_code=200)
     def list_tasks(status: str | None = Query(default=None)):
         """List tasks with optional ?status= filter."""

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -174,6 +174,19 @@ def test_status_returns_summary(client):
     assert data["tasks"]["done"] == 0
 
 
+def test_task_count(client):
+    """GET /tasks/count returns task counts by status."""
+    _carry(client, task_id="task-001")
+    _carry(client, task_id="task-002")
+
+    r = client.get("/tasks/count")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["ready"] == 2
+    assert data["active"] == 0
+    assert data["done"] == 0
+
+
 def test_guard_acquire_and_release(client):
     r = client.post("/guards/repo/main", json={"owner": "node-1/worker-1"})
     assert r.status_code == 200


### PR DESCRIPTION
Add GET /tasks/count. File: antfarm/core/serve.py. Add @app.get('/tasks/count') def task_count(): return _backend.status()['tasks']. Test: tests/test_serve.py test_task_count. Branch: feat/task-count. Commit: feat(serve): add task count endpoint.