### PR TITLE
refactor(soldier): extract review-verdict helper to review_pack.py (#157)

### DIFF
--- a/antfarm/core/review_pack.py
+++ b/antfarm/core/review_pack.py
@@ -88,3 +88,37 @@ def generate_review_pack(artifact: TaskArtifact, task_title: str = "") -> str:
         lines.append("")
 
     return "\n".join(lines)
+
+
+def extract_verdict_from_review_task(review_task: dict) -> dict | None:
+    """Extract ReviewVerdict dict from a completed review task.
+
+    Lookup order:
+    1. Attempt artifact with a "verdict" key
+    2. Attempt-level review_verdict field
+    3. Trail entry fallback: most recent [REVIEW_VERDICT] JSON message
+    """
+    current_attempt_id = review_task.get("current_attempt")
+    if not current_attempt_id:
+        return None
+    for attempt in review_task.get("attempts", []):
+        if attempt.get("attempt_id") == current_attempt_id:
+            # Check attempt artifact for verdict
+            artifact = attempt.get("artifact")
+            if artifact and "verdict" in artifact:
+                return artifact
+            # Check attempt-level review_verdict
+            rv = attempt.get("review_verdict")
+            if rv:
+                return rv
+    # Fall back to trail entries containing [REVIEW_VERDICT]
+    for entry in reversed(review_task.get("trail", [])):
+        msg = entry.get("message", "")
+        if msg.startswith("[REVIEW_VERDICT] "):
+            import json
+
+            try:
+                return json.loads(msg[len("[REVIEW_VERDICT] "):])
+            except (json.JSONDecodeError, ValueError):
+                continue
+    return None

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -25,6 +25,7 @@ from enum import StrEnum
 from antfarm.core.backends.base import TaskBackend
 from antfarm.core.colony_client import ColonyClient
 from antfarm.core.models import ReviewVerdict
+from antfarm.core.review_pack import extract_verdict_from_review_task
 
 logger = logging.getLogger(__name__)
 
@@ -246,7 +247,7 @@ class Soldier:
                 continue
 
             # Review task is done — extract verdict from review task's artifact
-            review_verdict = self._extract_verdict_from_review_task(review_task)
+            review_verdict = extract_verdict_from_review_task(review_task)
             if review_verdict is None:
                 # Review done but no verdict — treat as failure
                 self.kickback_with_cascade(
@@ -733,39 +734,6 @@ class Soldier:
             return review_task_id
         except Exception:
             return None
-
-    @staticmethod
-    def _extract_verdict_from_review_task(review_task: dict) -> dict | None:
-        """Extract ReviewVerdict dict from a completed review task.
-
-        The reviewer stores the verdict in the review task's attempt artifact
-        under the "review_verdict" key, or as the artifact itself if it has
-        a "verdict" key.
-        """
-        current_attempt_id = review_task.get("current_attempt")
-        if not current_attempt_id:
-            return None
-        for attempt in review_task.get("attempts", []):
-            if attempt.get("attempt_id") == current_attempt_id:
-                # Check attempt artifact for verdict
-                artifact = attempt.get("artifact")
-                if artifact and "verdict" in artifact:
-                    return artifact
-                # Check attempt-level review_verdict
-                rv = attempt.get("review_verdict")
-                if rv:
-                    return rv
-        # Fall back to trail entries containing [REVIEW_VERDICT]
-        for entry in reversed(review_task.get("trail", [])):
-            msg = entry.get("message", "")
-            if msg.startswith("[REVIEW_VERDICT] "):
-                import json
-
-                try:
-                    return json.loads(msg[len("[REVIEW_VERDICT] "):])
-                except (json.JSONDecodeError, ValueError):
-                    continue
-        return None
 
     # ------------------------------------------------------------------
     # from_backend: in-process Soldier (no HTTP round-trips)

--- a/tests/test_review_pack.py
+++ b/tests/test_review_pack.py
@@ -1,7 +1,7 @@
 """Tests for antfarm.core.review_pack generation."""
 
 from antfarm.core.models import TaskArtifact
-from antfarm.core.review_pack import generate_review_pack
+from antfarm.core.review_pack import extract_verdict_from_review_task, generate_review_pack
 
 
 def _make_artifact(**overrides) -> TaskArtifact:
@@ -107,3 +107,79 @@ def test_review_pack_minimal_artifact():
     pack = generate_review_pack(artifact)
     assert "t1" in pack
     assert "Checks" in pack
+
+
+# --- extract_verdict_from_review_task tests ---
+
+
+def _review_task(*, current_attempt="att-1", attempts=None, trail=None):
+    task = {"current_attempt": current_attempt}
+    if attempts is not None:
+        task["attempts"] = attempts
+    if trail is not None:
+        task["trail"] = trail
+    return task
+
+
+def test_extract_verdict_from_artifact_key():
+    task = _review_task(
+        attempts=[
+            {
+                "attempt_id": "att-1",
+                "artifact": {"verdict": "approve", "comments": "LGTM"},
+            }
+        ],
+    )
+    result = extract_verdict_from_review_task(task)
+    assert result == {"verdict": "approve", "comments": "LGTM"}
+
+
+def test_extract_verdict_from_review_verdict_field():
+    task = _review_task(
+        attempts=[
+            {
+                "attempt_id": "att-1",
+                "artifact": None,
+                "review_verdict": {"verdict": "request_changes", "reason": "missing tests"},
+            }
+        ],
+    )
+    result = extract_verdict_from_review_task(task)
+    assert result == {"verdict": "request_changes", "reason": "missing tests"}
+
+
+def test_extract_verdict_from_trail_fallback():
+    task = _review_task(
+        attempts=[{"attempt_id": "att-1"}],
+        trail=[
+            {"message": "started review"},
+            {"message": '[REVIEW_VERDICT] {"verdict":"approve"}'},
+        ],
+    )
+    result = extract_verdict_from_review_task(task)
+    assert result == {"verdict": "approve"}
+
+
+def test_extract_verdict_none_when_no_current_attempt():
+    task = _review_task(current_attempt=None)
+    assert extract_verdict_from_review_task(task) is None
+
+
+def test_extract_verdict_none_when_malformed_trail_json():
+    task = _review_task(
+        attempts=[{"attempt_id": "att-1"}],
+        trail=[{"message": "[REVIEW_VERDICT] {not valid json}"}],
+    )
+    assert extract_verdict_from_review_task(task) is None
+
+
+def test_extract_verdict_most_recent_trail_entry_wins():
+    task = _review_task(
+        attempts=[{"attempt_id": "att-1"}],
+        trail=[
+            {"message": '[REVIEW_VERDICT] {"verdict":"request_changes"}'},
+            {"message": '[REVIEW_VERDICT] {"verdict":"approve"}'},
+        ],
+    )
+    result = extract_verdict_from_review_task(task)
+    assert result == {"verdict": "approve"}


### PR DESCRIPTION
## Summary
- Move `Soldier._extract_verdict_from_review_task` from `soldier.py` to `review_pack.py` as public `extract_verdict_from_review_task()`
- Pure refactor — no behavior change, function body identical
- Unblocks Queen (v0.6.0 Phase 3) sharing the same verdict extraction path

## Test plan
- [x] 6 new unit tests in `test_review_pack.py` covering all 3 extraction paths + edge cases
- [x] All 598 tests pass (592 existing + 6 new)
- [x] `ruff check .` clean
- [x] Reviewed: function body byte-identical, no scope creep

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)