### PR TITLE
feat(backend): enforce max-attempt limit on kickback

### DIFF
--- a/antfarm/core/backends/base.py
+++ b/antfarm/core/backends/base.py
@@ -87,15 +87,22 @@ class TaskBackend(ABC):
         ...
 
     @abstractmethod
-    def kickback(self, task_id: str, reason: str) -> None:
-        """Transition task to READY, current attempt to SUPERSEDED.
+    def kickback(
+        self, task_id: str, reason: str, max_attempts: int = 3
+    ) -> None:
+        """Transition task to READY (or BLOCKED if attempts exhausted).
 
         Sets current_attempt to None. Next pull() creates a fresh attempt.
         Adds a failure TrailEntry with the reason.
 
+        If the total completed/superseded attempts >= effective max,
+        the task transitions to BLOCKED instead of READY. Per-task
+        ``max_attempts`` overrides the function parameter.
+
         Args:
             task_id: ID of the task.
             reason: Human-readable reason for the kickback.
+            max_attempts: Default max before blocking.
         """
         ...
 

--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -342,12 +342,18 @@ class FileBackend(TaskBackend):
             self._write_json(active_path, data)
             os.rename(active_path, done_path)
 
-    def kickback(self, task_id: str, reason: str) -> None:
-        """Move task from done/ to ready/. SUPERSEDE current attempt.
+    def kickback(
+        self, task_id: str, reason: str, max_attempts: int = 3
+    ) -> None:
+        """Move task from done/ to ready/ or blocked/ if max attempts exhausted.
 
         Soldier calls kickback after a failed integration merge. The task
         is in done/ at that point (harvested but not yet merged).
         Sets current_attempt to None. Adds failure TrailEntry.
+
+        If total completed/superseded attempts >= effective max, transitions
+        to BLOCKED instead of READY. Per-task ``max_attempts`` overrides the
+        function parameter.
         """
         with self._lock:
             done_path = self._done_path(task_id)
@@ -355,7 +361,6 @@ class FileBackend(TaskBackend):
                 raise FileNotFoundError(f"Task '{task_id}' not found in done/")
 
             data = self._read_json(done_path)
-            assert_task_transition(data["status"], TaskStatus.READY.value)
             now = _now_iso()
 
             current_attempt_id = data.get("current_attempt")
@@ -374,12 +379,34 @@ class FileBackend(TaskBackend):
             data.setdefault("trail", [])
             data["trail"].append(trail_entry.to_dict())
 
-            data["status"] = TaskStatus.READY.value
             data["current_attempt"] = None
             data["updated_at"] = now
 
-            self._write_json(done_path, data)
-            os.rename(done_path, self._ready_path(task_id))
+            # Determine effective max_attempts (per-task overrides parameter)
+            effective_max = data.get("max_attempts") or max_attempts
+
+            # Count completed/superseded attempts
+            finished = sum(
+                1
+                for a in data["attempts"]
+                if a["status"]
+                in (AttemptStatus.DONE.value, AttemptStatus.SUPERSEDED.value)
+            )
+
+            if finished >= effective_max:
+                assert_task_transition(
+                    data["status"], TaskStatus.BLOCKED.value
+                )
+                data["status"] = TaskStatus.BLOCKED.value
+                self._write_json(done_path, data)
+                os.rename(done_path, self._blocked_path(task_id))
+            else:
+                assert_task_transition(
+                    data["status"], TaskStatus.READY.value
+                )
+                data["status"] = TaskStatus.READY.value
+                self._write_json(done_path, data)
+                os.rename(done_path, self._ready_path(task_id))
 
     def mark_harvest_pending(self, task_id: str, attempt_id: str) -> None:
         """Transition task from ACTIVE to HARVEST_PENDING.

--- a/antfarm/core/colony_client.py
+++ b/antfarm/core/colony_client.py
@@ -150,8 +150,18 @@ class ColonyClient:
         r = self._client.post(f"/tasks/{task_id}/harvest", json=payload)
         r.raise_for_status()
 
-    def kickback(self, task_id: str, reason: str) -> None:
-        r = self._client.post(f"/tasks/{task_id}/kickback", json={"reason": reason})
+    def kickback(
+        self,
+        task_id: str,
+        reason: str,
+        max_attempts: int | None = None,
+    ) -> None:
+        payload: dict = {"reason": reason}
+        if max_attempts is not None:
+            payload["max_attempts"] = max_attempts
+        r = self._client.post(
+            f"/tasks/{task_id}/kickback", json=payload
+        )
         r.raise_for_status()
 
     def mark_harvest_pending(self, task_id: str, attempt_id: str) -> None:

--- a/antfarm/core/lifecycle.py
+++ b/antfarm/core/lifecycle.py
@@ -50,7 +50,8 @@ LEGAL_TASK_TRANSITIONS: dict[str, set[str]] = {
     "claimed": {"active"},
     "active": {"harvest_pending", "paused"},
     "harvest_pending": {"done", "failed"},
-    "done": {"merge_ready", "kicked_back", "queued"},  # "queued" = legacy kickback (done→ready)
+    # "queued" = legacy kickback, "blocked" = max-attempt exhaustion
+    "done": {"merge_ready", "kicked_back", "queued", "blocked"},
     "kicked_back": {"queued"},
     "merge_ready": {"merged"},
     "merged": set(),  # terminal

--- a/antfarm/core/models.py
+++ b/antfarm/core/models.py
@@ -410,6 +410,7 @@ class Task:
     capabilities_required: list[str] = field(default_factory=list)
     pinned_to: str | None = None
     merge_override: int | None = None
+    max_attempts: int | None = None
     status: TaskStatus = TaskStatus.READY
     current_attempt: str | None = None
     attempts: list[Attempt] = field(default_factory=list)
@@ -428,6 +429,7 @@ class Task:
             "capabilities_required": list(self.capabilities_required),
             "pinned_to": self.pinned_to,
             "merge_override": self.merge_override,
+            "max_attempts": self.max_attempts,
             "status": self.status.value,
             "current_attempt": self.current_attempt,
             "attempts": [a.to_dict() for a in self.attempts],
@@ -451,6 +453,7 @@ class Task:
             capabilities_required=list(data.get("capabilities_required", [])),
             pinned_to=data.get("pinned_to"),
             merge_override=data.get("merge_override"),
+            max_attempts=data.get("max_attempts"),
             status=TaskStatus(data.get("status", TaskStatus.READY)),
             current_attempt=data.get("current_attempt"),
             attempts=[Attempt.from_dict(a) for a in data.get("attempts", [])],

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import collections
 import json
+import os
 import threading
 import time
 from datetime import UTC, datetime
@@ -25,6 +26,7 @@ from antfarm.core.backends.base import TaskBackend
 # Module-level state — set by get_app()
 _lock = threading.Lock()
 _backend: TaskBackend | None = None
+_max_attempts: int = 3
 _soldier_status: str = "not started"
 _soldier_thread: threading.Thread | None = None
 
@@ -144,6 +146,7 @@ class HarvestRequest(BaseModel):
 
 class KickbackRequest(BaseModel):
     reason: str
+    max_attempts: int | None = None
 
 
 class ReviewVerdictRequest(BaseModel):
@@ -200,7 +203,7 @@ def get_app(
     Returns:
         Configured FastAPI application.
     """
-    global _backend
+    global _backend, _max_attempts
 
     if backend is not None:
         _backend = backend
@@ -208,6 +211,16 @@ def get_app(
         from antfarm.core.backends.file import FileBackend
 
         _backend = FileBackend(root=data_dir)
+
+    # Load max_attempts default from config
+    config_path = os.path.join(data_dir, "config.json")
+    if os.path.exists(config_path):
+        try:
+            with open(config_path) as f:
+                cfg = json.load(f)
+            _max_attempts = cfg.get("max_attempts", 3)
+        except (json.JSONDecodeError, OSError):
+            pass
 
     app = FastAPI(title="Antfarm Colony")
 
@@ -393,9 +406,16 @@ def get_app(
 
     @app.post("/tasks/{task_id}/kickback", status_code=200)
     def kickback_task(task_id: str, req: KickbackRequest):
-        """Return a task to ready state with the given reason."""
+        """Return a task to ready (or blocked if max attempts exhausted)."""
+        effective = (
+            req.max_attempts
+            if req.max_attempts is not None
+            else _max_attempts
+        )
         try:
-            _backend.kickback(task_id, req.reason)
+            _backend.kickback(
+                task_id, req.reason, max_attempts=effective
+            )
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         _emit_event("kickback", task_id, req.reason)

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -804,8 +804,12 @@ class _BackendAdapter:
     def mark_merged(self, task_id: str, attempt_id: str) -> None:
         self._backend.mark_merged(task_id, attempt_id)
 
-    def kickback(self, task_id: str, reason: str) -> None:
-        self._backend.kickback(task_id, reason)
+    def kickback(
+        self, task_id: str, reason: str, max_attempts: int = 3
+    ) -> None:
+        self._backend.kickback(
+            task_id, reason, max_attempts=max_attempts
+        )
 
     def store_review_verdict(
         self, task_id: str, attempt_id: str, verdict: dict

--- a/tests/test_file_backend.py
+++ b/tests/test_file_backend.py
@@ -863,3 +863,134 @@ def test_harvest_without_artifact_backward_compat(backend: FileBackend) -> None:
             assert "artifact" not in a
             break
 
+
+# ---------------------------------------------------------------------------
+# Max-attempt enforcement
+# ---------------------------------------------------------------------------
+
+
+def _kickback_cycle(backend: FileBackend, task_id: str) -> None:
+    """Helper: pull -> harvest -> kickback a task through one full cycle."""
+    pulled = backend.pull("worker-1")
+    assert pulled is not None
+    assert pulled["id"] == task_id
+    attempt_id = pulled["current_attempt"]
+    backend.mark_harvested(task_id, attempt_id, pr="pr", branch="branch")
+    backend.kickback(task_id, reason="tests failed", max_attempts=3)
+
+
+def test_kickback_blocks_after_max_attempts(
+    backend: FileBackend, tmp_path: Path
+) -> None:
+    """After max_attempts kickbacks, task transitions to blocked/."""
+    backend.carry(_make_task("task-1"))
+
+    # First two kickbacks: task goes back to ready
+    _kickback_cycle(backend, "task-1")
+    assert backend.get_task("task-1")["status"] == TaskStatus.READY.value
+
+    _kickback_cycle(backend, "task-1")
+    assert backend.get_task("task-1")["status"] == TaskStatus.READY.value
+
+    # Third kickback: blocked (max_attempts=3 means 3 total attempts)
+    pulled = backend.pull("worker-1")
+    assert pulled is not None
+    attempt_id = pulled["current_attempt"]
+    backend.mark_harvested(
+        "task-1", attempt_id, pr="pr", branch="branch"
+    )
+    backend.kickback("task-1", reason="tests failed again", max_attempts=3)
+
+    task = backend.get_task("task-1")
+    assert task is not None
+    assert task["status"] == TaskStatus.BLOCKED.value
+    blocked_file = (
+        tmp_path / ".antfarm" / "tasks" / "blocked" / "task-1.json"
+    )
+    assert blocked_file.exists()
+
+
+def test_blocked_task_not_forageable(backend: FileBackend) -> None:
+    """A task in blocked/ should not be returned by pull()."""
+    backend.carry(_make_task("task-1"))
+
+    # Exhaust max attempts (max_attempts=1 -> blocked after first kickback)
+    pulled = backend.pull("worker-1")
+    assert pulled is not None
+    attempt_id = pulled["current_attempt"]
+    backend.mark_harvested("task-1", attempt_id, pr="pr", branch="branch")
+    backend.kickback("task-1", reason="fail", max_attempts=1)
+
+    # Task is now blocked — pull should return nothing
+    result = backend.pull("worker-1")
+    assert result is None
+
+
+def test_kickback_under_max_attempts_goes_to_ready(
+    backend: FileBackend,
+) -> None:
+    """Kickback before reaching max_attempts transitions task to ready."""
+    backend.carry(_make_task("task-1"))
+
+    # With max_attempts=5, first kickback should go to ready
+    pulled = backend.pull("worker-1")
+    assert pulled is not None
+    attempt_id = pulled["current_attempt"]
+    backend.mark_harvested("task-1", attempt_id, pr="pr", branch="branch")
+    backend.kickback("task-1", reason="fail", max_attempts=5)
+
+    task = backend.get_task("task-1")
+    assert task is not None
+    assert task["status"] == TaskStatus.READY.value
+
+
+def test_per_task_max_attempts_override(backend: FileBackend) -> None:
+    """Task-level max_attempts field overrides the function parameter."""
+    task = _make_task("task-1")
+    task["max_attempts"] = 1  # task says 1 attempt max
+    backend.carry(task)
+
+    # Even though function default is 3, task-level override of 1 wins
+    pulled = backend.pull("worker-1")
+    assert pulled is not None
+    attempt_id = pulled["current_attempt"]
+    backend.mark_harvested("task-1", attempt_id, pr="pr", branch="branch")
+    backend.kickback("task-1", reason="fail", max_attempts=3)
+
+    task = backend.get_task("task-1")
+    assert task is not None
+    assert task["status"] == TaskStatus.BLOCKED.value
+
+
+def test_unblock_does_not_reset_attempt_counter(
+    backend: FileBackend,
+) -> None:
+    """After unblocking, the next kickback blocks again (no reset)."""
+    backend.carry(_make_task("task-1"))
+
+    # Exhaust max attempts (max_attempts=1)
+    pulled = backend.pull("worker-1")
+    assert pulled is not None
+    attempt_id = pulled["current_attempt"]
+    backend.mark_harvested("task-1", attempt_id, pr="pr", branch="branch")
+    backend.kickback("task-1", reason="fail", max_attempts=1)
+    assert (
+        backend.get_task("task-1")["status"] == TaskStatus.BLOCKED.value
+    )
+
+    # Unblock it
+    backend.unblock_task("task-1")
+    assert (
+        backend.get_task("task-1")["status"] == TaskStatus.READY.value
+    )
+
+    # Another cycle should block again since attempts still counted
+    pulled = backend.pull("worker-1")
+    assert pulled is not None
+    attempt_id = pulled["current_attempt"]
+    backend.mark_harvested("task-1", attempt_id, pr="pr", branch="branch")
+    backend.kickback("task-1", reason="fail again", max_attempts=1)
+    assert (
+        backend.get_task("task-1")["status"] == TaskStatus.BLOCKED.value
+    )
+


### PR DESCRIPTION
## Summary
- Add configurable `max_attempts` parameter to `kickback()` across backend, API, colony client, and soldier
- When a task exhausts its attempts (completed + superseded >= max), it transitions to `blocked/` instead of `ready/`, preventing infinite retry loops
- Per-task `max_attempts` field overrides the function default; colony server loads default from `.antfarm/config.json`
- Add `max_attempts` field to Task model for round-trip persistence through pull/harvest cycles

## Test Plan
- [x] `test_kickback_blocks_after_max_attempts` — 3 kickbacks with max_attempts=3 blocks
- [x] `test_blocked_task_not_forageable` — blocked task not returned by pull()
- [x] `test_kickback_under_max_attempts_goes_to_ready` — kickback before max stays ready
- [x] `test_per_task_max_attempts_override` — task-level max_attempts=1 overrides default
- [x] `test_unblock_does_not_reset_attempt_counter` — unblock then kickback blocks again
- [x] All 580 existing tests pass
- [x] `ruff check .` passes

Closes #146