### PR TITLE
feat(backend): enforce max-attempt limit on kickback

### DIFF
--- a/antfarm/core/backends/base.py
+++ b/antfarm/core/backends/base.py
@@ -87,15 +87,20 @@ class TaskBackend(ABC):
         ...
 
     @abstractmethod
-    def kickback(self, task_id: str, reason: str) -> None:
+    def kickback(self, task_id: str, reason: str, max_attempts: int = 3) -> None:
         """Transition task to READY, current attempt to SUPERSEDED.
 
         Sets current_attempt to None. Next pull() creates a fresh attempt.
         Adds a failure TrailEntry with the reason.
 
+        If the number of completed/superseded attempts >= max_attempts,
+        the task transitions to BLOCKED instead of READY.
+        Per-task max_attempts field overrides the default.
+
         Args:
             task_id: ID of the task.
             reason: Human-readable reason for the kickback.
+            max_attempts: Maximum number of attempts before blocking (default 3).
         """
         ...
 

--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -342,12 +342,16 @@ class FileBackend(TaskBackend):
             self._write_json(active_path, data)
             os.rename(active_path, done_path)
 
-    def kickback(self, task_id: str, reason: str) -> None:
-        """Move task from done/ to ready/. SUPERSEDE current attempt.
+    def kickback(self, task_id: str, reason: str, max_attempts: int = 3) -> None:
+        """Move task from done/ to ready/, or to blocked/ if max attempts reached.
 
         Soldier calls kickback after a failed integration merge. The task
         is in done/ at that point (harvested but not yet merged).
         Sets current_attempt to None. Adds failure TrailEntry.
+
+        If the number of completed/superseded attempts >= max_attempts,
+        the task transitions to BLOCKED instead of READY.
+        Per-task max_attempts field overrides the default.
         """
         with self._lock:
             done_path = self._done_path(task_id)
@@ -355,7 +359,6 @@ class FileBackend(TaskBackend):
                 raise FileNotFoundError(f"Task '{task_id}' not found in done/")
 
             data = self._read_json(done_path)
-            assert_task_transition(data["status"], TaskStatus.READY.value)
             now = _now_iso()
 
             current_attempt_id = data.get("current_attempt")
@@ -367,19 +370,45 @@ class FileBackend(TaskBackend):
                     worker_id = a.get("worker_id") or "system"
                     break
 
-            # Add failure trail entry
-            trail_entry = TrailEntry(
-                ts=now, worker_id=worker_id, message=reason, action_type="kickback"
-            )
-            data.setdefault("trail", [])
-            data["trail"].append(trail_entry.to_dict())
-
-            data["status"] = TaskStatus.READY.value
             data["current_attempt"] = None
             data["updated_at"] = now
 
-            self._write_json(done_path, data)
-            os.rename(done_path, self._ready_path(task_id))
+            # Count completed/superseded attempts
+            attempt_count = len([
+                a for a in data["attempts"]
+                if a["status"] in (AttemptStatus.DONE.value, AttemptStatus.SUPERSEDED.value)
+            ])
+
+            # Per-task max_attempts overrides the default
+            effective_max = data.get("max_attempts") or max_attempts
+
+            if attempt_count >= effective_max:
+                # Transition to BLOCKED
+                block_reason = (
+                    f"Max attempts ({effective_max}) reached: {reason}"
+                )
+                assert_task_transition(data["status"], TaskStatus.BLOCKED.value)
+                trail_entry = TrailEntry(
+                    ts=now, worker_id=worker_id,
+                    message=block_reason, action_type="block",
+                )
+                data.setdefault("trail", [])
+                data["trail"].append(trail_entry.to_dict())
+                data["status"] = TaskStatus.BLOCKED.value
+                self._write_json(done_path, data)
+                os.rename(done_path, self._blocked_path(task_id))
+            else:
+                # Normal kickback to READY
+                assert_task_transition(data["status"], TaskStatus.READY.value)
+                trail_entry = TrailEntry(
+                    ts=now, worker_id=worker_id,
+                    message=reason, action_type="kickback",
+                )
+                data.setdefault("trail", [])
+                data["trail"].append(trail_entry.to_dict())
+                data["status"] = TaskStatus.READY.value
+                self._write_json(done_path, data)
+                os.rename(done_path, self._ready_path(task_id))
 
     def mark_harvest_pending(self, task_id: str, attempt_id: str) -> None:
         """Transition task from ACTIVE to HARVEST_PENDING.

--- a/antfarm/core/colony_client.py
+++ b/antfarm/core/colony_client.py
@@ -150,8 +150,13 @@ class ColonyClient:
         r = self._client.post(f"/tasks/{task_id}/harvest", json=payload)
         r.raise_for_status()
 
-    def kickback(self, task_id: str, reason: str) -> None:
-        r = self._client.post(f"/tasks/{task_id}/kickback", json={"reason": reason})
+    def kickback(
+        self, task_id: str, reason: str, max_attempts: int | None = None
+    ) -> None:
+        payload: dict = {"reason": reason}
+        if max_attempts is not None:
+            payload["max_attempts"] = max_attempts
+        r = self._client.post(f"/tasks/{task_id}/kickback", json=payload)
         r.raise_for_status()
 
     def mark_harvest_pending(self, task_id: str, attempt_id: str) -> None:

--- a/antfarm/core/lifecycle.py
+++ b/antfarm/core/lifecycle.py
@@ -50,7 +50,7 @@ LEGAL_TASK_TRANSITIONS: dict[str, set[str]] = {
     "claimed": {"active"},
     "active": {"harvest_pending", "paused"},
     "harvest_pending": {"done", "failed"},
-    "done": {"merge_ready", "kicked_back", "queued"},  # "queued" = legacy kickback (done→ready)
+    "done": {"merge_ready", "kicked_back", "queued", "blocked"},  # +blocked for max-attempt
     "kicked_back": {"queued"},
     "merge_ready": {"merged"},
     "merged": set(),  # terminal

--- a/antfarm/core/models.py
+++ b/antfarm/core/models.py
@@ -410,6 +410,7 @@ class Task:
     capabilities_required: list[str] = field(default_factory=list)
     pinned_to: str | None = None
     merge_override: int | None = None
+    max_attempts: int | None = None
     status: TaskStatus = TaskStatus.READY
     current_attempt: str | None = None
     attempts: list[Attempt] = field(default_factory=list)
@@ -428,6 +429,7 @@ class Task:
             "capabilities_required": list(self.capabilities_required),
             "pinned_to": self.pinned_to,
             "merge_override": self.merge_override,
+            "max_attempts": self.max_attempts,
             "status": self.status.value,
             "current_attempt": self.current_attempt,
             "attempts": [a.to_dict() for a in self.attempts],
@@ -451,6 +453,7 @@ class Task:
             capabilities_required=list(data.get("capabilities_required", [])),
             pinned_to=data.get("pinned_to"),
             merge_override=data.get("merge_override"),
+            max_attempts=data.get("max_attempts"),
             status=TaskStatus(data.get("status", TaskStatus.READY)),
             current_attempt=data.get("current_attempt"),
             attempts=[Attempt.from_dict(a) for a in data.get("attempts", [])],

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import collections
 import json
+import os
 import threading
 import time
 from datetime import UTC, datetime
@@ -144,6 +145,7 @@ class HarvestRequest(BaseModel):
 
 class KickbackRequest(BaseModel):
     reason: str
+    max_attempts: int | None = None  # None = use colony default
 
 
 class ReviewVerdictRequest(BaseModel):
@@ -208,6 +210,14 @@ def get_app(
         from antfarm.core.backends.file import FileBackend
 
         _backend = FileBackend(root=data_dir)
+
+    # Load colony config for max_attempts default
+    _max_attempts = 3
+    config_path = os.path.join(data_dir, "config.json")
+    if os.path.exists(config_path):
+        with open(config_path) as f:
+            colony_config = json.load(f)
+        _max_attempts = colony_config.get("max_attempts", 3)
 
     app = FastAPI(title="Antfarm Colony")
 
@@ -394,8 +404,11 @@ def get_app(
     @app.post("/tasks/{task_id}/kickback", status_code=200)
     def kickback_task(task_id: str, req: KickbackRequest):
         """Return a task to ready state with the given reason."""
+        effective_max = (
+            req.max_attempts if req.max_attempts is not None else _max_attempts
+        )
         try:
-            _backend.kickback(task_id, req.reason)
+            _backend.kickback(task_id, req.reason, max_attempts=effective_max)
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         _emit_event("kickback", task_id, req.reason)

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -804,8 +804,8 @@ class _BackendAdapter:
     def mark_merged(self, task_id: str, attempt_id: str) -> None:
         self._backend.mark_merged(task_id, attempt_id)
 
-    def kickback(self, task_id: str, reason: str) -> None:
-        self._backend.kickback(task_id, reason)
+    def kickback(self, task_id: str, reason: str, max_attempts: int = 3) -> None:
+        self._backend.kickback(task_id, reason, max_attempts=max_attempts)
 
     def store_review_verdict(
         self, task_id: str, attempt_id: str, verdict: dict

--- a/tests/test_file_backend.py
+++ b/tests/test_file_backend.py
@@ -863,3 +863,110 @@ def test_harvest_without_artifact_backward_compat(backend: FileBackend) -> None:
             assert "artifact" not in a
             break
 
+
+# ---------------------------------------------------------------------------
+# Max-attempt enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_kickback_blocks_after_max_attempts(backend: FileBackend, tmp_path: Path) -> None:
+    """Task transitions to blocked after max_attempts kickbacks."""
+    backend.carry(_make_task("task-max"))
+
+    for i in range(3):
+        pulled = backend.pull("worker-1")
+        assert pulled is not None
+        attempt_id = pulled["current_attempt"]
+        backend.mark_harvested("task-max", attempt_id, pr=f"pr/{i}", branch=f"feat/{i}")
+        backend.kickback("task-max", reason=f"failure {i}", max_attempts=3)
+
+    # After 3 kickbacks, task should be blocked, not ready
+    blocked_file = tmp_path / ".antfarm" / "tasks" / "blocked" / "task-max.json"
+    ready_file = tmp_path / ".antfarm" / "tasks" / "ready" / "task-max.json"
+    assert blocked_file.exists()
+    assert not ready_file.exists()
+
+    data = json.loads(blocked_file.read_text())
+    assert data["status"] == TaskStatus.BLOCKED.value
+    assert "max attempts" in data["trail"][-1]["message"].lower()
+
+
+def test_blocked_task_not_forageable(backend: FileBackend) -> None:
+    """A blocked task should not be returned by pull()."""
+    backend.carry(_make_task("task-blk"))
+
+    # Pull, harvest, kickback to blocked
+    for i in range(3):
+        pulled = backend.pull("worker-1")
+        assert pulled is not None
+        attempt_id = pulled["current_attempt"]
+        backend.mark_harvested("task-blk", attempt_id, pr=f"pr/{i}", branch=f"feat/{i}")
+        backend.kickback("task-blk", reason=f"failure {i}", max_attempts=3)
+
+    # Now try to pull — should return None (only task is blocked)
+    result = backend.pull("worker-1")
+    assert result is None
+
+
+def test_kickback_under_max_attempts_goes_to_ready(
+    backend: FileBackend, tmp_path: Path
+) -> None:
+    """Kickback before max_attempts still transitions to ready."""
+    backend.carry(_make_task("task-ok"))
+    pulled = backend.pull("worker-1")
+    attempt_id = pulled["current_attempt"]
+    backend.mark_harvested("task-ok", attempt_id, pr="pr/1", branch="feat/1")
+    backend.kickback("task-ok", reason="failure 1", max_attempts=3)
+
+    ready_file = tmp_path / ".antfarm" / "tasks" / "ready" / "task-ok.json"
+    assert ready_file.exists()
+
+
+def test_per_task_max_attempts_override(
+    backend: FileBackend, tmp_path: Path
+) -> None:
+    """Task-level max_attempts overrides the default."""
+    task = _make_task("task-override")
+    task["max_attempts"] = 1
+    backend.carry(task)
+
+    pulled = backend.pull("worker-1")
+    attempt_id = pulled["current_attempt"]
+    backend.mark_harvested("task-override", attempt_id, pr="pr/1", branch="feat/1")
+    backend.kickback("task-override", reason="failure 1", max_attempts=5)
+
+    # Task had max_attempts=1, should be blocked after 1 kickback
+    blocked_file = tmp_path / ".antfarm" / "tasks" / "blocked" / "task-override.json"
+    assert blocked_file.exists()
+
+
+def test_unblock_does_not_reset_attempt_counter(
+    backend: FileBackend, tmp_path: Path
+) -> None:
+    """Unblocking a task that hit max_attempts will block again on next kickback."""
+    backend.carry(_make_task("task-unblk"))
+
+    # Exhaust max_attempts (3 kickbacks -> blocked)
+    for i in range(3):
+        pulled = backend.pull("worker-1")
+        assert pulled is not None
+        attempt_id = pulled["current_attempt"]
+        backend.mark_harvested("task-unblk", attempt_id, pr=f"pr/{i}", branch=f"feat/{i}")
+        backend.kickback("task-unblk", reason=f"failure {i}", max_attempts=3)
+
+    assert backend.get_task("task-unblk")["status"] == "blocked"
+
+    # Operator unblocks — task goes back to ready
+    backend.unblock_task("task-unblk")
+    assert backend.get_task("task-unblk")["status"] == "ready"
+
+    # Next cycle: pull, harvest, kickback — should block again immediately
+    # because attempt history is NOT reset
+    pulled = backend.pull("worker-1")
+    assert pulled is not None
+    attempt_id = pulled["current_attempt"]
+    backend.mark_harvested("task-unblk", attempt_id, pr="pr/retry", branch="feat/retry")
+    backend.kickback("task-unblk", reason="still failing", max_attempts=3)
+
+    assert backend.get_task("task-unblk")["status"] == "blocked"
+


### PR DESCRIPTION
## Summary
- Tasks that exceed `max_attempts` kickbacks now transition to `blocked/` instead of `ready/`, preventing infinite retry loops
- Per-task `max_attempts` field overrides the colony-wide default (3), loaded from `.antfarm/config.json`
- Propagated through `KickbackRequest`, `ColonyClient`, and `_BackendAdapter`

## Changes
- `antfarm/core/backends/base.py` — added `max_attempts` param to `kickback()` ABC
- `antfarm/core/backends/file.py` — implemented max-attempt check in `kickback()`
- `antfarm/core/lifecycle.py` — added `done → blocked` to legal transitions
- `antfarm/core/models.py` — added `max_attempts` field to `Task` dataclass
- `antfarm/core/serve.py` — load config, pass `max_attempts` through API
- `antfarm/core/colony_client.py` — added `max_attempts` param to `kickback()`
- `antfarm/core/soldier.py` — updated `_BackendAdapter.kickback()`
- `tests/test_file_backend.py` — 5 new tests for max-attempt enforcement

## Test Plan
- [x] 5 new tests pass: blocks after max, not forageable, under max goes ready, per-task override, unblock doesn't reset counter
- [x] Full suite: 580 tests pass
- [x] Linter: `ruff check antfarm/ tests/` clean

Closes #146