### PR TITLE
feat(worker): planner mission-mode branch (#164)

### DIFF
--- a/antfarm/core/models.py
+++ b/antfarm/core/models.py
@@ -193,6 +193,9 @@ class TaskArtifact:
     risks: list[str] = field(default_factory=list)
     review_focus: list[str] = field(default_factory=list)
 
+    # Mission-mode plan output (only present on planner tasks in a mission)
+    plan_artifact: dict | None = None
+
     def to_dict(self) -> dict:
         return {
             "task_id": self.task_id,
@@ -219,6 +222,7 @@ class TaskArtifact:
             "summary": self.summary,
             "risks": list(self.risks),
             "review_focus": list(self.review_focus),
+            "plan_artifact": self.plan_artifact,
         }
 
     @classmethod
@@ -248,6 +252,7 @@ class TaskArtifact:
             summary=data.get("summary"),
             risks=list(data.get("risks", [])),
             review_focus=list(data.get("review_focus", [])),
+            plan_artifact=data.get("plan_artifact"),
         )
 
 

--- a/antfarm/core/worker.py
+++ b/antfarm/core/worker.py
@@ -382,13 +382,30 @@ class WorkerRuntime:
                 task, attempt_id, result.stdout + result.stderr
             )
             if plan_result:
-                artifact = {
-                    "plan_task_id": task_id,
-                    "created_task_ids": plan_result["created_ids"],
-                    "task_count": len(plan_result["created_ids"]),
-                    "warnings": plan_result["warnings"],
-                    "dependency_summary": plan_result["dep_summary"],
-                }
+                is_mission_mode = plan_result.get("mission_mode", False)
+                if is_mission_mode:
+                    artifact = {
+                        "plan_task_id": task_id,
+                        "plan_artifact": plan_result["plan_artifact"],
+                        "task_count": plan_result["plan_artifact"]["task_count"],
+                        "warnings": plan_result["warnings"],
+                        "dependency_summary": plan_result["dep_summary"],
+                    }
+                    trail_msg = (
+                        f"plan complete (mission mode): "
+                        f"{plan_result['plan_artifact']['task_count']} tasks proposed"
+                    )
+                else:
+                    artifact = {
+                        "plan_task_id": task_id,
+                        "created_task_ids": plan_result["created_ids"],
+                        "task_count": len(plan_result["created_ids"]),
+                        "warnings": plan_result["warnings"],
+                        "dependency_summary": plan_result["dep_summary"],
+                    }
+                    trail_msg = (
+                        f"plan complete: created {len(plan_result['created_ids'])} tasks"
+                    )
                 with contextlib.suppress(Exception):
                     self.colony.mark_harvest_pending(task_id, attempt_id)
                 with contextlib.suppress(Exception):
@@ -397,10 +414,7 @@ class WorkerRuntime:
                         artifact=artifact,
                     )
                 with contextlib.suppress(Exception):
-                    self.colony.trail(
-                        task_id, self.worker_id,
-                        f"plan complete: created {len(plan_result['created_ids'])} tasks",
-                    )
+                    self.colony.trail(task_id, self.worker_id, trail_msg)
                 return True
 
             # Plan parsing failed — trail the error
@@ -759,7 +773,36 @@ class WorkerRuntime:
         warnings = engine.generate_warnings(plan_result)
         warn_strs = [str(w) for w in warnings] if isinstance(warnings, list) else []
 
-        # Carry each child task
+        # Build dependency summary
+        dep_pairs: list[str] = []
+        for i, t in enumerate(resolved_tasks):
+            for dep in t.depends_on:
+                dep_pairs.append(f"{dep} → {child_ids[i]}")
+        dep_summary = ", ".join(dep_pairs) if dep_pairs else "all parallel"
+
+        # ---- MISSION MODE ----
+        if task.get("mission_id"):
+            from antfarm.core.missions import PlanArtifact as MissionPlanArtifact
+
+            plan_artifact = MissionPlanArtifact(
+                plan_task_id=task["id"],
+                attempt_id=attempt_id,
+                proposed_tasks=[
+                    t.to_carry_dict(child_ids[i])
+                    for i, t in enumerate(resolved_tasks)
+                ],
+                task_count=len(resolved_tasks),
+                warnings=warn_strs,
+                dependency_summary=dep_summary,
+            )
+            return {
+                "mission_mode": True,
+                "plan_artifact": plan_artifact.to_dict(),
+                "warnings": warn_strs,
+                "dep_summary": dep_summary,
+            }
+
+        # ---- LEGACY (non-mission) MODE: carry each child task ----
         created_ids: list[str] = []
         failed_ids: list[str] = []
         for i, proposed_task in enumerate(resolved_tasks):
@@ -811,13 +854,6 @@ class WorkerRuntime:
                     f"{len(failed_ids)} failed: {', '.join(failed_ids)}",
                 )
             return None
-
-        # Build dependency summary
-        dep_pairs: list[str] = []
-        for i, t in enumerate(resolved_tasks):
-            for dep in t.depends_on:
-                dep_pairs.append(f"{dep} → {child_ids[i]}")
-        dep_summary = ", ".join(dep_pairs) if dep_pairs else "all parallel"
 
         return {
             "created_ids": created_ids,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1056,3 +1056,190 @@ def test_planner_prompt_includes_plan_instructions(tmp_path, http_client):
     assert "PLANNER" in prompt
     assert "[PLAN_RESULT]" in prompt
     assert "Maximum 10 tasks" in prompt
+
+
+# ---------------------------------------------------------------------------
+# v0.6.0: Planner mission mode (#164)
+# ---------------------------------------------------------------------------
+
+
+def _carry_mission_plan(tc, task_id="plan-mission", title="Mission Plan", spec="plan this",
+                        mission_id="mission-001"):
+    """Carry a plan task with mission_id set."""
+    # First create the mission so link_task_to_mission works
+    tc.post("/missions", json={"mission_id": mission_id, "spec": "test mission"})
+    r = tc.post("/tasks", json={
+        "id": task_id,
+        "title": title,
+        "spec": spec,
+        "capabilities_required": ["plan"],
+        "mission_id": mission_id,
+    })
+    assert r.status_code == 201
+    return r.json()
+
+
+def test_planner_mission_mode_stores_artifact(tc, tmp_path, http_client):
+    """Plan task with mission_id stores plan_artifact, no children carried."""
+    _carry_mission_plan(tc, task_id="plan-m-001", mission_id="mission-art")
+    rt = _make_planner_runtime(tmp_path, http_client)
+
+    plan_json = _json.dumps([
+        {"title": "Task A", "spec": "do A", "touches": ["api"],
+         "depends_on": [], "priority": 5, "complexity": "S"},
+        {"title": "Task B", "spec": "do B", "touches": ["db"],
+         "depends_on": [1], "priority": 10, "complexity": "M"},
+    ])
+
+    def plan_agent(task, workspace) -> AgentResult:
+        return AgentResult(
+            returncode=0,
+            stdout=_plan_agent_output(plan_json),
+            stderr="",
+            branch="",
+        )
+
+    rt._launch_agent = plan_agent
+    rt.run()
+
+    # Plan task should be harvested (done)
+    r = tc.get("/tasks/plan-m-001")
+    task = r.json()
+    assert task["status"] == "done"
+
+    # Harvest artifact should contain plan_artifact
+    attempt = task["attempts"][0]
+    assert attempt["status"] == "done"
+    artifact = attempt.get("artifact", {})
+    assert artifact is not None
+    assert "plan_artifact" in artifact
+    pa = artifact["plan_artifact"]
+    assert pa["plan_task_id"] == "plan-m-001"
+    assert pa["task_count"] == 2
+    assert len(pa["proposed_tasks"]) == 2
+    assert pa["proposed_tasks"][0]["title"] == "Task A"
+
+    # No children should have been carried
+    r = tc.get("/tasks/task-m-001-01")
+    assert r.status_code == 404
+
+    r = tc.get("/tasks/task-m-001-02")
+    assert r.status_code == 404
+
+    # Trail should mention mission mode
+    messages = [e["message"] for e in task["trail"]]
+    assert any("mission mode" in m for m in messages)
+
+
+def test_planner_legacy_mode_carries_children(tc, tmp_path, http_client):
+    """Plan task without mission_id carries children directly (existing behavior)."""
+    _carry_plan(tc, task_id="plan-legacy")
+    rt = _make_planner_runtime(tmp_path, http_client)
+
+    plan_json = _json.dumps([
+        {"title": "Legacy Child", "spec": "do legacy", "touches": ["api"],
+         "depends_on": [], "priority": 5, "complexity": "S"},
+    ])
+
+    def plan_agent(task, workspace) -> AgentResult:
+        return AgentResult(
+            returncode=0,
+            stdout=_plan_agent_output(plan_json),
+            stderr="",
+            branch="",
+        )
+
+    rt._launch_agent = plan_agent
+    rt.run()
+
+    # Plan task should be done
+    r = tc.get("/tasks/plan-legacy")
+    assert r.json()["status"] == "done"
+
+    # Child task SHOULD have been carried (legacy mode)
+    r = tc.get("/tasks/task-legacy-01")
+    assert r.status_code == 200
+    assert r.json()["title"] == "Legacy Child"
+
+
+def test_planner_mission_mode_invalid_plan_trails_and_no_artifact(tc, tmp_path, http_client):
+    """Mission plan task with invalid plan output trails error, no artifact."""
+    _carry_mission_plan(tc, task_id="plan-m-bad", mission_id="mission-bad")
+    rt = _make_planner_runtime(tmp_path, http_client)
+
+    def plan_agent(task, workspace) -> AgentResult:
+        return AgentResult(
+            returncode=0,
+            stdout="no plan tags here",
+            stderr="",
+            branch="",
+        )
+
+    rt._launch_agent = plan_agent
+    rt.run()
+
+    # Plan task stays active (not harvested)
+    r = tc.get("/tasks/plan-m-bad")
+    task = r.json()
+    assert task["status"] == "active"
+
+    # Trail should mention parsing failure
+    messages = [e["message"] for e in task["trail"]]
+    assert any("could not parse" in m for m in messages)
+
+
+def test_task_artifact_plan_artifact_roundtrip():
+    """TaskArtifact.plan_artifact field roundtrips through to_dict/from_dict."""
+    from antfarm.core.models import TaskArtifact
+
+    plan_data = {
+        "plan_task_id": "plan-rt",
+        "attempt_id": "att-001",
+        "proposed_tasks": [{"title": "T1", "spec": "do T1"}],
+        "task_count": 1,
+        "warnings": ["watch out"],
+        "dependency_summary": "all parallel",
+    }
+
+    art = TaskArtifact(
+        task_id="plan-rt",
+        attempt_id="att-001",
+        worker_id="w1",
+        branch="feat/plan-rt",
+        pr_url=None,
+        base_commit_sha="abc",
+        head_commit_sha="def",
+        target_branch="main",
+        target_branch_sha_at_harvest="ghi",
+        plan_artifact=plan_data,
+    )
+
+    d = art.to_dict()
+    assert d["plan_artifact"] == plan_data
+
+    restored = TaskArtifact.from_dict(d)
+    assert restored.plan_artifact == plan_data
+
+
+def test_task_artifact_plan_artifact_none_by_default():
+    """TaskArtifact.plan_artifact is None by default (non-plan tasks)."""
+    from antfarm.core.models import TaskArtifact
+
+    art = TaskArtifact(
+        task_id="t1",
+        attempt_id="att-001",
+        worker_id="w1",
+        branch="feat/t1",
+        pr_url=None,
+        base_commit_sha="abc",
+        head_commit_sha="def",
+        target_branch="main",
+        target_branch_sha_at_harvest="ghi",
+    )
+
+    assert art.plan_artifact is None
+    d = art.to_dict()
+    assert d["plan_artifact"] is None
+
+    restored = TaskArtifact.from_dict(d)
+    assert restored.plan_artifact is None


### PR DESCRIPTION
## Summary
- Planner stores plan as PlanArtifact on attempt when task has `mission_id` (mission-mode)
- Non-mission plans retain existing carry-children behavior (backwards compatible)
- Added `plan_artifact` field to TaskArtifact model

## Test plan
- [x] 5 new tests, 653 total pass, ruff clean
- [x] Code review: APPROVED

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)