### PR TITLE
Add spawned_by to CarryRequest for lineage

### DIFF
--- a/antfarm/core/colony_client.py
+++ b/antfarm/core/colony_client.py
@@ -112,6 +112,7 @@ class ColonyClient:
         priority: int = 10,
         complexity: str = "M",
         capabilities_required: list[str] | None = None,
+        spawned_by: dict | None = None,
     ) -> dict:
         """Create a task in the colony."""
         payload: dict = {
@@ -125,6 +126,8 @@ class ColonyClient:
         }
         if capabilities_required:
             payload["capabilities_required"] = capabilities_required
+        if spawned_by:
+            payload["spawned_by"] = spawned_by
         r = self._client.post("/tasks", json=payload)
         r.raise_for_status()
         return r.json()

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -95,6 +95,7 @@ class CarryRequest(BaseModel):
     touches: list[str] = []
     capabilities_required: list[str] = []
     created_by: str = "api"
+    spawned_by: dict | None = None
 
 
 class NodeRequest(BaseModel):
@@ -305,6 +306,8 @@ def get_app(
             "created_at": now,
             "updated_at": now,
         }
+        if req.spawned_by:
+            task["spawned_by"] = req.spawned_by
         try:
             task_id = _backend.carry(task)
         except ValueError as exc:


### PR DESCRIPTION
WORKFLOW:
1. Read antfarm/core/serve.py — understand CarryRequest model and carry_task endpoint
2. Read antfarm/core/colony_client.py — understand carry() method
3. Plan your changes
4. Implement
5. Run: python3.12 -m pytest tests/ -x -q --ignore=tests/test_redis_backend.py && ruff check .
6. Commit and push

CHANGES:

1. antfarm/core/serve.py — Add spawned_by to CarryRequest:
   class CarryRequest(BaseModel):
       ... existing fields ...
       spawned_by: dict | None = None

   In carry_task