### PR TITLE
Add planner mode to worker runtime

### DIFF
--- a/antfarm/core/colony_client.py
+++ b/antfarm/core/colony_client.py
@@ -112,6 +112,7 @@ class ColonyClient:
         priority: int = 10,
         complexity: str = "M",
         capabilities_required: list[str] | None = None,
+        spawned_by: dict | None = None,
     ) -> dict:
         """Create a task in the colony."""
         payload: dict = {
@@ -125,6 +126,8 @@ class ColonyClient:
         }
         if capabilities_required:
             payload["capabilities_required"] = capabilities_required
+        if spawned_by:
+            payload["spawned_by"] = spawned_by
         r = self._client.post("/tasks", json=payload)
         r.raise_for_status()
         return r.json()

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -95,6 +95,7 @@ class CarryRequest(BaseModel):
     touches: list[str] = []
     capabilities_required: list[str] = []
     created_by: str = "api"
+    spawned_by: dict | None = None
 
 
 class NodeRequest(BaseModel):
@@ -305,6 +306,8 @@ def get_app(
             "created_at": now,
             "updated_at": now,
         }
+        if req.spawned_by:
+            task["spawned_by"] = req.spawned_by
         try:
             task_id = _backend.carry(task)
         except ValueError as exc:

--- a/antfarm/core/worker.py
+++ b/antfarm/core/worker.py
@@ -374,6 +374,43 @@ class WorkerRuntime:
                 task_id, self.worker_id, "agent completed, building artifact"
             )
 
+        # Plan task: parse output, validate, carry children, harvest with plan artifact
+        caps_req = set(task.get("capabilities_required", []))
+        is_plan = "plan" in caps_req
+        if is_plan:
+            plan_result = self._process_plan_output(
+                task, attempt_id, result.stdout + result.stderr
+            )
+            if plan_result:
+                artifact = {
+                    "plan_task_id": task_id,
+                    "created_task_ids": plan_result["created_ids"],
+                    "task_count": len(plan_result["created_ids"]),
+                    "warnings": plan_result["warnings"],
+                    "dependency_summary": plan_result["dep_summary"],
+                }
+                with contextlib.suppress(Exception):
+                    self.colony.mark_harvest_pending(task_id, attempt_id)
+                with contextlib.suppress(Exception):
+                    self.colony.harvest(
+                        task_id, attempt_id, pr="", branch="",
+                        artifact=artifact,
+                    )
+                with contextlib.suppress(Exception):
+                    self.colony.trail(
+                        task_id, self.worker_id,
+                        f"plan complete: created {len(plan_result['created_ids'])} tasks",
+                    )
+                return True
+
+            # Plan parsing failed — trail the error
+            with contextlib.suppress(Exception):
+                self.colony.trail(
+                    task_id, self.worker_id,
+                    "plan failed: could not parse agent output into tasks",
+                )
+            return True
+
         # Set harvest_pending before writing result (best-effort)
         with contextlib.suppress(Exception):
             self.colony.mark_harvest_pending(task_id, attempt_id)
@@ -532,12 +569,41 @@ class WorkerRuntime:
         """
         spec = task.get("spec", "")
         title = task.get("title", "")
-        is_review = task["id"].startswith("review-")
+        caps_req = set(task.get("capabilities_required", []))
+        is_plan = "plan" in caps_req
+        is_review = "review" in caps_req
         branch = _extract_branch_from_spec(spec) if is_review else None
         if not branch:
             branch = f"feat/{task['id']}-{task['current_attempt']}"
 
-        if is_review:
+        if is_plan:
+            prompt = (
+                f"Task: {title}\n\n"
+                "You are a PLANNER. Decompose this spec into implementation tasks.\n\n"
+                f"Spec:\n{spec}\n\n"
+                f"You are working in: {workspace}\n"
+                "Read the codebase to understand the project structure.\n\n"
+                "Output a JSON array of tasks between [PLAN_RESULT] tags.\n"
+                "Each task object must have:\n"
+                '  - "title": short imperative title\n'
+                '  - "spec": detailed implementation instructions (2-5 sentences)\n'
+                '  - "touches": list of scope tags (e.g. ["api", "auth"])\n'
+                '  - "depends_on": list of task indices (1-based) or []\n'
+                '  - "priority": integer 1-20 (lower = higher priority)\n'
+                '  - "complexity": "S", "M", or "L"\n\n'
+                "Rules:\n"
+                "- Maximum 10 tasks\n"
+                "- Make tasks as parallel as possible\n"
+                "- Use depends_on only when strictly necessary\n"
+                "- Each task should be independently implementable\n\n"
+                "Example output:\n"
+                "[PLAN_RESULT]\n"
+                '[{"title": "Add auth middleware", "spec": "...", '
+                '"touches": ["api"], "depends_on": [], '
+                '"priority": 5, "complexity": "M"}]\n'
+                "[/PLAN_RESULT]\n"
+            )
+        elif is_review:
             prompt = (
                 f"Task: {title}\n\n"
                 f"Spec: {spec}\n\n"
@@ -565,7 +631,7 @@ class WorkerRuntime:
                 "4. Push the branch: git push -u origin {branch}\n"
             )
 
-        agent_role = "reviewer" if is_review else "worker"
+        agent_role = "planner" if is_plan else ("reviewer" if is_review else "worker")
         if self.agent_type == "claude-code":
             cmd = [
                 "claude", "-p",
@@ -603,6 +669,146 @@ class WorkerRuntime:
             stderr=proc.stderr,
             branch=branch,
         )
+
+    # ------------------------------------------------------------------
+    # Plan output processing
+    # ------------------------------------------------------------------
+
+    def _process_plan_output(
+        self, task: dict, attempt_id: str, output: str,
+    ) -> dict | None:
+        """Parse plan output, validate, and carry child tasks.
+
+        Returns dict with created_ids, warnings, dep_summary on success.
+        Returns None if parsing or validation fails.
+        """
+        import re
+
+        # Extract JSON from [PLAN_RESULT]...[/PLAN_RESULT] tags
+        match = re.search(
+            r"\[PLAN_RESULT\]\s*(.*?)\s*\[/PLAN_RESULT\]",
+            output, re.DOTALL,
+        )
+        if not match:
+            logger.warning("no [PLAN_RESULT] tags in planner output")
+            return None
+
+        # Parse and validate using shared PlannerEngine logic
+        from antfarm.core.planner import PlannerEngine, resolve_dependencies
+
+        engine = PlannerEngine()
+        plan_result = engine.parse_structured_plan(match.group(1))
+
+        if not plan_result.tasks:
+            logger.warning("plan produced no tasks")
+            with contextlib.suppress(Exception):
+                self.colony.trail(
+                    task["id"], self.worker_id,
+                    "plan produced no tasks"
+                    + (f": {plan_result.warnings[0]}" if plan_result.warnings else ""),
+                )
+            return None
+
+        errors = engine.validate_plan(plan_result)
+        if errors:
+            for err in errors:
+                logger.warning("plan validation error: %s", err)
+                with contextlib.suppress(Exception):
+                    self.colony.trail(
+                        task["id"], self.worker_id,
+                        f"plan validation error: {err}",
+                    )
+            return None
+
+        tasks = plan_result.tasks
+
+        # Guardrail: max 10 children
+        if len(tasks) > 10:
+            logger.warning("plan has %d tasks, max 10", len(tasks))
+            with contextlib.suppress(Exception):
+                self.colony.trail(
+                    task["id"], self.worker_id,
+                    f"plan rejected: {len(tasks)} tasks exceeds max 10",
+                )
+            return None
+
+        # Generate deterministic child IDs (NOT plan-prefixed — these are impl tasks)
+        parent_id = task["id"]
+        slug = parent_id.removeprefix("plan-")
+        child_ids = [f"task-{slug}-{i:02d}" for i in range(1, len(tasks) + 1)]
+
+        # Resolve index-based deps to child IDs
+        resolved_tasks = resolve_dependencies(tasks, child_ids)
+
+        # Generate warnings
+        warnings = engine.generate_warnings(plan_result)
+        warn_strs = [str(w) for w in warnings] if isinstance(warnings, list) else []
+
+        # Carry each child task
+        created_ids: list[str] = []
+        failed_ids: list[str] = []
+        for i, proposed_task in enumerate(resolved_tasks):
+            child_id = child_ids[i]
+            payload = proposed_task.to_carry_dict(child_id)
+
+            # Guardrail: no recursive plans
+            payload["capabilities_required"] = []
+
+            # Lineage metadata
+            spawned_by = {
+                "task_id": parent_id,
+                "attempt_id": attempt_id,
+            }
+
+            try:
+                self.colony.carry(
+                    task_id=child_id,
+                    title=payload["title"],
+                    spec=payload["spec"],
+                    depends_on=payload.get("depends_on", []),
+                    touches=payload.get("touches", []),
+                    priority=payload.get("priority", 10),
+                    complexity=payload.get("complexity", "M"),
+                    capabilities_required=[],
+                    spawned_by=spawned_by,
+                )
+                created_ids.append(child_id)
+                logger.info("carried child task %s", child_id)
+            except Exception as exc:
+                # 409 = already exists (idempotent retry)
+                if "409" in str(exc) or "already exists" in str(exc):
+                    created_ids.append(child_id)
+                    logger.info("child task %s already exists (idempotent)", child_id)
+                else:
+                    logger.warning("failed to carry child %s: %s", child_id, exc)
+                    failed_ids.append(child_id)
+
+        # Partial failure: if any non-idempotent carry failed, do NOT harvest
+        if failed_ids:
+            logger.warning(
+                "plan partial failure: %d/%d tasks failed",
+                len(failed_ids), len(resolved_tasks),
+            )
+            with contextlib.suppress(Exception):
+                self.colony.trail(
+                    task["id"], self.worker_id,
+                    f"plan partial failure: {len(created_ids)} created, "
+                    f"{len(failed_ids)} failed: {', '.join(failed_ids)}",
+                )
+            return None
+
+        # Build dependency summary
+        dep_pairs: list[str] = []
+        for i, t in enumerate(resolved_tasks):
+            for dep in t.depends_on:
+                dep_pairs.append(f"{dep} → {child_ids[i]}")
+        dep_summary = ", ".join(dep_pairs) if dep_pairs else "all parallel"
+
+        return {
+            "created_ids": created_ids,
+            "warnings": warn_strs,
+            "dep_summary": dep_summary,
+        }
 
     # ------------------------------------------------------------------
     # Heartbeat thread

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -7,6 +7,7 @@ WorkspaceManager.create() is monkeypatched to skip real git operations.
 
 from __future__ import annotations
 
+import json as _json
 from unittest.mock import MagicMock
 
 import httpx
@@ -731,3 +732,327 @@ def test_build_artifact_handles_git_failure(tmp_path, http_client):
     assert artifact["lines_removed"] == 0
     assert artifact["head_sha"] == ""
     assert artifact["base_sha"] == ""
+
+
+# ---------------------------------------------------------------------------
+# v0.5.8: Planner mode (#129)
+# ---------------------------------------------------------------------------
+
+
+def _carry_plan(tc, task_id="plan-test", title="Plan Test", spec="decompose this"):
+    """Carry a plan task with capabilities_required=["plan"]."""
+    r = tc.post("/tasks", json={
+        "id": task_id,
+        "title": title,
+        "spec": spec,
+        "capabilities_required": ["plan"],
+    })
+    assert r.status_code == 201
+    return r.json()
+
+
+def _plan_agent_output(tasks_json: str) -> str:
+    """Build agent stdout containing [PLAN_RESULT] tags."""
+    return f"Analyzing codebase...\n[PLAN_RESULT]\n{tasks_json}\n[/PLAN_RESULT]\nDone."
+
+
+def _make_planner_runtime(tmp_path, http_client):
+    """Create a WorkerRuntime with planner capabilities."""
+    rt = WorkerRuntime(
+        colony_url="http://test",
+        node_id="node-1",
+        name="planner-1",
+        agent_type="generic",
+        workspace_root=str(tmp_path / "workspaces"),
+        repo_path=str(tmp_path),
+        integration_branch="main",
+        heartbeat_interval=999.0,
+        capabilities=["plan"],
+        client=http_client,
+    )
+    rt.workspace_mgr.create = MagicMock(return_value=str(tmp_path / "ws"))
+    return rt
+
+
+def test_planner_mode_detects_plan_task(tc, tmp_path, http_client):
+    """Plan task is detected via capabilities_required, not prefix."""
+    _carry_plan(tc)
+    rt = _make_planner_runtime(tmp_path, http_client)
+
+    plan_json = _json.dumps([
+        {"title": "Task A", "spec": "do A", "touches": ["api"],
+         "depends_on": [], "priority": 5, "complexity": "S"},
+    ])
+
+    def plan_agent(task, workspace) -> AgentResult:
+        return AgentResult(
+            returncode=0,
+            stdout=_plan_agent_output(plan_json),
+            stderr="",
+            branch="",
+        )
+
+    rt._launch_agent = plan_agent
+    rt.run()
+
+    # Plan task should be harvested (done)
+    r = tc.get("/tasks/plan-test")
+    assert r.json()["status"] == "done"
+
+    # Child task should have been created
+    r = tc.get("/tasks/task-test-01")
+    assert r.status_code == 200
+    child = r.json()
+    assert child["title"] == "Task A"
+    assert child["status"] == "ready"
+
+
+def test_planner_creates_deterministic_child_ids(tc, tmp_path, http_client):
+    """Child IDs follow pattern task-{slug}-01, task-{slug}-02."""
+    _carry_plan(tc, task_id="plan-auth-system")
+    rt = _make_planner_runtime(tmp_path, http_client)
+
+    plan_json = _json.dumps([
+        {"title": "Add middleware", "spec": "do middleware", "touches": ["api"],
+         "depends_on": [], "priority": 5, "complexity": "M"},
+        {"title": "Add routes", "spec": "do routes", "touches": ["api"],
+         "depends_on": [1], "priority": 10, "complexity": "M"},
+    ])
+
+    def plan_agent(task, workspace) -> AgentResult:
+        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json),
+                           stderr="", branch="")
+
+    rt._launch_agent = plan_agent
+    rt.run()
+
+    # Check child IDs
+    r1 = tc.get("/tasks/task-auth-system-01")
+    assert r1.status_code == 200
+    assert r1.json()["title"] == "Add middleware"
+
+    r2 = tc.get("/tasks/task-auth-system-02")
+    assert r2.status_code == 200
+    assert r2.json()["title"] == "Add routes"
+    # Dep should be resolved to child ID
+    assert "task-auth-system-01" in r2.json()["depends_on"]
+
+
+def test_planner_rejects_more_than_10_tasks(tc, tmp_path, http_client):
+    """Plan with >10 tasks is rejected (guardrail)."""
+    _carry_plan(tc)
+    rt = _make_planner_runtime(tmp_path, http_client)
+
+    tasks = [
+        {"title": f"Task {i}", "spec": f"do {i}", "touches": [],
+         "depends_on": [], "priority": 10, "complexity": "S"}
+        for i in range(11)
+    ]
+    plan_json = _json.dumps(tasks)
+
+    def plan_agent(task, workspace) -> AgentResult:
+        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json),
+                           stderr="", branch="")
+
+    rt._launch_agent = plan_agent
+    rt.run()
+
+    # Plan task should NOT be harvested (stays active due to failure)
+    r = tc.get("/tasks/plan-test")
+    task = r.json()
+    assert task["status"] == "active"
+
+    # Trail should mention rejection
+    messages = [e["message"] for e in task["trail"]]
+    assert any("exceeds max 10" in m for m in messages)
+
+
+def test_planner_no_plan_result_tags(tc, tmp_path, http_client):
+    """Agent output without [PLAN_RESULT] tags fails gracefully."""
+    _carry_plan(tc)
+    rt = _make_planner_runtime(tmp_path, http_client)
+
+    def plan_agent(task, workspace) -> AgentResult:
+        return AgentResult(returncode=0, stdout="no tags here", stderr="", branch="")
+
+    rt._launch_agent = plan_agent
+    rt.run()
+
+    r = tc.get("/tasks/plan-test")
+    task = r.json()
+    assert task["status"] == "active"
+
+    messages = [e["message"] for e in task["trail"]]
+    assert any("could not parse" in m for m in messages)
+
+
+def test_planner_children_no_recursive_plans(tc, tmp_path, http_client):
+    """Child tasks have capabilities_required=[] to prevent recursive plans."""
+    _carry_plan(tc)
+    rt = _make_planner_runtime(tmp_path, http_client)
+
+    plan_json = _json.dumps([
+        {"title": "Sub task", "spec": "do sub", "touches": [],
+         "depends_on": [], "priority": 5, "complexity": "S"},
+    ])
+
+    def plan_agent(task, workspace) -> AgentResult:
+        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json),
+                           stderr="", branch="")
+
+    rt._launch_agent = plan_agent
+    rt.run()
+
+    r = tc.get("/tasks/task-test-01")
+    child = r.json()
+    assert child.get("capabilities_required", []) == []
+
+
+def test_planner_harvest_artifact(tc, tmp_path, http_client):
+    """Plan task harvest artifact contains created_task_ids and dep summary."""
+    _carry_plan(tc, task_id="plan-feat")
+    rt = _make_planner_runtime(tmp_path, http_client)
+
+    plan_json = _json.dumps([
+        {"title": "A", "spec": "do A", "touches": [], "depends_on": [],
+         "priority": 5, "complexity": "S"},
+        {"title": "B", "spec": "do B", "touches": [], "depends_on": [1],
+         "priority": 10, "complexity": "M"},
+    ])
+
+    def plan_agent(task, workspace) -> AgentResult:
+        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json),
+                           stderr="", branch="")
+
+    rt._launch_agent = plan_agent
+    rt.run()
+
+    r = tc.get("/tasks/plan-feat")
+    task = r.json()
+    assert task["status"] == "done"
+
+    # Check the attempt has artifact data
+    attempt = task["attempts"][0]
+    assert attempt["status"] == "done"
+
+
+def test_planner_spawned_by_lineage(tc, tmp_path, http_client):
+    """Child tasks carry spawned_by metadata linking to parent plan task."""
+    _carry_plan(tc, task_id="plan-lineage")
+    rt = _make_planner_runtime(tmp_path, http_client)
+
+    plan_json = _json.dumps([
+        {"title": "Child", "spec": "do child", "touches": [],
+         "depends_on": [], "priority": 5, "complexity": "S"},
+    ])
+
+    def plan_agent(task, workspace) -> AgentResult:
+        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json),
+                           stderr="", branch="")
+
+    rt._launch_agent = plan_agent
+    rt.run()
+
+    r = tc.get("/tasks/task-lineage-01")
+    child = r.json()
+    assert child.get("spawned_by") is not None
+    assert child["spawned_by"]["task_id"] == "plan-lineage"
+
+
+def test_planner_agent_failure_no_harvest(tc, tmp_path, http_client):
+    """Plan agent that exits non-zero does not attempt plan processing."""
+    _carry_plan(tc)
+    rt = _make_planner_runtime(tmp_path, http_client)
+
+    def bad_plan_agent(task, workspace) -> AgentResult:
+        return AgentResult(returncode=1, stdout="", stderr="crash", branch="")
+
+    rt._launch_agent = bad_plan_agent
+    rt.run()
+
+    r = tc.get("/tasks/plan-test")
+    task = r.json()
+    # Task stays active (agent failed, no harvest)
+    assert task["status"] == "active"
+
+
+def test_planner_409_idempotent(tc, tmp_path, http_client):
+    """409 on child carry (already exists) is treated as idempotent success."""
+    # Pre-create a child task that will collide
+    tc.post("/tasks", json={
+        "id": "task-idem-01",
+        "title": "Pre-existing",
+        "spec": "already here",
+    })
+
+    _carry_plan(tc, task_id="plan-idem")
+    rt = _make_planner_runtime(tmp_path, http_client)
+
+    plan_json = _json.dumps([
+        {"title": "Child", "spec": "do child", "touches": [],
+         "depends_on": [], "priority": 5, "complexity": "S"},
+    ])
+
+    def plan_agent(task, workspace) -> AgentResult:
+        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json),
+                           stderr="", branch="")
+
+    rt._launch_agent = plan_agent
+    rt.run()
+
+    # Plan task should still be harvested successfully (409 is idempotent)
+    r = tc.get("/tasks/plan-idem")
+    assert r.json()["status"] == "done"
+
+
+def test_planner_invalid_json_in_tags(tc, tmp_path, http_client):
+    """Invalid JSON inside [PLAN_RESULT] tags fails gracefully."""
+    _carry_plan(tc)
+    rt = _make_planner_runtime(tmp_path, http_client)
+
+    def plan_agent(task, workspace) -> AgentResult:
+        return AgentResult(
+            returncode=0,
+            stdout="[PLAN_RESULT]\nnot valid json\n[/PLAN_RESULT]",
+            stderr="",
+            branch="",
+        )
+
+    rt._launch_agent = plan_agent
+    rt.run()
+
+    r = tc.get("/tasks/plan-test")
+    task = r.json()
+    # Should stay active — parsing failed
+    assert task["status"] == "active"
+
+
+def test_planner_prompt_includes_plan_instructions(tmp_path, http_client):
+    """Plan task prompt includes PLANNER instructions and [PLAN_RESULT] example."""
+    import subprocess
+    from unittest.mock import patch
+
+    rt = _make_planner_runtime(tmp_path, http_client)
+
+    task = {
+        "id": "plan-check",
+        "title": "Plan Check",
+        "spec": "decompose this feature",
+        "current_attempt": "att-001",
+        "capabilities_required": ["plan"],
+    }
+
+    captured_cmd = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+        return MagicMock(returncode=0, stdout="done", stderr="")
+
+    with patch.object(subprocess, "run", side_effect=fake_run):
+        rt._launch_agent(task, str(tmp_path / "ws"))
+
+    # The prompt (last arg) should contain planner-specific content
+    prompt = captured_cmd[-1]
+    assert "PLANNER" in prompt
+    assert "[PLAN_RESULT]" in prompt
+    assert "Maximum 10 tasks" in prompt


### PR DESCRIPTION
WORKFLOW:
1. Read antfarm/core/worker.py — understand _launch_agent() and _process_one_task()
2. Read antfarm/core/planner.py — understand PlannerEngine, parse_structured_plan, validate_plan, resolve_dependencies
3. Read docs/superpowers/plans/2026-04-06-v058-planner-worker.md — section 3 (Worker Planner Mode)
4. Plan your changes
5. Implement
6. Run: python3.12 -m pytest tests/ -x -q --ignore=tests/test_redis_backend.py && ruff check .
7. Commit and push

CHANGES TO antfarm/core/worker.py:

1. 