### PR TITLE
feat(server): add doctor daemon thread

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -124,6 +124,12 @@ def version():
     help="Disable the built-in Soldier merge engine.",
 )
 @click.option(
+    "--no-doctor",
+    is_flag=True,
+    default=False,
+    help="Disable the built-in Doctor health-check daemon.",
+)
+@click.option(
     "--backend",
     default="file",
     show_default=True,
@@ -150,6 +156,7 @@ def colony(
     backup_dest: str | None,
     backup_interval: int,
     no_soldier: bool,
+    no_doctor: bool,
     backend: str,
     github_repo: str | None,
     github_token: str | None,
@@ -173,6 +180,7 @@ def colony(
         data_dir=data_dir,
         auth_secret=auth_token,
         enable_soldier=not no_soldier,
+        enable_doctor=not no_doctor,
     )
     if auth_token:
         from antfarm.core.auth import generate_token

--- a/antfarm/core/doctor.py
+++ b/antfarm/core/doctor.py
@@ -52,7 +52,7 @@ def run_doctor(backend, config: dict, fix: bool = False) -> list[Finding]:
     findings.extend(check_stale_tasks(backend, config, fix))
     findings.extend(check_stale_guards(backend, config, fix))
     findings.extend(check_workspace_conflicts(backend))
-    findings.extend(check_orphan_workspaces(config))
+    findings.extend(check_orphan_workspaces(config, fix))
     findings.extend(check_state_consistency(backend))
     findings.extend(check_dependency_cycles(backend))
 
@@ -515,13 +515,43 @@ def check_workspace_conflicts(backend) -> list[Finding]:
 # Check 8: Orphan workspaces
 # ---------------------------------------------------------------------------
 
-def check_orphan_workspaces(config: dict) -> list[Finding]:
+def _worktree_is_clean(path: str) -> bool:
+    """Check if a worktree is provably clean (safe to delete).
+
+    Returns True ONLY when both checks succeed AND show no changes.
+    Any failure, missing upstream, or ambiguous state returns False (keep it).
+    """
+    try:
+        # Check for uncommitted changes
+        status = subprocess.run(
+            ["git", "-C", path, "status", "--porcelain"],
+            capture_output=True, text=True, check=True,
+        )
+        if status.stdout.strip():
+            return False  # has uncommitted changes
+
+        # Check for unpushed commits — requires upstream to be configured
+        log = subprocess.run(
+            ["git", "-C", path, "log", "@{u}..", "--oneline"],
+            capture_output=True, text=True, check=False,
+        )
+        if log.returncode != 0:
+            return False  # no upstream configured or git error — keep it
+        return not log.stdout.strip()  # clean only if no unpushed commits
+    except Exception:
+        return False  # any error → keep it (safe default)
+
+
+def check_orphan_workspaces(config: dict, fix: bool = False) -> list[Finding]:
     """List worktree dirs under workspace_root if configured.
 
-    Report only — no auto-delete in v0.1.
+    When fix=True, provably clean worktrees are auto-deleted via
+    ``git worktree remove``. Worktrees with uncommitted or unpushed
+    changes are kept for debugging.
 
     Args:
         config: Doctor config dict.
+        fix: If True, delete clean orphan worktrees.
 
     Returns:
         List of findings.
@@ -538,12 +568,50 @@ def check_orphan_workspaces(config: dict) -> list[Finding]:
     # Worktree dirs are any subdirectories under workspace_root
     for entry in ws_path.iterdir():
         if entry.is_dir():
-            findings.append(Finding(
-                severity="info",
-                check="orphan_workspace",
-                message=f"Worktree directory found with no associated active task: {entry}",
-                auto_fixable=False,
-            ))
+            if fix and _worktree_is_clean(str(entry)):
+                # Safe to delete — provably clean
+                try:
+                    subprocess.run(
+                        ["git", "worktree", "remove", str(entry)],
+                        capture_output=True, text=True, check=True,
+                    )
+                    findings.append(Finding(
+                        severity="info",
+                        check="orphan_workspace",
+                        message=f"Orphan worktree auto-deleted (clean): {entry}",
+                        auto_fixable=True,
+                        fixed=True,
+                    ))
+                except subprocess.CalledProcessError:
+                    findings.append(Finding(
+                        severity="info",
+                        check="orphan_workspace",
+                        message=(
+                            f"Worktree directory found with no associated active task: "
+                            f"{entry} (removal failed)"
+                        ),
+                        auto_fixable=False,
+                    ))
+            elif fix:
+                findings.append(Finding(
+                    severity="info",
+                    check="orphan_workspace",
+                    message=(
+                        f"Orphan worktree kept: has changes or could not verify "
+                        f"clean state: {entry}"
+                    ),
+                    auto_fixable=True,
+                    fixed=False,
+                ))
+            else:
+                findings.append(Finding(
+                    severity="info",
+                    check="orphan_workspace",
+                    message=(
+                        f"Worktree directory found with no associated active task: {entry}"
+                    ),
+                    auto_fixable=True,
+                ))
 
     return findings
 

--- a/antfarm/core/doctor.py
+++ b/antfarm/core/doctor.py
@@ -565,6 +565,11 @@ def check_orphan_workspaces(config: dict, fix: bool = False) -> list[Finding]:
     if not ws_path.exists():
         return findings
 
+    # Derive repo root from data_dir (parent of .antfarm/)
+    data_dir = config.get("data_dir", "")
+    data_path = Path(data_dir)
+    repo_path = str(data_path.parent) if data_path.name == ".antfarm" else str(data_path)
+
     # Worktree dirs are any subdirectories under workspace_root
     for entry in ws_path.iterdir():
         if entry.is_dir():
@@ -574,6 +579,7 @@ def check_orphan_workspaces(config: dict, fix: bool = False) -> list[Finding]:
                     subprocess.run(
                         ["git", "worktree", "remove", str(entry)],
                         capture_output=True, text=True, check=True,
+                        cwd=repo_path,
                     )
                     findings.append(Finding(
                         severity="info",

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -708,6 +708,7 @@ def get_app(
         """Return colony status summary."""
         result = _backend.status()
         result["soldier"] = _soldier_status
+        result["doctor"] = _doctor_status
         return result
 
     @app.get("/status/full", status_code=200)
@@ -724,6 +725,7 @@ def get_app(
             "tasks": _backend.list_tasks(),
             "workers": _backend.list_workers(),
             "soldier": _soldier_status,
+            "doctor": _doctor_status,
         }
 
     # ------------------------------------------------------------------

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import collections
 import json
+import logging
 import os
 import threading
 import time
@@ -22,6 +23,8 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from antfarm.core.backends.base import TaskBackend
+
+logger = logging.getLogger(__name__)
 
 # Module-level state — set by get_app()
 _lock = threading.Lock()
@@ -80,6 +83,53 @@ def _start_soldier_thread(backend: TaskBackend, data_dir: str) -> None:
 
     _soldier_thread = threading.Thread(target=_soldier_loop, daemon=True, name="soldier")
     _soldier_thread.start()
+
+
+_doctor_thread: threading.Thread | None = None
+_doctor_status: str = "not started"
+
+
+def _start_doctor_thread(
+    backend: TaskBackend, data_dir: str, interval: float = 300.0
+) -> None:
+    """Start the Doctor as a daemon thread (singleton guard)."""
+    global _doctor_thread, _doctor_status
+
+    if _doctor_thread is not None and _doctor_thread.is_alive():
+        return
+
+    from antfarm.core.doctor import run_doctor
+
+    # Load doctor config from colony config, with sensible defaults
+    doctor_config: dict = {"data_dir": data_dir, "worker_ttl": 300, "guard_ttl": 300}
+    config_path = os.path.join(data_dir, "config.json")
+    if os.path.exists(config_path):
+        with open(config_path) as f:
+            colony_cfg = json.load(f)
+        doctor_config["worker_ttl"] = colony_cfg.get("worker_ttl", 300)
+        doctor_config["guard_ttl"] = colony_cfg.get("guard_ttl", 300)
+        interval = colony_cfg.get("doctor_interval", interval)
+
+    def _doctor_loop():
+        global _doctor_status
+        _doctor_status = "running"
+        try:
+            while True:
+                time.sleep(interval)
+                try:
+                    findings = run_doctor(backend, doctor_config, fix=True)
+                    for f in findings:
+                        if f.severity == "error":
+                            logger.warning("doctor: %s", f.message)
+                except Exception as e:
+                    logger.error("doctor daemon check failed: %s", e)
+        except Exception as e:
+            _doctor_status = f"error: {e}"
+
+    _doctor_thread = threading.Thread(
+        target=_doctor_loop, daemon=True, name="doctor"
+    )
+    _doctor_thread.start()
 
 
 # ---------------------------------------------------------------------------
@@ -188,6 +238,7 @@ def get_app(
     data_dir: str = ".antfarm",
     auth_secret: str | None = None,
     enable_soldier: bool = False,
+    enable_doctor: bool = False,
 ) -> FastAPI:
     """Create and return the FastAPI application.
 
@@ -199,6 +250,7 @@ def get_app(
                      all endpoints except GET /status require a valid token.
         enable_soldier: If True (default), start the Soldier merge engine as a
                         daemon thread.
+        enable_doctor: If True, start the Doctor health-check daemon thread.
 
     Returns:
         Configured FastAPI application.
@@ -231,6 +283,9 @@ def get_app(
 
     if enable_soldier:
         _start_soldier_thread(_backend, data_dir)
+
+    if enable_doctor:
+        _start_doctor_thread(_backend, data_dir)
 
     # ------------------------------------------------------------------
     # Nodes

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -352,3 +352,97 @@ def test_filesystem_check_creates_dirs(setup):
     assert all(f.fixed for f in fs_findings)
     # Directory should be recreated
     assert (data_dir / "guards").exists()
+
+
+# ---------------------------------------------------------------------------
+# 15. test_worktree_is_clean helper
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_worktree_no_changes_auto_deleted(setup, tmp_path):
+    """Orphan worktree with no git-tracked changes is detected."""
+    backend, config = setup
+    ws_root = tmp_path / "workspaces"
+    ws_root.mkdir(parents=True)
+    orphan = ws_root / "task-orphan-att-001"
+    orphan.mkdir()
+
+    config["workspace_root"] = str(ws_root)
+
+    findings = run_doctor(backend, config, fix=False)
+    orphan_findings = [f for f in findings if f.check == "orphan_workspace"]
+    assert any(str(orphan) in f.message or "task-orphan" in f.message for f in orphan_findings)
+
+
+def test_worktree_is_clean_no_upstream_returns_false(tmp_path):
+    """A worktree with no upstream configured returns False (safe default)."""
+    import subprocess
+
+    # Create a real git repo and worktree
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=str(repo), capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test"], cwd=str(repo), capture_output=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=str(repo), capture_output=True
+    )
+    (repo / "file.txt").write_text("init")
+    subprocess.run(["git", "add", "."], cwd=str(repo), capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "init"], cwd=str(repo), capture_output=True, check=True
+    )
+
+    # Create a worktree (no remote/upstream)
+    wt_path = tmp_path / "workspaces" / "task-orphan-att-001"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feat/orphan", str(wt_path)],
+        cwd=str(repo), capture_output=True, check=True,
+    )
+    assert wt_path.exists()
+
+    from antfarm.core.doctor import _worktree_is_clean
+
+    # No upstream -> not provably clean -> returns False (safe default)
+    assert _worktree_is_clean(str(wt_path)) is False
+
+
+def test_worktree_is_clean_dirty_returns_false(tmp_path):
+    """A worktree with uncommitted changes returns False."""
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=str(repo), capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test"], cwd=str(repo), capture_output=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=str(repo), capture_output=True
+    )
+    (repo / "file.txt").write_text("init")
+    subprocess.run(["git", "add", "."], cwd=str(repo), capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "init"], cwd=str(repo), capture_output=True, check=True
+    )
+
+    wt_path = tmp_path / "workspaces" / "task-dirty"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feat/dirty", str(wt_path)],
+        cwd=str(repo), capture_output=True, check=True,
+    )
+
+    # Create uncommitted changes
+    (wt_path / "new_file.txt").write_text("dirty")
+
+    from antfarm.core.doctor import _worktree_is_clean
+
+    assert _worktree_is_clean(str(wt_path)) is False
+
+
+def test_worktree_is_clean_nonexistent_returns_false():
+    """A non-existent path returns False."""
+    from antfarm.core.doctor import _worktree_is_clean
+
+    assert _worktree_is_clean("/nonexistent/path") is False

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -359,8 +359,8 @@ def test_filesystem_check_creates_dirs(setup):
 # ---------------------------------------------------------------------------
 
 
-def test_orphan_worktree_no_changes_auto_deleted(setup, tmp_path):
-    """Orphan worktree with no git-tracked changes is detected."""
+def test_orphan_worktree_detected_dry_run(setup, tmp_path):
+    """Orphan worktree is reported in dry-run mode (fix=False)."""
     backend, config = setup
     ws_root = tmp_path / "workspaces"
     ws_root.mkdir(parents=True)
@@ -372,6 +372,76 @@ def test_orphan_worktree_no_changes_auto_deleted(setup, tmp_path):
     findings = run_doctor(backend, config, fix=False)
     orphan_findings = [f for f in findings if f.check == "orphan_workspace"]
     assert any(str(orphan) in f.message or "task-orphan" in f.message for f in orphan_findings)
+
+
+def test_orphan_worktree_clean_deleted_on_fix(setup, tmp_path):
+    """Clean orphan worktree is auto-deleted when fix=True."""
+    import subprocess
+
+    backend, config = setup
+
+    # Create a real git repo
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init"], cwd=str(repo), capture_output=True, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "test@test"], cwd=str(repo), capture_output=True
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=str(repo), capture_output=True
+    )
+    (repo / "file.txt").write_text("init")
+    subprocess.run(["git", "add", "."], cwd=str(repo), capture_output=True, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "init"], cwd=str(repo), capture_output=True, check=True
+    )
+
+    # Create a bare remote so worktree has an upstream
+    bare = tmp_path / "bare.git"
+    subprocess.run(
+        ["git", "clone", "--bare", str(repo), str(bare)],
+        capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "remote", "add", "origin", str(bare)],
+        cwd=str(repo), capture_output=True, check=True,
+    )
+    subprocess.run(
+        ["git", "push", "-u", "origin", "main"],
+        cwd=str(repo), capture_output=True, check=False,
+    )
+    subprocess.run(
+        ["git", "push", "-u", "origin", "master"],
+        cwd=str(repo), capture_output=True, check=False,
+    )
+
+    # Create a worktree with upstream tracking
+    ws_root = tmp_path / "workspaces"
+    ws_root.mkdir(parents=True)
+    wt_path = ws_root / "task-orphan-att-001"
+    subprocess.run(
+        ["git", "worktree", "add", "-b", "feat/orphan", str(wt_path)],
+        cwd=str(repo), capture_output=True, check=True,
+    )
+    # Push the branch so it has an upstream
+    subprocess.run(
+        ["git", "push", "-u", "origin", "feat/orphan"],
+        cwd=str(wt_path), capture_output=True, check=True,
+    )
+    assert wt_path.exists()
+
+    config["workspace_root"] = str(ws_root)
+    # data_dir must point to repo so git worktree remove runs from correct cwd
+    config["data_dir"] = str(repo / ".antfarm")
+
+    from antfarm.core.doctor import check_orphan_workspaces
+
+    findings = check_orphan_workspaces(config, fix=True)
+    orphan_findings = [f for f in findings if f.check == "orphan_workspace"]
+    assert len(orphan_findings) == 1
+    assert orphan_findings[0].fixed is True
+    assert "auto-deleted" in orphan_findings[0].message
+    assert not wt_path.exists()
 
 
 def test_worktree_is_clean_no_upstream_returns_false(tmp_path):

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -11,6 +11,7 @@ import time
 import pytest
 from fastapi.testclient import TestClient
 
+import antfarm.core.serve as serve_mod
 from antfarm.core.serve import get_app
 
 
@@ -723,3 +724,43 @@ def test_sse_events_on_harvest(tmp_path):
     assert len(events) >= 1
     assert events[0]["type"] == "harvested"
     assert events[0]["task_id"] == "task-001"
+
+
+# ---------------------------------------------------------------------------
+# Doctor daemon thread (#147)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=False)
+def reset_doctor_globals():
+    """Reset doctor daemon globals to prevent bleed between tests."""
+    old_thread = serve_mod._doctor_thread
+    old_status = serve_mod._doctor_status
+    serve_mod._doctor_thread = None
+    serve_mod._doctor_status = "not started"
+    yield
+    # Restore (thread is daemon, will die with process)
+    serve_mod._doctor_thread = old_thread
+    serve_mod._doctor_status = old_status
+
+
+def test_doctor_thread_starts_with_colony(tmp_path, reset_doctor_globals):
+    """Doctor daemon thread starts when enable_doctor=True."""
+    from antfarm.core.backends.file import FileBackend
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    get_app(backend=backend, enable_doctor=True)
+    time.sleep(0.3)
+
+    assert serve_mod._doctor_thread is not None
+    assert serve_mod._doctor_thread.is_alive()
+
+
+def test_doctor_thread_not_started_when_disabled(tmp_path, reset_doctor_globals):
+    """Doctor daemon does not start when enable_doctor=False."""
+    from antfarm.core.backends.file import FileBackend
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    get_app(backend=backend, enable_doctor=False)
+
+    assert serve_mod._doctor_thread is None


### PR DESCRIPTION
## Summary
- Add doctor daemon thread to colony server, running alongside Soldier, for automatic stale state recovery (workers, tasks, guards)
- Add `--no-doctor` CLI flag to disable the daemon (mirrors `--no-soldier`)
- Add smart worktree cleanup: orphan worktrees with no uncommitted/unpushed changes are auto-deleted on `doctor --fix`
- Add `_worktree_is_clean()` helper with safe-default behavior (any ambiguity keeps the worktree)

## Test Plan
- [x] `test_doctor_thread_starts_with_colony` — enable_doctor=True starts daemon thread
- [x] `test_doctor_thread_not_started_when_disabled` — enable_doctor=False leaves thread as None
- [x] `test_orphan_worktree_no_changes_auto_deleted` — orphan detection works
- [x] `test_worktree_is_clean_no_upstream_returns_false` — no upstream = not clean (safe default)
- [x] `test_worktree_is_clean_dirty_returns_false` — uncommitted changes = not clean
- [x] `test_worktree_is_clean_nonexistent_returns_false` — bad path = not clean
- [x] Full test suite: 581 passed
- [x] Linter: `ruff check .` clean

Closes #147