### PR TITLE
Add planner worker tests — 18 new tests

### DIFF
--- a/antfarm/core/colony_client.py
+++ b/antfarm/core/colony_client.py
@@ -112,6 +112,7 @@ class ColonyClient:
         priority: int = 10,
         complexity: str = "M",
         capabilities_required: list[str] | None = None,
+        spawned_by: dict | None = None,
     ) -> dict:
         """Create a task in the colony."""
         payload: dict = {
@@ -125,6 +126,8 @@ class ColonyClient:
         }
         if capabilities_required:
             payload["capabilities_required"] = capabilities_required
+        if spawned_by:
+            payload["spawned_by"] = spawned_by
         r = self._client.post("/tasks", json=payload)
         r.raise_for_status()
         return r.json()

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -95,6 +95,7 @@ class CarryRequest(BaseModel):
     touches: list[str] = []
     capabilities_required: list[str] = []
     created_by: str = "api"
+    spawned_by: dict | None = None
 
 
 class NodeRequest(BaseModel):
@@ -305,6 +306,8 @@ def get_app(
             "created_at": now,
             "updated_at": now,
         }
+        if req.spawned_by:
+            task["spawned_by"] = req.spawned_by
         try:
             task_id = _backend.carry(task)
         except ValueError as exc:

--- a/antfarm/core/tui.py
+++ b/antfarm/core/tui.py
@@ -25,6 +25,7 @@ from rich.text import Text
 
 @dataclass
 class PipelineSnapshot:
+    planning: list[dict] = field(default_factory=list)
     building: list[dict] = field(default_factory=list)
     waiting_new: list[dict] = field(default_factory=list)
     waiting_rework: list[dict] = field(default_factory=list)
@@ -219,8 +220,13 @@ class AntfarmTUI:
             status = task.get("status", "")
             is_review = task_id.startswith("review-")
 
+            caps_req = set(task.get("capabilities_required", []))
+            is_plan = "plan" in caps_req
+
             if status == "active":
-                if is_review:
+                if is_plan:
+                    snap.planning.append(task)
+                elif is_review:
                     snap.under_review.append(task)
                     snap.review_tasks[task_id] = task
                 else:

--- a/antfarm/core/worker.py
+++ b/antfarm/core/worker.py
@@ -369,6 +369,39 @@ class WorkerRuntime:
             )
             return True
 
+        # Plan task processing — carry children instead of building artifact
+        caps_req = set(task.get("capabilities_required", []))
+        if "plan" in caps_req:
+            plan_result = self._process_plan_output(
+                task, attempt_id, result.stdout + result.stderr
+            )
+            if plan_result:
+                artifact = {
+                    "plan_task_id": task_id,
+                    "created_task_ids": plan_result["created_ids"],
+                    "task_count": len(plan_result["created_ids"]),
+                    "warnings": plan_result["warnings"],
+                    "dependency_summary": plan_result["dep_summary"],
+                }
+                with contextlib.suppress(Exception):
+                    self.colony.harvest(
+                        task_id, attempt_id, pr="", branch="",
+                        artifact=artifact,
+                    )
+                with contextlib.suppress(Exception):
+                    self.colony.trail(
+                        task_id, self.worker_id,
+                        f"plan complete: created {len(plan_result['created_ids'])} tasks",
+                    )
+                return True
+            # Plan parsing failed
+            with contextlib.suppress(Exception):
+                self.colony.trail(
+                    task_id, self.worker_id,
+                    "plan failed: could not parse agent output into tasks",
+                )
+            return True
+
         with contextlib.suppress(Exception):
             self.colony.trail(
                 task_id, self.worker_id, "agent completed, building artifact"
@@ -532,12 +565,41 @@ class WorkerRuntime:
         """
         spec = task.get("spec", "")
         title = task.get("title", "")
+        caps_req = set(task.get("capabilities_required", []))
+        is_plan = "plan" in caps_req
         is_review = task["id"].startswith("review-")
         branch = _extract_branch_from_spec(spec) if is_review else None
         if not branch:
             branch = f"feat/{task['id']}-{task['current_attempt']}"
 
-        if is_review:
+        if is_plan:
+            prompt = (
+                f"Task: {title}\n\n"
+                f"You are a PLANNER. Decompose this spec into implementation tasks.\n\n"
+                f"Spec:\n{spec}\n\n"
+                f"You are working in: {workspace}\n"
+                f"Read the codebase to understand the project structure.\n\n"
+                "Output a JSON array of tasks between [PLAN_RESULT] tags.\n"
+                "Each task object must have:\n"
+                '  - "title": short imperative title\n'
+                '  - "spec": detailed implementation instructions (2-5 sentences)\n'
+                '  - "touches": list of scope tags (e.g. ["api", "auth"])\n'
+                '  - "depends_on": list of task indices (1-based) or []\n'
+                '  - "priority": integer 1-20 (lower = higher priority)\n'
+                '  - "complexity": "S", "M", or "L"\n\n'
+                "Rules:\n"
+                "- Maximum 10 tasks\n"
+                "- Make tasks as parallel as possible\n"
+                "- Use depends_on only when strictly necessary\n"
+                "- Each task should be independently implementable\n\n"
+                "Example output:\n"
+                "[PLAN_RESULT]\n"
+                '[{"title": "Add auth middleware", "spec": "...", '
+                '"touches": ["api"], "depends_on": [], '
+                '"priority": 5, "complexity": "M"}]\n'
+                "[/PLAN_RESULT]\n"
+            )
+        elif is_review:
             prompt = (
                 f"Task: {title}\n\n"
                 f"Spec: {spec}\n\n"
@@ -603,6 +665,133 @@ class WorkerRuntime:
             stderr=proc.stderr,
             branch=branch,
         )
+
+    # ------------------------------------------------------------------
+    # Plan task processing
+    # ------------------------------------------------------------------
+
+    def _process_plan_output(
+        self, task: dict, attempt_id: str, output: str,
+    ) -> dict | None:
+        """Parse plan output, validate, and carry child tasks.
+
+        Returns dict with created_ids, warnings, dep_summary on success.
+        Returns None if parsing or validation fails.
+        """
+        import re
+
+        # Extract JSON from [PLAN_RESULT]...[/PLAN_RESULT] tags
+        match = re.search(
+            r"\[PLAN_RESULT\]\s*(.*?)\s*\[/PLAN_RESULT\]",
+            output, re.DOTALL,
+        )
+        if not match:
+            logger.warning("no [PLAN_RESULT] tags in planner output")
+            return None
+
+        # Parse using shared PlannerEngine logic
+        from antfarm.core.planner import PlannerEngine, resolve_dependencies
+
+        engine = PlannerEngine()
+        plan_result = engine.parse_structured_plan(match.group(1))
+
+        if not plan_result.tasks:
+            logger.warning("plan parse returned no tasks")
+            return None
+
+        # Validate
+        errors = engine.validate_plan(plan_result)
+        if errors:
+            for err in errors:
+                logger.warning("plan validation error: %s", err)
+                with contextlib.suppress(Exception):
+                    self.colony.trail(
+                        task["id"], self.worker_id,
+                        f"plan validation error: {err}",
+                    )
+            return None
+
+        tasks = plan_result.tasks
+
+        # Guardrail: max 10 children
+        if len(tasks) > 10:
+            logger.warning("plan has %d tasks, max 10", len(tasks))
+            with contextlib.suppress(Exception):
+                self.colony.trail(
+                    task["id"], self.worker_id,
+                    f"plan rejected: {len(tasks)} tasks exceeds max 10",
+                )
+            return None
+
+        # Generate deterministic child IDs
+        parent_id = task["id"]
+        slug = parent_id.removeprefix("plan-")
+        child_ids = [f"task-{slug}-{i:02d}" for i in range(1, len(tasks) + 1)]
+
+        # Resolve index-based deps to child IDs
+        resolved_tasks = resolve_dependencies(tasks, child_ids)
+
+        # Generate warnings
+        warnings = engine.generate_warnings(plan_result)
+        warn_strs = [str(w) for w in warnings] if isinstance(warnings, list) else []
+
+        # Carry each child task
+        created_ids: list[str] = []
+        failed_ids: list[str] = []
+        for i, proposed_task in enumerate(resolved_tasks):
+            child_id = child_ids[i]
+            try:
+                self.colony.carry(
+                    task_id=child_id,
+                    title=proposed_task.title,
+                    spec=proposed_task.spec,
+                    depends_on=proposed_task.depends_on,
+                    touches=proposed_task.touches,
+                    priority=proposed_task.priority,
+                    complexity=proposed_task.complexity,
+                    capabilities_required=[],  # no recursive plans
+                    spawned_by={
+                        "task_id": parent_id,
+                        "attempt_id": attempt_id,
+                    },
+                )
+                created_ids.append(child_id)
+                logger.info("carried child task %s", child_id)
+            except Exception as exc:
+                # 409 = already exists (idempotent retry)
+                if "409" in str(exc) or "already exists" in str(exc):
+                    created_ids.append(child_id)
+                    logger.info("child task %s already exists (idempotent)", child_id)
+                else:
+                    logger.warning("failed to carry child %s: %s", child_id, exc)
+                    failed_ids.append(child_id)
+
+        # Partial failure: abort harvest
+        if failed_ids:
+            logger.warning(
+                "plan partial failure: %d/%d tasks failed",
+                len(failed_ids), len(tasks),
+            )
+            with contextlib.suppress(Exception):
+                self.colony.trail(
+                    task["id"], self.worker_id,
+                    f"plan partial failure: {len(created_ids)} created, "
+                    f"{len(failed_ids)} failed: {', '.join(failed_ids)}",
+                )
+            return None
+
+        # Build dependency summary
+        dep_pairs: list[str] = []
+        for i, t in enumerate(resolved_tasks):
+            for dep in t.depends_on:
+                dep_pairs.append(f"{dep} -> {child_ids[i]}")
+        dep_summary = ", ".join(dep_pairs) if dep_pairs else "all parallel"
+
+        return {
+            "created_ids": created_ids,
+            "warnings": warn_strs,
+            "dep_summary": dep_summary,
+        }
 
     # ------------------------------------------------------------------
     # Heartbeat thread

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -592,6 +592,89 @@ def test_worker_start_explicit_name_overrides():
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# v0.5.8: carry --type plan and worker start --type planner
+# ---------------------------------------------------------------------------
+
+
+def test_carry_type_plan_adds_prefix():
+    """carry --type plan --id auth -> task ID is 'plan-auth'."""
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"task_id": "plan-auth"}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "carry",
+                "--title", "Plan auth",
+                "--spec", "Build auth",
+                "--type", "plan",
+                "--id", "auth",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]
+    assert payload["id"] == "plan-auth"
+
+
+def test_carry_type_plan_adds_capability():
+    """carry --type plan -> capabilities_required includes 'plan'."""
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"task_id": "plan-xxx"}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "carry",
+                "--title", "Plan something",
+                "--spec", "Do planning",
+                "--type", "plan",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]
+    assert "plan" in payload.get("capabilities_required", [])
+
+
+def test_worker_start_type_planner_adds_capability():
+    """worker start --type planner -> capabilities includes 'plan'."""
+    runner = CliRunner()
+    captured_kwargs = {}
+
+    def fake_worker_runtime(**kwargs):
+        captured_kwargs.update(kwargs)
+        return MagicMock()
+
+    with patch("antfarm.core.worker.WorkerRuntime", side_effect=fake_worker_runtime):
+        result = runner.invoke(
+            main,
+            [
+                "worker", "start",
+                "--agent", "claude-code",
+                "--type", "planner",
+                "--node", "n1",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "plan" in captured_kwargs.get("capabilities", [])
+
+
 def test_plan_carry_resolves_index_deps():
     """plan --carry resolves 1-based index deps to generated task IDs."""
     runner = CliRunner()

--- a/tests/test_planner_worker_e2e.py
+++ b/tests/test_planner_worker_e2e.py
@@ -1,0 +1,167 @@
+"""End-to-end test for the planner worker flow.
+
+Proves: carry plan task -> planner worker decomposes -> child tasks appear
+in queue with deterministic IDs, resolved deps, spawned_by lineage,
+and plan task is harvested with artifact listing created IDs.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from antfarm.core.backends.file import FileBackend
+from antfarm.core.serve import get_app
+from antfarm.core.worker import AgentResult, WorkerRuntime
+
+# ---------------------------------------------------------------------------
+# Sync httpx transport (same pattern as test_worker.py)
+# ---------------------------------------------------------------------------
+
+
+class _StarletteTransport(httpx.BaseTransport):
+    def __init__(self, app):
+        self._tc = TestClient(app, raise_server_exceptions=True)
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        resp = self._tc.request(
+            request.method,
+            str(request.url.path),
+            content=request.content,
+            headers=dict(request.headers),
+            params=dict(request.url.params),
+        )
+        return httpx.Response(
+            resp.status_code,
+            headers=dict(resp.headers),
+            content=resp.content,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def backend(tmp_path):
+    return FileBackend(root=str(tmp_path / ".antfarm"))
+
+
+@pytest.fixture
+def app(backend):
+    return get_app(backend=backend)
+
+
+@pytest.fixture
+def http_client(app):
+    transport = _StarletteTransport(app)
+    client = httpx.Client(transport=transport, base_url="http://test")
+    yield client
+    client.close()
+
+
+@pytest.fixture
+def tc(app):
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# E2E test
+# ---------------------------------------------------------------------------
+
+
+def test_e2e_plan_to_build_flow(tc, tmp_path, http_client):
+    """Full planner flow: carry plan -> planner decomposes -> children in queue."""
+    # 1. Carry a plan task
+    r = tc.post("/tasks", json={
+        "id": "plan-auth",
+        "title": "Plan auth system",
+        "spec": "Build a complete authentication system with login, signup, and tokens",
+        "capabilities_required": ["plan"],
+    })
+    assert r.status_code == 201
+
+    # 2. Create planner worker runtime
+    rt = WorkerRuntime(
+        colony_url="http://test",
+        node_id="node-1",
+        name="planner-1",
+        agent_type="generic",
+        workspace_root=str(tmp_path / "workspaces"),
+        repo_path=str(tmp_path),
+        integration_branch="main",
+        heartbeat_interval=999.0,
+        capabilities=["plan"],
+        client=http_client,
+    )
+    rt.workspace_mgr.create = MagicMock(return_value=str(tmp_path / "ws"))
+
+    # 3. Simulate agent output with 3 tasks, task 3 depends on task 1
+    plan_tasks = [
+        {
+            "title": "Add login endpoint",
+            "spec": "Implement POST /login with JWT",
+            "touches": ["api", "auth"],
+            "depends_on": [],
+            "priority": 5,
+            "complexity": "M",
+        },
+        {
+            "title": "Add signup endpoint",
+            "spec": "Implement POST /signup with validation",
+            "touches": ["api", "auth"],
+            "depends_on": [],
+            "priority": 5,
+            "complexity": "M",
+        },
+        {
+            "title": "Add token refresh",
+            "spec": "Implement POST /refresh using existing login",
+            "touches": ["api"],
+            "depends_on": [1],  # depends on login endpoint
+            "priority": 10,
+            "complexity": "S",
+        },
+    ]
+    plan_output = f"[PLAN_RESULT]\n{json.dumps(plan_tasks)}\n[/PLAN_RESULT]"
+
+    def planner_agent(task, workspace) -> AgentResult:
+        return AgentResult(returncode=0, stdout=plan_output, stderr="", branch="")
+
+    rt._launch_agent = planner_agent
+    rt.run()
+
+    # 4. Verify child tasks were created with deterministic IDs
+    r = tc.get("/tasks")
+    all_tasks = {t["id"]: t for t in r.json()}
+
+    assert "task-auth-01" in all_tasks
+    assert "task-auth-02" in all_tasks
+    assert "task-auth-03" in all_tasks
+
+    # 5. Verify dependency resolution: task-auth-03 depends on task-auth-01
+    assert "task-auth-01" in all_tasks["task-auth-03"]["depends_on"]
+
+    # 6. Verify spawned_by lineage
+    child_01 = all_tasks["task-auth-01"]
+    assert child_01.get("spawned_by", {}).get("task_id") == "plan-auth"
+    assert child_01["spawned_by"]["attempt_id"] is not None
+
+    # 7. Verify no recursive plans (capabilities_required empty)
+    assert child_01["capabilities_required"] == []
+    assert all_tasks["task-auth-02"]["capabilities_required"] == []
+    assert all_tasks["task-auth-03"]["capabilities_required"] == []
+
+    # 8. Verify plan task was harvested
+    plan_task = all_tasks["plan-auth"]
+    assert plan_task["status"] == "done"
+
+    # 9. Verify child tasks are ready for builders
+    assert all_tasks["task-auth-01"]["status"] == "ready"
+    assert all_tasks["task-auth-02"]["status"] == "ready"
+    assert all_tasks["task-auth-03"]["status"] == "ready"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -225,3 +225,32 @@ def test_pin_filter_skipped_when_worker_id_none():
         worker_id=None,
     )
     assert result is t
+
+
+# ---------------------------------------------------------------------------
+# v0.5.8: Planner worker routing
+# ---------------------------------------------------------------------------
+
+
+def test_planner_worker_only_forages_plan_tasks():
+    """Worker with capabilities=["plan"] does NOT forage regular tasks."""
+    regular = make_task("t1", capabilities_required=[])
+    result = select_task(
+        [regular],
+        done_task_ids=set(),
+        active_tasks=[],
+        worker_capabilities={"plan"},
+    )
+    assert result is None
+
+
+def test_planner_worker_forages_plan_task():
+    """Worker with capabilities=["plan"] forages plan tasks."""
+    plan_task = make_task("plan-auth", capabilities_required=["plan"])
+    result = select_task(
+        [plan_task],
+        done_task_ids=set(),
+        active_tasks=[],
+        worker_capabilities={"plan"},
+    )
+    assert result is plan_task

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -136,6 +136,20 @@ def test_classify_recently_merged():
     assert len(snap.recently_merged) == 1
 
 
+def test_classify_tasks_planning():
+    """Plan task in active -> planning list, not building."""
+    tui = _make_tui()
+    tasks = [_task(task_id="plan-auth", status="active",
+                   current_attempt="att-001",
+                   attempts=[_attempt()])]
+    # Add capabilities_required to the task dict
+    tasks[0]["capabilities_required"] = ["plan"]
+    snap = tui._classify_tasks(tasks)
+    assert len(snap.planning) == 1
+    assert snap.planning[0]["id"] == "plan-auth"
+    assert len(snap.building) == 0
+
+
 def test_classify_review_task_not_in_building():
     """A review task that is active should be in under_review, not building."""
     tui = _make_tui()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -731,3 +731,353 @@ def test_build_artifact_handles_git_failure(tmp_path, http_client):
     assert artifact["lines_removed"] == 0
     assert artifact["head_sha"] == ""
     assert artifact["base_sha"] == ""
+
+
+# ---------------------------------------------------------------------------
+# v0.5.8: Planner worker mode
+# ---------------------------------------------------------------------------
+
+
+def _carry_plan(tc, task_id="plan-auth", title="Plan auth", spec="Build auth system"):
+    """Carry a plan task with capabilities_required=["plan"]."""
+    r = tc.post("/tasks", json={
+        "id": task_id,
+        "title": title,
+        "spec": spec,
+        "capabilities_required": ["plan"],
+    })
+    assert r.status_code == 201
+    return r.json()
+
+
+def _plan_output(tasks_json: str) -> str:
+    """Wrap tasks JSON in [PLAN_RESULT] tags."""
+    return f"[PLAN_RESULT]\n{tasks_json}\n[/PLAN_RESULT]"
+
+
+def _valid_plan_json(count: int = 3) -> str:
+    """Generate valid plan JSON with count tasks."""
+    import json
+    tasks = []
+    for i in range(count):
+        tasks.append({
+            "title": f"Task {i + 1}",
+            "spec": f"Implement feature {i + 1}",
+            "touches": [f"module-{i + 1}"],
+            "depends_on": [],
+            "priority": 10,
+            "complexity": "M",
+        })
+    return json.dumps(tasks)
+
+
+def test_planner_prompt_includes_plan_instructions(tmp_path, http_client):
+    """Plan task gets planning-specific prompt with [PLAN_RESULT] tags."""
+    import subprocess
+    from unittest.mock import patch
+
+    rt = WorkerRuntime(
+        colony_url="http://test",
+        node_id="node-1",
+        name="planner-1",
+        agent_type="claude-code",
+        workspace_root=str(tmp_path / "workspaces"),
+        repo_path=str(tmp_path),
+        capabilities=["plan"],
+        client=http_client,
+    )
+
+    task = {
+        "id": "plan-auth",
+        "title": "Plan auth system",
+        "spec": "Build an auth system",
+        "current_attempt": "att-001",
+        "capabilities_required": ["plan"],
+    }
+
+    captured_cmd = []
+
+    def fake_run(cmd, **kwargs):
+        captured_cmd.extend(cmd)
+        return MagicMock(returncode=0, stdout="done", stderr="")
+
+    with patch.object(subprocess, "run", side_effect=fake_run):
+        rt._launch_agent(task, str(tmp_path / "ws"))
+
+    # The prompt (last arg to claude) should include plan instructions
+    prompt = captured_cmd[-1]
+    assert "[PLAN_RESULT]" in prompt
+    assert "PLANNER" in prompt
+    assert "Maximum 10 tasks" in prompt
+
+
+def test_process_plan_output_valid(tc, runtime):
+    """Valid JSON with 3 tasks -> 3 child tasks carried with deterministic IDs."""
+    _carry_plan(tc, task_id="plan-auth")
+
+    plan_json = _valid_plan_json(3)
+    plan_stdout = _plan_output(plan_json)
+
+    def planner_agent(task, workspace) -> AgentResult:
+        return AgentResult(returncode=0, stdout=plan_stdout, stderr="", branch="")
+
+    runtime._launch_agent = planner_agent
+    runtime._build_artifact = lambda *a, **kw: {}
+    runtime._create_pr = lambda *a, **kw: ""
+    runtime.capabilities = ["plan"]
+    runtime.run()
+
+    # Verify 3 child tasks were created
+    r = tc.get("/tasks")
+    tasks = r.json()
+    child_ids = [t["id"] for t in tasks if t["id"].startswith("task-auth-")]
+    assert len(child_ids) == 3
+    assert "task-auth-01" in child_ids
+    assert "task-auth-02" in child_ids
+    assert "task-auth-03" in child_ids
+
+
+def test_process_plan_output_invalid_json(tc, runtime):
+    """Malformed JSON -> returns None."""
+    _carry_plan(tc, task_id="plan-bad-json")
+
+    plan_stdout = _plan_output("not valid json {{{")
+
+    def planner_agent(task, workspace) -> AgentResult:
+        return AgentResult(returncode=0, stdout=plan_stdout, stderr="", branch="")
+
+    runtime._launch_agent = planner_agent
+    runtime.capabilities = ["plan"]
+    runtime.run()
+
+    # No child tasks should be created
+    r2 = tc.get("/tasks")
+    all_tasks = r2.json()
+    child_tasks = [t for t in all_tasks if t["id"] != "plan-bad-json"]
+    assert len(child_tasks) == 0
+
+
+def test_process_plan_output_no_tags(tc, runtime):
+    """Output without [PLAN_RESULT] tags -> returns None."""
+    _carry_plan(tc, task_id="plan-no-tags")
+
+    def planner_agent(task, workspace) -> AgentResult:
+        return AgentResult(
+            returncode=0,
+            stdout='Just some text with no tags [{"title":"a","spec":"b"}]',
+            stderr="",
+            branch="",
+        )
+
+    runtime._launch_agent = planner_agent
+    runtime.capabilities = ["plan"]
+    runtime.run()
+
+    # No child tasks created
+    r = tc.get("/tasks")
+    all_tasks = r.json()
+    child_tasks = [t for t in all_tasks if t["id"] != "plan-no-tags"]
+    assert len(child_tasks) == 0
+
+
+def test_process_plan_output_max_children(tc, runtime):
+    """15 tasks -> rejected (max 10), trail entry logged."""
+    _carry_plan(tc, task_id="plan-too-many")
+
+    plan_json = _valid_plan_json(15)
+    plan_stdout = _plan_output(plan_json)
+
+    def planner_agent(task, workspace) -> AgentResult:
+        return AgentResult(returncode=0, stdout=plan_stdout, stderr="", branch="")
+
+    runtime._launch_agent = planner_agent
+    runtime.capabilities = ["plan"]
+    runtime.run()
+
+    # No child tasks created
+    r = tc.get("/tasks")
+    all_tasks = r.json()
+    child_tasks = [t for t in all_tasks if t["id"] != "plan-too-many"]
+    assert len(child_tasks) == 0
+
+    # Trail should mention rejection
+    r2 = tc.get("/tasks/plan-too-many")
+    task = r2.json()
+    messages = [e["message"] for e in task.get("trail", [])]
+    assert any("exceeds max 10" in m for m in messages)
+
+
+def test_process_plan_output_deterministic_ids(tc, runtime):
+    """Parent plan-auth -> children task-auth-01, task-auth-02."""
+    _carry_plan(tc, task_id="plan-auth")
+
+    import json
+    tasks = [
+        {"title": "Add login", "spec": "Login endpoint", "touches": ["api"],
+         "depends_on": [], "priority": 5, "complexity": "S"},
+        {"title": "Add signup", "spec": "Signup endpoint", "touches": ["api"],
+         "depends_on": [], "priority": 5, "complexity": "S"},
+    ]
+    plan_stdout = _plan_output(json.dumps(tasks))
+
+    def planner_agent(task, workspace) -> AgentResult:
+        return AgentResult(returncode=0, stdout=plan_stdout, stderr="", branch="")
+
+    runtime._launch_agent = planner_agent
+    runtime.capabilities = ["plan"]
+    runtime.run()
+
+    r = tc.get("/tasks")
+    all_tasks = r.json()
+    child_ids = sorted([t["id"] for t in all_tasks if t["id"].startswith("task-auth-")])
+    assert child_ids == ["task-auth-01", "task-auth-02"]
+
+
+def test_process_plan_output_idempotent_retry(tc, runtime):
+    """409 on carry is handled (idempotent retry) — no duplicates."""
+    _carry_plan(tc, task_id="plan-retry")
+
+    import json
+    tasks = [
+        {"title": "Task A", "spec": "Do A", "touches": [], "depends_on": [],
+         "priority": 10, "complexity": "M"},
+    ]
+    plan_stdout = _plan_output(json.dumps(tasks))
+
+    call_count = [0]
+
+    def planner_agent(task, workspace) -> AgentResult:
+        call_count[0] += 1
+        return AgentResult(returncode=0, stdout=plan_stdout, stderr="", branch="")
+
+    runtime._launch_agent = planner_agent
+    runtime.capabilities = ["plan"]
+
+    # Pre-create the child task to simulate a retry scenario
+    tc.post("/tasks", json={
+        "id": "task-retry-01",
+        "title": "Task A",
+        "spec": "Do A",
+    })
+
+    # Run planner — carry will get 409 for task-retry-01, should handle gracefully
+    runtime.run()
+
+    # Should still have exactly 1 child task (no duplicate)
+    r = tc.get("/tasks")
+    all_tasks = r.json()
+    child_tasks = [t for t in all_tasks if t["id"] == "task-retry-01"]
+    assert len(child_tasks) == 1
+
+
+def test_process_plan_output_partial_failure_aborts(tc, runtime):
+    """Non-409 carry failure -> returns None, task stays active."""
+    _carry_plan(tc, task_id="plan-partial")
+
+    import json
+    tasks = [
+        {"title": "Task A", "spec": "Do A", "touches": [], "depends_on": [],
+         "priority": 10, "complexity": "M"},
+        {"title": "Task B", "spec": "Do B", "touches": [], "depends_on": [],
+         "priority": 10, "complexity": "M"},
+    ]
+    plan_stdout = _plan_output(json.dumps(tasks))
+
+    def planner_agent(task, workspace) -> AgentResult:
+        return AgentResult(returncode=0, stdout=plan_stdout, stderr="", branch="")
+
+    runtime._launch_agent = planner_agent
+    runtime.capabilities = ["plan"]
+
+    # Patch colony.carry to fail on second call with a non-409 error
+    original_carry = runtime.colony.carry
+    carry_count = [0]
+
+    def failing_carry(*args, **kwargs):
+        carry_count[0] += 1
+        if carry_count[0] == 2:
+            raise RuntimeError("server error")
+        return original_carry(*args, **kwargs)
+
+    runtime.colony.carry = failing_carry
+    runtime.run()
+
+    # Plan task should NOT be harvested (no artifact recorded)
+    r = tc.get("/tasks/plan-partial")
+    task = r.json()
+    # Trail should mention partial failure
+    messages = [e["message"] for e in task.get("trail", [])]
+    assert any("partial failure" in m for m in messages)
+
+
+def test_process_plan_output_no_recursive_plans(tc, runtime):
+    """Child tasks have capabilities_required=[] (no plan capability)."""
+    _carry_plan(tc, task_id="plan-norecurse")
+
+    import json
+    tasks = [
+        {"title": "Task A", "spec": "Do A", "touches": [], "depends_on": [],
+         "priority": 10, "complexity": "M"},
+    ]
+    plan_stdout = _plan_output(json.dumps(tasks))
+
+    def planner_agent(task, workspace) -> AgentResult:
+        return AgentResult(returncode=0, stdout=plan_stdout, stderr="", branch="")
+
+    runtime._launch_agent = planner_agent
+    runtime.capabilities = ["plan"]
+    runtime.run()
+
+    r = tc.get("/tasks/task-norecurse-01")
+    child = r.json()
+    assert child["capabilities_required"] == []
+
+
+def test_process_plan_output_lineage(tc, runtime):
+    """Child tasks have spawned_by field with parent task_id + attempt_id."""
+    _carry_plan(tc, task_id="plan-lineage")
+
+    import json
+    tasks = [
+        {"title": "Task A", "spec": "Do A", "touches": [], "depends_on": [],
+         "priority": 10, "complexity": "M"},
+    ]
+    plan_stdout = _plan_output(json.dumps(tasks))
+
+    def planner_agent(task, workspace) -> AgentResult:
+        return AgentResult(returncode=0, stdout=plan_stdout, stderr="", branch="")
+
+    runtime._launch_agent = planner_agent
+    runtime.capabilities = ["plan"]
+    runtime.run()
+
+    r = tc.get("/tasks/task-lineage-01")
+    child = r.json()
+    assert "spawned_by" in child
+    assert child["spawned_by"]["task_id"] == "plan-lineage"
+    assert child["spawned_by"]["attempt_id"] is not None
+
+
+def test_process_plan_output_dep_resolution(tc, runtime):
+    """Task 2 depends on [1] -> resolved to task-deptest-01."""
+    _carry_plan(tc, task_id="plan-deptest")
+
+    import json
+    tasks = [
+        {"title": "Task A", "spec": "Do A", "touches": ["api"], "depends_on": [],
+         "priority": 5, "complexity": "S"},
+        {"title": "Task B", "spec": "Do B", "touches": ["db"], "depends_on": [1],
+         "priority": 10, "complexity": "M"},
+    ]
+    plan_stdout = _plan_output(json.dumps(tasks))
+
+    def planner_agent(task, workspace) -> AgentResult:
+        return AgentResult(returncode=0, stdout=plan_stdout, stderr="", branch="")
+
+    runtime._launch_agent = planner_agent
+    runtime.capabilities = ["plan"]
+    runtime.run()
+
+    r = tc.get("/tasks/task-deptest-02")
+    child_b = r.json()
+    assert "task-deptest-01" in child_b["depends_on"]


### PR DESCRIPTION
WORKFLOW:
1. Read ALL changed files from the 5 preceding tasks
2. Read docs/superpowers/plans/2026-04-06-v058-planner-worker.md — section 7 (Tests)
3. Plan test cases
4. Implement
5. Run: python3.12 -m pytest tests/ -x -q --ignore=tests/test_redis_backend.py && ruff check .
6. Commit and push

ADD THESE TESTS:

tests/test_worker.py:
- test_planner_prompt_includes_plan_instructions
- test_process_plan_output_valid (3 tasks carried with deterministic IDs)
- test_process_plan_output_invalid_json (r