### PR TITLE
Soldier skips plan tasks in process_done_tasks

### DIFF
--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -127,6 +127,10 @@ class Soldier:
             task_id = task.get("id", "")
             if task_id.startswith("review-"):
                 continue
+            # Skip plan tasks — they produce tasks, not code
+            caps_req = set(task.get("capabilities_required", []))
+            if "plan" in caps_req:
+                continue
             if self._has_merged_attempt(task):
                 continue
             # Skip if already has a verdict


### PR DESCRIPTION
WORKFLOW:
1. Read antfarm/core/soldier.py — understand process_done_tasks() method
2. Plan your changes
3. Implement
4. Run: python3.12 -m pytest tests/ -x -q --ignore=tests/test_redis_backend.py && ruff check .
5. Commit and push

CHANGES TO antfarm/core/soldier.py:

In process_done_tasks(), after the existing skip for review tasks, add:
   # Skip plan tasks — they produce tasks, not code
   caps_req = set(task.get('capabilities_required', []))
   if 'plan' in caps_req:
       continue

Plan ta