### PR TITLE
feat(server): colony API /missions endpoints (#161)

### DIFF
--- a/antfarm/core/colony_client.py
+++ b/antfarm/core/colony_client.py
@@ -113,6 +113,7 @@ class ColonyClient:
         complexity: str = "M",
         capabilities_required: list[str] | None = None,
         spawned_by: dict | None = None,
+        mission_id: str | None = None,
     ) -> dict:
         """Create a task in the colony."""
         payload: dict = {
@@ -128,6 +129,8 @@ class ColonyClient:
             payload["capabilities_required"] = capabilities_required
         if spawned_by:
             payload["spawned_by"] = spawned_by
+        if mission_id is not None:
+            payload["mission_id"] = mission_id
         r = self._client.post("/tasks", json=payload)
         r.raise_for_status()
         return r.json()
@@ -196,6 +199,59 @@ class ColonyClient:
 
     def status(self) -> dict:
         r = self._client.get("/status")
+        r.raise_for_status()
+        return r.json()
+
+    # ------------------------------------------------------------------
+    # Missions
+    # ------------------------------------------------------------------
+
+    def create_mission(
+        self,
+        spec: str,
+        spec_file: str | None = None,
+        config: dict | None = None,
+    ) -> dict:
+        """Create a mission. Returns dict with mission_id."""
+        payload: dict = {"spec": spec}
+        if spec_file is not None:
+            payload["spec_file"] = spec_file
+        if config is not None:
+            payload["config"] = config
+        r = self._client.post("/missions", json=payload)
+        r.raise_for_status()
+        return r.json()
+
+    def get_mission(self, mission_id: str) -> dict | None:
+        """Get a mission by ID. Returns None on 404."""
+        r = self._client.get(f"/missions/{mission_id}")
+        if r.status_code == 404:
+            return None
+        r.raise_for_status()
+        return r.json()
+
+    def list_missions(self, status: str | None = None) -> list[dict]:
+        """List missions with optional status filter."""
+        params = {"status": status} if status else {}
+        r = self._client.get("/missions", params=params)
+        r.raise_for_status()
+        return r.json()
+
+    def update_mission(self, mission_id: str, updates: dict) -> None:
+        """Apply shallow updates to a mission."""
+        r = self._client.patch(f"/missions/{mission_id}", json={"updates": updates})
+        r.raise_for_status()
+
+    def cancel_mission(self, mission_id: str) -> None:
+        """Cancel a mission."""
+        r = self._client.post(f"/missions/{mission_id}/cancel")
+        r.raise_for_status()
+
+    def get_mission_report(self, mission_id: str) -> dict | None:
+        """Get mission report. Returns None on 404."""
+        r = self._client.get(f"/missions/{mission_id}/report")
+        if r.status_code == 404:
+            return None
         r.raise_for_status()
         return r.json()
 

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -148,6 +148,7 @@ class CarryRequest(BaseModel):
     capabilities_required: list[str] = []
     created_by: str = "api"
     spawned_by: dict | None = None
+    mission_id: str | None = None
 
 
 class NodeRequest(BaseModel):
@@ -226,6 +227,17 @@ class GuardRequest(BaseModel):
 
 class OverrideOrderRequest(BaseModel):
     position: int
+
+
+class MissionCreateRequest(BaseModel):
+    mission_id: str | None = None
+    spec: str
+    spec_file: str | None = None
+    config: dict | None = None
+
+
+class MissionUpdateRequest(BaseModel):
+    updates: dict
 
 
 # ---------------------------------------------------------------------------
@@ -376,10 +388,23 @@ def get_app(
         }
         if req.spawned_by:
             task["spawned_by"] = req.spawned_by
-        try:
-            task_id = _backend.carry(task)
-        except ValueError as exc:
-            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        if req.mission_id:
+            task["mission_id"] = req.mission_id
+
+        if req.mission_id:
+            from antfarm.core.missions import link_task_to_mission
+
+            try:
+                task_id = link_task_to_mission(_backend, task, req.mission_id)
+            except FileNotFoundError as exc:
+                raise HTTPException(status_code=404, detail=str(exc)) from exc
+            except ValueError as exc:
+                raise HTTPException(status_code=409, detail=str(exc)) from exc
+        else:
+            try:
+                task_id = _backend.carry(task)
+            except ValueError as exc:
+                raise HTTPException(status_code=409, detail=str(exc)) from exc
 
         # Check for overlap warnings with active tasks
         warnings: list[str] = []
@@ -596,9 +621,15 @@ def get_app(
         return _backend.status()["tasks"]
 
     @app.get("/tasks", status_code=200)
-    def list_tasks(status: str | None = Query(default=None)):
-        """List tasks with optional ?status= filter."""
-        return _backend.list_tasks(status=status)
+    def list_tasks(
+        status: str | None = Query(default=None),
+        mission_id: str | None = Query(default=None),
+    ):
+        """List tasks with optional ?status= and ?mission_id= filters."""
+        tasks = _backend.list_tasks(status=status)
+        if mission_id is not None:
+            tasks = [t for t in tasks if t.get("mission_id") == mission_id]
+        return tasks
 
     @app.get("/tasks/{task_id}", status_code=200)
     def get_task(task_id: str):
@@ -629,6 +660,114 @@ def get_app(
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         return {"ok": True}
+
+    # ------------------------------------------------------------------
+    # Missions
+    # ------------------------------------------------------------------
+
+    @app.post("/missions", status_code=201)
+    def create_mission(req: MissionCreateRequest):
+        """Create a mission. Returns 201 with mission_id. 409 on duplicate."""
+        from antfarm.core.backends.github import GitHubBackend
+        from antfarm.core.missions import MissionConfig, MissionStatus
+
+        if isinstance(_backend, GitHubBackend):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Mission mode requires FileBackend in v0.6.0. "
+                    "Use --backend file or wait for v0.6.1."
+                ),
+            )
+
+        mission_id = req.mission_id or f"mission-{int(time.time() * 1000)}"
+        now = _now_iso()
+
+        cfg = MissionConfig.from_dict(req.config or {})
+        if cfg.completion_mode == "all_or_nothing":
+            logger.warning(
+                "mission %s requested completion_mode='all_or_nothing'; "
+                "treated as best_effort for v0.6.0 (real semantics land in v0.6.1+)",
+                mission_id,
+            )
+
+        mission = {
+            "mission_id": mission_id,
+            "spec": req.spec,
+            "spec_file": req.spec_file,
+            "status": MissionStatus.PLANNING.value,
+            "plan_task_id": None,
+            "plan_artifact": None,
+            "task_ids": [],
+            "blocked_task_ids": [],
+            "config": cfg.to_dict(),
+            "created_at": now,
+            "updated_at": now,
+            "completed_at": None,
+            "report": None,
+            "last_progress_at": now,
+            "re_plan_count": 0,
+        }
+
+        try:
+            _backend.create_mission(mission)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+        return {"mission_id": mission_id}
+
+    @app.get("/missions", status_code=200)
+    def list_missions(status: str | None = Query(default=None)):
+        """List missions with optional ?status= filter."""
+        return _backend.list_missions(status=status)
+
+    @app.get("/missions/{mission_id}", status_code=200)
+    def get_mission(mission_id: str):
+        """Get a mission by ID. Returns 404 if not found."""
+        mission = _backend.get_mission(mission_id)
+        if mission is None:
+            raise HTTPException(
+                status_code=404, detail=f"Mission '{mission_id}' not found"
+            )
+        return mission
+
+    @app.patch("/missions/{mission_id}", status_code=200)
+    def update_mission(mission_id: str, req: MissionUpdateRequest):
+        """Apply shallow updates to a mission. 404 if missing."""
+        try:
+            _backend.update_mission(mission_id, req.updates)
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return {"ok": True}
+
+    @app.post("/missions/{mission_id}/cancel", status_code=200)
+    def cancel_mission(mission_id: str):
+        """Cancel a mission. Idempotent for terminal states."""
+        mission = _backend.get_mission(mission_id)
+        if mission is None:
+            raise HTTPException(
+                status_code=404, detail=f"Mission '{mission_id}' not found"
+            )
+        terminal = {"complete", "failed", "cancelled"}
+        if mission["status"] in terminal:
+            return {"ok": True}
+        _backend.update_mission(mission_id, {"status": "cancelled"})
+        return {"ok": True}
+
+    @app.get("/missions/{mission_id}/report", status_code=200)
+    def get_mission_report(mission_id: str):
+        """Return mission report or 404 if not yet generated."""
+        mission = _backend.get_mission(mission_id)
+        if mission is None:
+            raise HTTPException(
+                status_code=404, detail=f"Mission '{mission_id}' not found"
+            )
+        report = mission.get("report")
+        if report is None:
+            raise HTTPException(
+                status_code=404, detail=f"No report for mission '{mission_id}'"
+            )
+        return report
 
     # ------------------------------------------------------------------
     # Scent (SSE trail streaming)

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -388,12 +388,11 @@ def get_app(
         }
         if req.spawned_by:
             task["spawned_by"] = req.spawned_by
-        if req.mission_id:
-            task["mission_id"] = req.mission_id
 
         if req.mission_id:
             from antfarm.core.missions import link_task_to_mission
 
+            task["mission_id"] = req.mission_id
             try:
                 task_id = link_task_to_mission(_backend, task, req.mission_id)
             except FileNotFoundError as exc:

--- a/tests/test_mission_serve.py
+++ b/tests/test_mission_serve.py
@@ -1,0 +1,198 @@
+"""Tests for /missions Colony API endpoints (antfarm.core.serve).
+
+Uses FastAPI TestClient with a fresh FileBackend per test via tmp_path fixture.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from fastapi.testclient import TestClient
+
+from antfarm.core.serve import get_app
+
+
+@pytest.fixture
+def client(tmp_path):
+    from antfarm.core.backends.file import FileBackend
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend)
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_mission(client, mission_id="mission-001", spec="Build the thing"):
+    return client.post(
+        "/missions",
+        json={"mission_id": mission_id, "spec": spec},
+    )
+
+
+def _carry(client, task_id="task-001", title="Test Task", spec="Do the thing", **kwargs):
+    payload = {"id": task_id, "title": title, "spec": spec, **kwargs}
+    return client.post("/tasks", json=payload)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_create_mission_endpoint_returns_id(client):
+    """POST /missions returns 201 with mission_id."""
+    r = _create_mission(client)
+    assert r.status_code == 201
+    assert r.json()["mission_id"] == "mission-001"
+
+
+def test_create_mission_duplicate_returns_409(client):
+    """POST /missions with duplicate mission_id returns 409."""
+    _create_mission(client)
+    r = _create_mission(client)
+    assert r.status_code == 409
+
+
+def test_create_mission_all_or_nothing_warns(client, caplog):
+    """completion_mode='all_or_nothing' logs warning and persists the field."""
+    with caplog.at_level(logging.WARNING):
+        r = client.post(
+            "/missions",
+            json={
+                "mission_id": "mission-aon",
+                "spec": "all or nothing test",
+                "config": {"completion_mode": "all_or_nothing"},
+            },
+        )
+    assert r.status_code == 201
+    assert "all_or_nothing" in caplog.text
+    assert "best_effort" in caplog.text
+
+    # Field persisted
+    mission = client.get("/missions/mission-aon").json()
+    assert mission["config"]["completion_mode"] == "all_or_nothing"
+
+
+def test_list_missions_empty_returns_empty_list(client):
+    """GET /missions returns empty list when no missions exist."""
+    r = client.get("/missions")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_list_missions_filter_by_status(client):
+    """GET /missions?status= filters by mission status."""
+    _create_mission(client, mission_id="m-1")
+    _create_mission(client, mission_id="m-2")
+    # Cancel one
+    client.post("/missions/m-2/cancel")
+
+    r = client.get("/missions", params={"status": "planning"})
+    assert r.status_code == 200
+    missions = r.json()
+    assert len(missions) == 1
+    assert missions[0]["mission_id"] == "m-1"
+
+    r = client.get("/missions", params={"status": "cancelled"})
+    assert len(r.json()) == 1
+    assert r.json()[0]["mission_id"] == "m-2"
+
+
+def test_get_mission_404(client):
+    """GET /missions/{id} returns 404 for non-existent mission."""
+    r = client.get("/missions/nonexistent")
+    assert r.status_code == 404
+
+
+def test_patch_mission_merges_fields(client):
+    """PATCH /missions/{id} applies shallow updates."""
+    _create_mission(client)
+    r = client.patch(
+        "/missions/mission-001",
+        json={"updates": {"status": "building"}},
+    )
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+
+    mission = client.get("/missions/mission-001").json()
+    assert mission["status"] == "building"
+
+
+def test_cancel_mission_terminal_state(client):
+    """POST /missions/{id}/cancel flips status to cancelled."""
+    _create_mission(client)
+    r = client.post("/missions/mission-001/cancel")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+
+    mission = client.get("/missions/mission-001").json()
+    assert mission["status"] == "cancelled"
+
+
+def test_cancel_mission_idempotent(client):
+    """Cancelling a cancelled mission returns 200 both times."""
+    _create_mission(client)
+    r1 = client.post("/missions/mission-001/cancel")
+    assert r1.status_code == 200
+
+    r2 = client.post("/missions/mission-001/cancel")
+    assert r2.status_code == 200
+    assert r2.json() == {"ok": True}
+
+
+def test_carry_with_mission_id_appends_to_task_ids(client):
+    """POST /tasks with mission_id links the task to the mission."""
+    _create_mission(client)
+    r = _carry(client, task_id="task-m1", mission_id="mission-001")
+    assert r.status_code == 201
+
+    mission = client.get("/missions/mission-001").json()
+    assert "task-m1" in mission["task_ids"]
+
+
+def test_carry_with_unknown_mission_id_404(client):
+    """POST /tasks with non-existent mission_id returns 404."""
+    r = _carry(client, task_id="task-m1", mission_id="no-such-mission")
+    assert r.status_code == 404
+
+
+def test_list_tasks_filter_by_mission_id(client):
+    """GET /tasks?mission_id= filters tasks by mission."""
+    _create_mission(client)
+    _carry(client, task_id="task-m1", mission_id="mission-001")
+    _carry(client, task_id="task-no-mission")
+
+    r = client.get("/tasks", params={"mission_id": "mission-001"})
+    assert r.status_code == 200
+    tasks = r.json()
+    assert len(tasks) == 1
+    assert tasks[0]["id"] == "task-m1"
+
+
+def test_get_mission_report_404_when_no_report(client):
+    """GET /missions/{id}/report returns 404 when report is None."""
+    _create_mission(client)
+    r = client.get("/missions/mission-001/report")
+    assert r.status_code == 404
+
+
+def test_get_mission_report_returns_report(client):
+    """GET /missions/{id}/report returns the report when set."""
+    _create_mission(client)
+    # Set a report via patch
+    report = {"mission_id": "mission-001", "total_tasks": 5, "merged_tasks": 3}
+    client.patch(
+        "/missions/mission-001",
+        json={"updates": {"report": report}},
+    )
+
+    r = client.get("/missions/mission-001/report")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["mission_id"] == "mission-001"
+    assert data["total_tasks"] == 5

--- a/tests/test_mission_serve.py
+++ b/tests/test_mission_serve.py
@@ -196,3 +196,26 @@ def test_get_mission_report_returns_report(client):
     data = r.json()
     assert data["mission_id"] == "mission-001"
     assert data["total_tasks"] == 5
+
+
+# ---------------------------------------------------------------------------
+# GitHubBackend preflight
+# ---------------------------------------------------------------------------
+
+
+def test_create_mission_rejects_github_backend(tmp_path):
+    """POST /missions returns 400 when backend is GitHubBackend."""
+    from unittest.mock import MagicMock
+
+    from antfarm.core.backends.github import GitHubBackend
+
+    mock_backend = MagicMock(spec=GitHubBackend)
+    # Make isinstance() check work
+    mock_backend.__class__ = GitHubBackend
+    app = get_app(backend=mock_backend)
+    gh_client = TestClient(app)
+
+    r = gh_client.post("/missions", json={"spec": "test"})
+    assert r.status_code == 400
+    assert "FileBackend" in r.json()["detail"]
+    assert "v0.6.0" in r.json()["detail"]

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -764,3 +764,26 @@ def test_doctor_thread_not_started_when_disabled(tmp_path, reset_doctor_globals)
     get_app(backend=backend, enable_doctor=False)
 
     assert serve_mod._doctor_thread is None
+
+
+# ---------------------------------------------------------------------------
+# Mission-linked carry (v0.6)
+# ---------------------------------------------------------------------------
+
+
+def test_carry_accepts_mission_id(client):
+    """POST /tasks with mission_id stamps it on the task and links to mission."""
+    # Create a mission first
+    client.post("/missions", json={"mission_id": "m-1", "spec": "test"})
+
+    r = client.post(
+        "/tasks",
+        json={"id": "task-linked", "title": "Linked", "spec": "do it", "mission_id": "m-1"},
+    )
+    assert r.status_code == 201
+
+    task = client.get("/tasks/task-linked").json()
+    assert task["mission_id"] == "m-1"
+
+    mission = client.get("/missions/m-1").json()
+    assert "task-linked" in mission["task_ids"]


### PR DESCRIPTION
## Summary
- 6 new `/missions` endpoints (create, list, get, patch, cancel, report)
- Extend `POST /tasks` with `mission_id` linking via `link_task_to_mission()`
- Extend `GET /tasks` with `?mission_id=` filter
- GitHubBackend preflight (400) on mission creation
- `all_or_nothing` completion_mode warning log
- Colony client mirror methods (6 new + carry extension)

## Test plan
- [x] 16 new tests (14 in test_mission_serve + 1 GitHubBackend + 1 in test_serve)
- [x] 644 tests pass total
- [x] `ruff check .` clean
- [x] Code review: dead code fixed, missing tests added

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)