### PR TITLE
feat(soldier): propagate mission_id + mission report generator (#165, #166)

### DIFF
--- a/antfarm/core/report.py
+++ b/antfarm/core/report.py
@@ -1,0 +1,422 @@
+"""Mission report generator and renderers.
+
+DEPENDENCY-FREE MODULE. Imports only from stdlib (textwrap, json, pathlib)
+and antfarm.core.missions. MUST NOT import rich, colorama, or any TUI
+framework — the morning digest must run headless in CI/cron.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from datetime import UTC, datetime
+from pathlib import Path
+
+from antfarm.core.missions import (
+    MissionReport,
+    MissionReportBlocked,
+    MissionReportTask,
+    MissionStatus,
+    is_infra_task,
+)
+
+
+def build_report(mission: dict, tasks: list[dict]) -> MissionReport:
+    """Build a MissionReport from a mission dict and its child task dicts.
+
+    Pure function. No I/O. Reads attempts/artifacts for line counts and PR URLs.
+    Surfaces failure-reason prefixes (``"system: "`` vs ``"review: "``) on
+    ``MissionReportBlocked.reason`` so the terminal/markdown renderers can
+    distinguish infra failures from content rejections.
+    """
+    config = mission.get("config", {})
+    completion_mode = config.get("completion_mode", "best_effort")
+
+    # Partition tasks: infra (plan/review) vs impl (builder work)
+    impl_tasks = [t for t in tasks if not is_infra_task(t)]
+    review_tasks = [t for t in tasks if is_infra_task(t)]
+
+    # Merged impl tasks
+    merged: list[MissionReportTask] = []
+    blocked: list[MissionReportBlocked] = []
+    all_pr_urls: list[str] = []
+    all_branches: list[str] = []
+    all_files_changed: list[str] = []
+    total_lines_added = 0
+    total_lines_removed = 0
+    all_risks: list[str] = []
+
+    for task in impl_tasks:
+        attempts = task.get("attempts", [])
+        merged_attempt = _find_merged_attempt(attempts)
+        if merged_attempt is not None:
+            artifact = merged_attempt.get("artifact", {}) or {}
+            pr_url = artifact.get("pr_url") or merged_attempt.get("pr")
+            lines_added = artifact.get("lines_added", 0)
+            lines_removed = artifact.get("lines_removed", 0)
+            files_changed = artifact.get("files_changed", [])
+            risks = artifact.get("risks", [])
+
+            merged.append(MissionReportTask(
+                task_id=task["id"],
+                title=task.get("title", ""),
+                pr_url=pr_url,
+                lines_added=lines_added,
+                lines_removed=lines_removed,
+                files_changed=list(files_changed),
+            ))
+            if pr_url:
+                all_pr_urls.append(pr_url)
+            branch = merged_attempt.get("branch")
+            if branch:
+                all_branches.append(branch)
+            all_files_changed.extend(files_changed)
+            total_lines_added += lines_added
+            total_lines_removed += lines_removed
+            all_risks.extend(risks)
+
+        elif task.get("status") == "blocked":
+            reason = _extract_blocked_reason(task)
+            attempt_count = len(attempts)
+            last_failure_type = _extract_last_failure_type(task)
+            blocked.append(MissionReportBlocked(
+                task_id=task["id"],
+                title=task.get("title", ""),
+                reason=reason,
+                attempt_count=attempt_count,
+                last_failure_type=last_failure_type,
+            ))
+
+    # Failed reviews: review tasks with verdict needs_changes or blocked
+    failed_reviews = 0
+    for task in review_tasks:
+        attempts = task.get("attempts", [])
+        for attempt in attempts:
+            verdict = attempt.get("review_verdict", {}) or {}
+            if verdict.get("verdict") in ("needs_changes", "blocked"):
+                failed_reviews += 1
+                break
+
+    # Duration
+    created_at = mission.get("created_at", "")
+    completed_at = mission.get("completed_at")
+    duration_minutes = _compute_duration_minutes(created_at, completed_at)
+
+    # Deduplicate files_changed
+    seen_files: set[str] = set()
+    unique_files: list[str] = []
+    for f in all_files_changed:
+        if f not in seen_files:
+            seen_files.add(f)
+            unique_files.append(f)
+
+    return MissionReport(
+        mission_id=mission["mission_id"],
+        spec_summary=mission.get("spec", "")[:200],
+        status=MissionStatus(mission["status"]),
+        completion_mode=completion_mode,
+        duration_minutes=duration_minutes,
+        total_tasks=len(impl_tasks),
+        merged_tasks=len(merged),
+        blocked_tasks=len(blocked),
+        failed_reviews=failed_reviews,
+        merged=merged,
+        blocked=blocked,
+        risks=all_risks,
+        pr_urls=all_pr_urls,
+        branches=all_branches,
+        total_lines_added=total_lines_added,
+        total_lines_removed=total_lines_removed,
+        files_changed=unique_files,
+        generated_at=datetime.now(UTC).isoformat() + "Z",
+    )
+
+
+def render_json(report: MissionReport) -> str:
+    """Return the report as a JSON string."""
+    return json.dumps(report.to_dict(), indent=2)
+
+
+def render_terminal(report: MissionReport, use_rich: bool = False) -> str:
+    """Return a plain-text string suitable for stdout printing.
+
+    v0.6.0: ``use_rich`` MUST be False. The parameter exists as a
+    forward-compat hook — a future version can lazy-import ``rich``
+    inside the method to enable colour output without a dependency bump
+    or breaking headless callers.
+
+    Uses only ``textwrap`` from the stdlib. 80-column wrap by default.
+    """
+    if use_rich:
+        raise NotImplementedError(
+            "rich rendering is a v0.6.1+ opt-in; v0.6.0 is dependency-free"
+        )
+
+    lines: list[str] = []
+    width = 80
+    sep = "=" * width
+
+    lines.append(sep)
+    lines.append(f"Mission Report: {report.mission_id}")
+    lines.append(sep)
+    lines.append("")
+
+    lines.append(f"Status:          {report.status.value}")
+    lines.append(f"Completion mode: {report.completion_mode}")
+    if report.completion_mode == "all_or_nothing":
+        lines.append("  WARNING: all_or_nothing — any blocked task fails the entire mission")
+    lines.append(f"Duration:        {report.duration_minutes:.1f} minutes")
+    lines.append(f"Generated at:    {report.generated_at}")
+    lines.append("")
+
+    # Summary
+    lines.append(f"Tasks: {report.total_tasks} total, "
+                 f"{report.merged_tasks} merged, "
+                 f"{report.blocked_tasks} blocked")
+    if report.failed_reviews:
+        lines.append(f"Failed reviews: {report.failed_reviews}")
+    lines.append(f"Lines: +{report.total_lines_added} / -{report.total_lines_removed}")
+    lines.append(f"Files changed: {len(report.files_changed)}")
+    lines.append("")
+
+    # Spec summary
+    if report.spec_summary:
+        lines.append("Spec summary:")
+        for wrapped in textwrap.wrap(report.spec_summary, width=width - 2):
+            lines.append(f"  {wrapped}")
+        lines.append("")
+
+    # Cancelled mission: show completed tasks section
+    if report.status == MissionStatus.CANCELLED and report.merged:
+        lines.append("-" * width)
+        lines.append("Completed before cancellation:")
+        lines.append("-" * width)
+        for mt in report.merged:
+            pr_str = f"  PR: {mt.pr_url}" if mt.pr_url else ""
+            lines.append(f"  [{mt.task_id}] {mt.title}{pr_str}")
+            lines.append(f"    +{mt.lines_added} / -{mt.lines_removed}, "
+                         f"{len(mt.files_changed)} files")
+        lines.append("")
+
+    # Merged tasks (non-cancelled)
+    if report.status != MissionStatus.CANCELLED and report.merged:
+        lines.append("-" * width)
+        lines.append("Merged tasks:")
+        lines.append("-" * width)
+        for mt in report.merged:
+            pr_str = f"  PR: {mt.pr_url}" if mt.pr_url else ""
+            lines.append(f"  [{mt.task_id}] {mt.title}{pr_str}")
+            lines.append(f"    +{mt.lines_added} / -{mt.lines_removed}, "
+                         f"{len(mt.files_changed)} files")
+        lines.append("")
+
+    # Blocked tasks
+    if report.blocked:
+        lines.append("-" * width)
+        lines.append("Blocked tasks:")
+        lines.append("-" * width)
+        for bt in report.blocked:
+            tag = _failure_tag_terminal(bt.reason)
+            lines.append(f"  {tag} [{bt.task_id}] {bt.title}")
+            reason_text = bt.reason
+            for wrapped in textwrap.wrap(reason_text, width=width - 6):
+                lines.append(f"      {wrapped}")
+            lines.append(f"      Attempts: {bt.attempt_count}")
+            if bt.last_failure_type:
+                lines.append(f"      Failure type: {bt.last_failure_type}")
+        lines.append("")
+
+    # Risks
+    if report.risks:
+        lines.append("-" * width)
+        lines.append("Risks:")
+        lines.append("-" * width)
+        for risk in report.risks:
+            for wrapped in textwrap.wrap(risk, width=width - 4):
+                lines.append(f"  - {wrapped}")
+        lines.append("")
+
+    # PR URLs
+    if report.pr_urls:
+        lines.append("-" * width)
+        lines.append("Pull requests:")
+        lines.append("-" * width)
+        for url in report.pr_urls:
+            lines.append(f"  {url}")
+        lines.append("")
+
+    lines.append(sep)
+    return "\n".join(lines)
+
+
+def render_markdown(report: MissionReport) -> str:
+    """Return a markdown string suitable for pasting into GitHub issues/PRs."""
+    lines: list[str] = []
+
+    lines.append(f"# Mission Report: {report.mission_id}")
+    lines.append("")
+
+    lines.append(f"**Status:** {report.status.value}")
+    lines.append(f"**Completion mode:** {report.completion_mode}")
+    if report.completion_mode == "all_or_nothing":
+        lines.append("> **Warning:** `all_or_nothing` — any blocked task fails the entire mission")
+    lines.append(f"**Duration:** {report.duration_minutes:.1f} minutes")
+    lines.append(f"**Generated:** {report.generated_at}")
+    lines.append("")
+
+    # Summary table
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|--------|-------|")
+    lines.append(f"| Total tasks | {report.total_tasks} |")
+    lines.append(f"| Merged | {report.merged_tasks} |")
+    lines.append(f"| Blocked | {report.blocked_tasks} |")
+    if report.failed_reviews:
+        lines.append(f"| Failed reviews | {report.failed_reviews} |")
+    lines.append(f"| Lines added | +{report.total_lines_added} |")
+    lines.append(f"| Lines removed | -{report.total_lines_removed} |")
+    lines.append(f"| Files changed | {len(report.files_changed)} |")
+    lines.append("")
+
+    # Cancelled mission: completed before cancellation
+    if report.status == MissionStatus.CANCELLED and report.merged:
+        lines.append("## Completed before cancellation")
+        lines.append("")
+        for mt in report.merged:
+            pr_link = f" ([PR]({mt.pr_url}))" if mt.pr_url else ""
+            lines.append(f"- **{mt.task_id}**: {mt.title}{pr_link}")
+            lines.append(f"  - +{mt.lines_added} / -{mt.lines_removed}, "
+                         f"{len(mt.files_changed)} files")
+        lines.append("")
+
+    # Merged tasks (non-cancelled)
+    if report.status != MissionStatus.CANCELLED and report.merged:
+        lines.append("## Merged tasks")
+        lines.append("")
+        for mt in report.merged:
+            pr_link = f" ([PR]({mt.pr_url}))" if mt.pr_url else ""
+            lines.append(f"- **{mt.task_id}**: {mt.title}{pr_link}")
+            lines.append(f"  - +{mt.lines_added} / -{mt.lines_removed}, "
+                         f"{len(mt.files_changed)} files")
+        lines.append("")
+
+    # Blocked tasks
+    if report.blocked:
+        lines.append("## Blocked tasks")
+        lines.append("")
+        for bt in report.blocked:
+            badge = _failure_badge_markdown(bt.reason)
+            lines.append(f"- {badge} **{bt.task_id}**: {bt.title}")
+            lines.append(f"  - Reason: {bt.reason}")
+            lines.append(f"  - Attempts: {bt.attempt_count}")
+            if bt.last_failure_type:
+                lines.append(f"  - Failure type: {bt.last_failure_type}")
+        lines.append("")
+
+    # Risks
+    if report.risks:
+        lines.append("## Risks")
+        lines.append("")
+        for risk in report.risks:
+            lines.append(f"- {risk}")
+        lines.append("")
+
+    # PR URLs
+    if report.pr_urls:
+        lines.append("## Pull requests")
+        lines.append("")
+        for url in report.pr_urls:
+            lines.append(f"- {url}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def save_report(data_dir: str, mission_id: str, report: MissionReport) -> str:
+    """Write report JSON to .antfarm/missions/{mission_id}_report.json.
+
+    Returns the path written.
+    """
+    missions_dir = Path(data_dir) / "missions"
+    missions_dir.mkdir(parents=True, exist_ok=True)
+    path = missions_dir / f"{mission_id}_report.json"
+    path.write_text(json.dumps(report.to_dict(), indent=2) + "\n")
+    return str(path)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_merged_attempt(attempts: list[dict]) -> dict | None:
+    """Return the first attempt with status 'merged', or None."""
+    for attempt in attempts:
+        if attempt.get("status") == "merged":
+            return attempt
+    return None
+
+
+def _extract_blocked_reason(task: dict) -> str:
+    """Extract the failure reason from the last trail entry of a blocked task."""
+    trail = task.get("trail", [])
+    if trail:
+        return trail[-1].get("message", "unknown")
+    return "unknown"
+
+
+def _extract_last_failure_type(task: dict) -> str | None:
+    """Extract the last failure type from a task's attempts."""
+    attempts = task.get("attempts", [])
+    for attempt in reversed(attempts):
+        artifact = attempt.get("artifact", {}) or {}
+        # Check for failure_record in the artifact
+        if "failure_type" in artifact:
+            return artifact["failure_type"]
+    # Check trail for failure records
+    trail = task.get("trail", [])
+    for entry in reversed(trail):
+        msg = entry.get("message", "")
+        if msg.startswith("system: "):
+            return "system"
+        if msg.startswith("review: "):
+            return "review"
+    return None
+
+
+def _compute_duration_minutes(created_at: str, completed_at: str | None) -> float:
+    """Compute duration in minutes between created_at and completed_at (or now)."""
+    if not created_at:
+        return 0.0
+    try:
+        start = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return 0.0
+    if completed_at:
+        try:
+            end = datetime.fromisoformat(completed_at.replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            end = datetime.now(UTC)
+    else:
+        end = datetime.now(UTC)
+    delta = end - start
+    return max(0.0, delta.total_seconds() / 60)
+
+
+def _failure_tag_terminal(reason: str) -> str:
+    """Return a terminal tag for the failure reason prefix."""
+    if reason.startswith("system: "):
+        return "[SYSTEM]"
+    if reason.startswith("review: "):
+        return "[REVIEW]"
+    return "[FAILED]"
+
+
+def _failure_badge_markdown(reason: str) -> str:
+    """Return a markdown badge for the failure reason prefix."""
+    if reason.startswith("system: "):
+        return "`[SYSTEM]`"
+    if reason.startswith("review: "):
+        return "`[REVIEW]`"
+    return "`[FAILED]`"

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -673,11 +673,25 @@ class Soldier:
 
         Idempotent: if review-{task_id} already exists, returns None without error.
         Includes review pack in the spec when artifact is available.
+        Propagates mission_id from the parent task to the review task.
+        Suppresses review-task creation when the parent mission is CANCELLED.
 
         Returns the review task ID, or None if creation failed or already exists.
         """
         task_id = task["id"]
         review_task_id = f"review-{task_id}"
+
+        # Suppress review-task creation for cancelled missions
+        parent_mission_id = task.get("mission_id")
+        if parent_mission_id:
+            mission = self.colony.get_mission(parent_mission_id)
+            if mission is not None and mission.get("status") == "cancelled":
+                logger.info(
+                    "suppressing review task for %s: mission %s is cancelled",
+                    task_id,
+                    parent_mission_id,
+                )
+                return None
 
         # Idempotency: skip if review task already exists
         existing = self.colony.get_task(review_task_id)
@@ -730,6 +744,7 @@ class Soldier:
                 priority=1,
                 complexity="S",
                 capabilities_required=["review"],
+                mission_id=parent_mission_id,
             )
             return review_task_id
         except Exception:
@@ -783,6 +798,7 @@ class _BackendAdapter:
         from datetime import UTC, datetime
 
         now = datetime.now(UTC).isoformat()
+        mission_id = kwargs.get("mission_id")
         task = {
             "id": kwargs.get("task_id", ""),
             "title": kwargs.get("title", ""),
@@ -792,6 +808,7 @@ class _BackendAdapter:
             "depends_on": kwargs.get("depends_on") or [],
             "touches": kwargs.get("touches") or [],
             "capabilities_required": kwargs.get("capabilities_required") or [],
+            "mission_id": mission_id,
             "created_by": "soldier",
             "status": "ready",
             "current_attempt": None,
@@ -801,7 +818,12 @@ class _BackendAdapter:
             "created_at": now,
             "updated_at": now,
         }
-        task_id = self._backend.carry(task)
+        if mission_id:
+            from antfarm.core.missions import link_task_to_mission
+
+            task_id = link_task_to_mission(self._backend, task, mission_id)
+        else:
+            task_id = self._backend.carry(task)
         return {"task_id": task_id}
 
     def mark_merged(self, task_id: str, attempt_id: str) -> None:
@@ -814,3 +836,6 @@ class _BackendAdapter:
         self, task_id: str, attempt_id: str, verdict: dict
     ) -> None:
         self._backend.store_review_verdict(task_id, attempt_id, verdict)
+
+    def get_mission(self, mission_id: str) -> dict | None:
+        return self._backend.get_mission(mission_id)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,565 @@
+"""Tests for antfarm.core.report — mission report generator and renderers."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from antfarm.core.missions import (
+    MissionReport,
+    MissionReportBlocked,
+    MissionReportTask,
+    MissionStatus,
+)
+from antfarm.core.report import (
+    build_report,
+    render_json,
+    render_markdown,
+    render_terminal,
+    save_report,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mission(
+    mission_id: str = "mission-001",
+    status: str = "complete",
+    task_ids: list[str] | None = None,
+    spec: str = "Build the widget",
+    created_at: str = "2026-04-01T00:00:00Z",
+    completed_at: str | None = "2026-04-01T01:30:00Z",
+    completion_mode: str = "best_effort",
+) -> dict:
+    return {
+        "mission_id": mission_id,
+        "spec": spec,
+        "status": status,
+        "task_ids": task_ids or [],
+        "config": {"completion_mode": completion_mode},
+        "created_at": created_at,
+        "completed_at": completed_at,
+        "updated_at": completed_at or created_at,
+        "blocked_task_ids": [],
+    }
+
+
+def _make_task(
+    task_id: str,
+    title: str = "Do something",
+    status: str = "done",
+    attempts: list[dict] | None = None,
+    trail: list[dict] | None = None,
+    capabilities_required: list[str] | None = None,
+) -> dict:
+    return {
+        "id": task_id,
+        "title": title,
+        "status": status,
+        "attempts": attempts or [],
+        "trail": trail or [],
+        "capabilities_required": capabilities_required or [],
+    }
+
+
+def _make_attempt(
+    attempt_id: str = "att-001",
+    status: str = "merged",
+    branch: str | None = "feat/task-001",
+    pr: str | None = None,
+    artifact: dict | None = None,
+    review_verdict: dict | None = None,
+) -> dict:
+    d: dict = {
+        "attempt_id": attempt_id,
+        "worker_id": "node-1/claude-1",
+        "status": status,
+        "branch": branch,
+        "pr": pr,
+        "started_at": "2026-04-01T00:00:00Z",
+        "completed_at": "2026-04-01T00:30:00Z",
+    }
+    if artifact is not None:
+        d["artifact"] = artifact
+    if review_verdict is not None:
+        d["review_verdict"] = review_verdict
+    return d
+
+
+def _make_artifact(
+    pr_url: str | None = "https://github.com/org/repo/pull/1",
+    lines_added: int = 100,
+    lines_removed: int = 20,
+    files_changed: list[str] | None = None,
+    risks: list[str] | None = None,
+) -> dict:
+    return {
+        "pr_url": pr_url,
+        "lines_added": lines_added,
+        "lines_removed": lines_removed,
+        "files_changed": files_changed or ["src/main.py"],
+        "risks": risks or [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. test_build_report_empty_mission
+# ---------------------------------------------------------------------------
+
+
+def test_build_report_empty_mission():
+    mission = _make_mission(task_ids=[])
+    report = build_report(mission, [])
+    assert report.mission_id == "mission-001"
+    assert report.total_tasks == 0
+    assert report.merged_tasks == 0
+    assert report.blocked_tasks == 0
+    assert report.merged == []
+    assert report.blocked == []
+
+
+# ---------------------------------------------------------------------------
+# 2. test_build_report_all_merged
+# ---------------------------------------------------------------------------
+
+
+def test_build_report_all_merged():
+    tasks = [
+        _make_task(
+            "task-001",
+            title="Widget A",
+            attempts=[_make_attempt(artifact=_make_artifact(lines_added=50, lines_removed=10))],
+        ),
+        _make_task(
+            "task-002",
+            title="Widget B",
+            attempts=[_make_attempt(
+                attempt_id="att-002",
+                artifact=_make_artifact(
+                    pr_url="https://github.com/org/repo/pull/2",
+                    lines_added=30,
+                    lines_removed=5,
+                    files_changed=["src/other.py"],
+                ),
+            )],
+        ),
+    ]
+    mission = _make_mission(task_ids=["task-001", "task-002"])
+    report = build_report(mission, tasks)
+    assert report.total_tasks == 2
+    assert report.merged_tasks == 2
+    assert report.blocked_tasks == 0
+    assert len(report.merged) == 2
+    assert report.total_lines_added == 80
+    assert report.total_lines_removed == 15
+
+
+# ---------------------------------------------------------------------------
+# 3. test_build_report_mixed_merged_blocked
+# ---------------------------------------------------------------------------
+
+
+def test_build_report_mixed_merged_blocked():
+    tasks = [
+        _make_task(
+            "task-001",
+            title="Done task",
+            attempts=[_make_attempt(artifact=_make_artifact())],
+        ),
+        _make_task(
+            "task-002",
+            title="Stuck task",
+            status="blocked",
+            attempts=[
+                _make_attempt(attempt_id="att-002", status="superseded"),
+                _make_attempt(attempt_id="att-003", status="superseded"),
+            ],
+            trail=[{"ts": "2026-04-01T01:00:00Z", "worker_id": "w", "message": "system: OOM"}],
+        ),
+    ]
+    mission = _make_mission(task_ids=["task-001", "task-002"])
+    report = build_report(mission, tasks)
+    assert report.merged_tasks == 1
+    assert report.blocked_tasks == 1
+    assert report.blocked[0].reason == "system: OOM"
+    assert report.blocked[0].attempt_count == 2
+
+
+# ---------------------------------------------------------------------------
+# 4. test_build_report_skips_plan_and_review_tasks_from_total
+# ---------------------------------------------------------------------------
+
+
+def test_build_report_skips_plan_and_review_tasks_from_total():
+    tasks = [
+        _make_task("task-001", title="Impl task", capabilities_required=[]),
+        _make_task("plan-001", title="Plan task", capabilities_required=["plan"]),
+        _make_task("review-plan-001", title="Review task", capabilities_required=["review"]),
+    ]
+    mission = _make_mission(task_ids=["task-001", "plan-001", "review-plan-001"])
+    report = build_report(mission, tasks)
+    # Only task-001 is an impl task
+    assert report.total_tasks == 1
+
+
+# ---------------------------------------------------------------------------
+# 5. test_build_report_aggregates_lines_added_removed
+# ---------------------------------------------------------------------------
+
+
+def test_build_report_aggregates_lines_added_removed():
+    tasks = [
+        _make_task(
+            "task-001",
+            attempts=[_make_attempt(artifact=_make_artifact(lines_added=100, lines_removed=20))],
+        ),
+        _make_task(
+            "task-002",
+            attempts=[_make_attempt(
+                attempt_id="att-002",
+                artifact=_make_artifact(lines_added=200, lines_removed=50),
+            )],
+        ),
+    ]
+    mission = _make_mission(task_ids=["task-001", "task-002"])
+    report = build_report(mission, tasks)
+    assert report.total_lines_added == 300
+    assert report.total_lines_removed == 70
+
+
+# ---------------------------------------------------------------------------
+# 6. test_build_report_collects_pr_urls_from_artifacts
+# ---------------------------------------------------------------------------
+
+
+def test_build_report_collects_pr_urls_from_artifacts():
+    tasks = [
+        _make_task(
+            "task-001",
+            attempts=[_make_attempt(artifact=_make_artifact(
+                pr_url="https://github.com/org/repo/pull/1",
+            ))],
+        ),
+        _make_task(
+            "task-002",
+            attempts=[_make_attempt(
+                attempt_id="att-002",
+                artifact=_make_artifact(pr_url="https://github.com/org/repo/pull/2"),
+            )],
+        ),
+    ]
+    mission = _make_mission(task_ids=["task-001", "task-002"])
+    report = build_report(mission, tasks)
+    assert len(report.pr_urls) == 2
+    assert "https://github.com/org/repo/pull/1" in report.pr_urls
+    assert "https://github.com/org/repo/pull/2" in report.pr_urls
+
+
+# ---------------------------------------------------------------------------
+# 7. test_build_report_blocked_pulls_reason_from_trail
+# ---------------------------------------------------------------------------
+
+
+def test_build_report_blocked_pulls_reason_from_trail():
+    tasks = [
+        _make_task(
+            "task-001",
+            title="Broken task",
+            status="blocked",
+            attempts=[_make_attempt(attempt_id="att-001", status="superseded")],
+            trail=[
+                {"ts": "t1", "worker_id": "w", "message": "started work"},
+                {"ts": "t2", "worker_id": "w", "message": "review: code does not meet standards"},
+            ],
+        ),
+    ]
+    mission = _make_mission(task_ids=["task-001"])
+    report = build_report(mission, tasks)
+    assert report.blocked_tasks == 1
+    assert report.blocked[0].reason == "review: code does not meet standards"
+
+
+# ---------------------------------------------------------------------------
+# 8. test_render_terminal_smoke
+# ---------------------------------------------------------------------------
+
+
+def test_render_terminal_smoke():
+    report = MissionReport(
+        mission_id="mission-001",
+        spec_summary="Build widget",
+        status=MissionStatus.COMPLETE,
+        completion_mode="best_effort",
+        duration_minutes=90.0,
+        total_tasks=3,
+        merged_tasks=2,
+        blocked_tasks=1,
+        failed_reviews=0,
+        merged=[
+            MissionReportTask("t-1", "Task 1", "https://github.com/pr/1", 100, 10, ["a.py"]),
+        ],
+        blocked=[
+            MissionReportBlocked("t-2", "Task 2", "system: OOM", 3, "agent_crash"),
+        ],
+        generated_at="2026-04-01T01:30:00Z",
+    )
+    output = render_terminal(report)
+    assert "mission-001" in output
+    assert "90.0 minutes" in output
+    assert "best_effort" in output
+
+
+# ---------------------------------------------------------------------------
+# 9. test_render_terminal_distinguishes_system_vs_review_prefix
+# ---------------------------------------------------------------------------
+
+
+def test_render_terminal_distinguishes_system_vs_review_prefix():
+    report = MissionReport(
+        mission_id="m-1",
+        spec_summary="",
+        status=MissionStatus.COMPLETE,
+        completion_mode="best_effort",
+        duration_minutes=10.0,
+        total_tasks=2,
+        merged_tasks=0,
+        blocked_tasks=2,
+        failed_reviews=0,
+        blocked=[
+            MissionReportBlocked("t-1", "Task 1", "system: worker crashed", 2, None),
+            MissionReportBlocked("t-2", "Task 2", "review: code quality too low", 1, None),
+        ],
+        generated_at="2026-04-01T00:10:00Z",
+    )
+    output = render_terminal(report)
+    assert "[SYSTEM]" in output
+    assert "[REVIEW]" in output
+
+
+# ---------------------------------------------------------------------------
+# 10. test_render_terminal_use_rich_raises_not_implemented
+# ---------------------------------------------------------------------------
+
+
+def test_render_terminal_use_rich_raises_not_implemented():
+    report = MissionReport(
+        mission_id="m-1",
+        spec_summary="",
+        status=MissionStatus.COMPLETE,
+        completion_mode="best_effort",
+        duration_minutes=0,
+        total_tasks=0,
+        merged_tasks=0,
+        blocked_tasks=0,
+        failed_reviews=0,
+        generated_at="",
+    )
+    with pytest.raises(NotImplementedError, match="rich rendering"):
+        render_terminal(report, use_rich=True)
+
+
+# ---------------------------------------------------------------------------
+# 11. test_render_terminal_no_rich_import
+# ---------------------------------------------------------------------------
+
+
+def test_render_terminal_no_rich_import():
+    """Importing antfarm.core.report must not pull in rich."""
+    import subprocess
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import antfarm.core.report; import sys; "
+            "sys.exit(1 if 'rich' in sys.modules else 0)",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "rich was imported as a side-effect of importing antfarm.core.report"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 12. test_render_markdown_smoke
+# ---------------------------------------------------------------------------
+
+
+def test_render_markdown_smoke():
+    report = MissionReport(
+        mission_id="mission-001",
+        spec_summary="Build widget",
+        status=MissionStatus.COMPLETE,
+        completion_mode="best_effort",
+        duration_minutes=90.0,
+        total_tasks=2,
+        merged_tasks=2,
+        blocked_tasks=0,
+        failed_reviews=0,
+        merged=[
+            MissionReportTask("t-1", "Task 1", "https://github.com/pr/1", 100, 10, ["a.py"]),
+            MissionReportTask("t-2", "Task 2", "https://github.com/pr/2", 50, 5, ["b.py"]),
+        ],
+        pr_urls=["https://github.com/pr/1", "https://github.com/pr/2"],
+        generated_at="2026-04-01T01:30:00Z",
+    )
+    output = render_markdown(report)
+    assert "# Mission Report" in output
+    assert "https://github.com/pr/1" in output
+    assert "https://github.com/pr/2" in output
+
+
+# ---------------------------------------------------------------------------
+# 13. test_render_markdown_distinguishes_system_vs_review_prefix
+# ---------------------------------------------------------------------------
+
+
+def test_render_markdown_distinguishes_system_vs_review_prefix():
+    report = MissionReport(
+        mission_id="m-1",
+        spec_summary="",
+        status=MissionStatus.COMPLETE,
+        completion_mode="best_effort",
+        duration_minutes=10.0,
+        total_tasks=2,
+        merged_tasks=0,
+        blocked_tasks=2,
+        failed_reviews=0,
+        blocked=[
+            MissionReportBlocked("t-1", "Task 1", "system: worker crashed", 2, None),
+            MissionReportBlocked("t-2", "Task 2", "review: code quality too low", 1, None),
+        ],
+        generated_at="2026-04-01T00:10:00Z",
+    )
+    output = render_markdown(report)
+    assert "`[SYSTEM]`" in output
+    assert "`[REVIEW]`" in output
+
+
+# ---------------------------------------------------------------------------
+# 14. test_save_report_writes_json_file
+# ---------------------------------------------------------------------------
+
+
+def test_save_report_writes_json_file(tmp_path):
+    report = MissionReport(
+        mission_id="mission-001",
+        spec_summary="test",
+        status=MissionStatus.COMPLETE,
+        completion_mode="best_effort",
+        duration_minutes=5.0,
+        total_tasks=1,
+        merged_tasks=1,
+        blocked_tasks=0,
+        failed_reviews=0,
+        generated_at="2026-04-01T00:05:00Z",
+    )
+    path = save_report(str(tmp_path), "mission-001", report)
+    assert (tmp_path / "missions" / "mission-001_report.json").exists()
+    data = json.loads((tmp_path / "missions" / "mission-001_report.json").read_text())
+    assert data["mission_id"] == "mission-001"
+    assert data["completion_mode"] == "best_effort"
+    assert path == str(tmp_path / "missions" / "mission-001_report.json")
+
+
+# ---------------------------------------------------------------------------
+# 15. test_cancelled_mission_report_includes_completed_tasks
+# ---------------------------------------------------------------------------
+
+
+def test_cancelled_mission_report_includes_completed_tasks():
+    tasks = [
+        _make_task(
+            f"task-{i:03d}",
+            title=f"Task {i}",
+            attempts=[_make_attempt(
+                attempt_id=f"att-{i:03d}",
+                artifact=_make_artifact(pr_url=f"https://github.com/pr/{i}"),
+            )],
+        )
+        for i in range(1, 4)  # 3 merged
+    ] + [
+        _make_task(f"task-{i:03d}", title=f"Task {i}", status="ready")
+        for i in range(4, 6)  # 2 not yet done
+    ]
+    mission = _make_mission(
+        task_ids=[f"task-{i:03d}" for i in range(1, 6)],
+        status="cancelled",
+    )
+    report = build_report(mission, tasks)
+    assert report.status == MissionStatus.CANCELLED
+    assert report.merged_tasks == 3
+    assert report.total_tasks == 5
+
+    # Terminal rendering should show "Completed before cancellation"
+    terminal_output = render_terminal(report)
+    assert "Completed before cancellation" in terminal_output
+    assert "task-001" in terminal_output
+
+    # Markdown rendering should show the same
+    md_output = render_markdown(report)
+    assert "Completed before cancellation" in md_output
+
+
+# ---------------------------------------------------------------------------
+# 16. test_report_includes_completion_mode
+# ---------------------------------------------------------------------------
+
+
+def test_report_includes_completion_mode():
+    tasks = [
+        _make_task(
+            "task-001",
+            attempts=[_make_attempt(artifact=_make_artifact())],
+        ),
+    ]
+    mission = _make_mission(
+        task_ids=["task-001"],
+        completion_mode="all_or_nothing",
+    )
+    report = build_report(mission, tasks)
+    assert report.completion_mode == "all_or_nothing"
+
+    # JSON output includes completion_mode
+    json_output = render_json(report)
+    data = json.loads(json_output)
+    assert data["completion_mode"] == "all_or_nothing"
+
+    # Terminal output includes completion_mode and warning
+    terminal_output = render_terminal(report)
+    assert "all_or_nothing" in terminal_output
+    assert "WARNING" in terminal_output
+
+
+# ---------------------------------------------------------------------------
+# Extra: test_report_distinguishes_system_vs_review_prefix (build_report level)
+# ---------------------------------------------------------------------------
+
+
+def test_report_distinguishes_system_vs_review_prefix():
+    """Verify build_report preserves system: and review: prefixes in reasons."""
+    tasks = [
+        _make_task(
+            "task-001",
+            status="blocked",
+            trail=[{"ts": "t1", "worker_id": "w", "message": "system: OOM killed"}],
+            attempts=[_make_attempt(status="superseded")],
+        ),
+        _make_task(
+            "task-002",
+            status="blocked",
+            trail=[{"ts": "t1", "worker_id": "w", "message": "review: rejected by reviewer"}],
+            attempts=[_make_attempt(attempt_id="att-002", status="superseded")],
+        ),
+    ]
+    mission = _make_mission(task_ids=["task-001", "task-002"])
+    report = build_report(mission, tasks)
+    reasons = [b.reason for b in report.blocked]
+    assert any(r.startswith("system: ") for r in reasons)
+    assert any(r.startswith("review: ") for r in reasons)

--- a/tests/test_soldier.py
+++ b/tests/test_soldier.py
@@ -636,3 +636,173 @@ def test_cascade_does_not_affect_independent(soldier_env):
 
     assert cc.get_task("task-ind-a")["status"] == "ready"
     assert cc.get_task("task-ind-b")["status"] == "done"  # untouched
+
+
+# ---------------------------------------------------------------------------
+# Mission-ID propagation tests
+# ---------------------------------------------------------------------------
+
+
+def _make_mission(backend, mission_id, status="building"):
+    """Helper to create a mission directly in the backend."""
+    from datetime import UTC, datetime
+
+    now = datetime.now(UTC).isoformat()
+    mission = {
+        "mission_id": mission_id,
+        "spec": "test spec",
+        "spec_file": None,
+        "status": status,
+        "plan_task_id": None,
+        "plan_artifact": None,
+        "task_ids": [],
+        "blocked_task_ids": [],
+        "config": {
+            "max_attempts": 3,
+            "max_parallel_builders": 4,
+            "require_plan_review": True,
+            "stall_threshold_minutes": 30,
+            "completion_mode": "best_effort",
+            "test_command": None,
+            "integration_branch": "main",
+            "blocked_timeout_action": "wait",
+            "blocked_timeout_minutes": 120,
+        },
+        "created_at": now,
+        "updated_at": now,
+        "completed_at": None,
+        "report": None,
+        "last_progress_at": now,
+        "re_plan_count": 0,
+    }
+    backend.create_mission(mission)
+    return mission
+
+
+def _make_done_task_with_mission(backend, task_id, mission_id=None):
+    """Helper to create a done task with a mission_id and a current attempt."""
+    from datetime import UTC, datetime
+
+    now = datetime.now(UTC).isoformat()
+    attempt_id = f"att-{task_id}"
+    task = {
+        "id": task_id,
+        "title": f"Task {task_id}",
+        "spec": "do the thing",
+        "complexity": "M",
+        "priority": 10,
+        "depends_on": [],
+        "touches": [],
+        "capabilities_required": [],
+        "mission_id": mission_id,
+        "created_by": "test",
+        "status": "ready",
+        "current_attempt": None,
+        "attempts": [],
+        "trail": [],
+        "signals": [],
+        "created_at": now,
+        "updated_at": now,
+    }
+    backend.carry(task)
+
+    # Register worker, pull, and harvest to get a proper done task with attempt
+    worker = {
+        "worker_id": f"w-{task_id}",
+        "node_id": "node-1",
+        "agent_type": "generic",
+        "workspace_root": "/tmp/ws",
+        "status": "idle",
+        "registered_at": now,
+        "last_heartbeat": now,
+    }
+    backend.register_worker(worker)
+    backend.pull(f"w-{task_id}")
+    pulled = backend.get_task(task_id)
+    attempt_id = pulled["current_attempt"]
+    backend.mark_harvested(task_id, attempt_id, pr=f"PR-{task_id}", branch=f"feat/{task_id}")
+    return backend.get_task(task_id)
+
+
+def test_soldier_review_task_inherits_mission_id(tmp_path):
+    """Review task created by Soldier inherits mission_id from parent task."""
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    mission_id = "mission-test-inherit"
+    _make_mission(backend, mission_id)
+
+    task = _make_done_task_with_mission(backend, "task-mi-1", mission_id=mission_id)
+    # Add task to mission's task_ids
+    backend.update_mission(mission_id, {"task_ids": [task["id"]]})
+
+    soldier = Soldier.from_backend(
+        backend,
+        repo_path=str(tmp_path),
+        require_review=True,
+    )
+    review_id = soldier.create_review_task(task)
+    assert review_id == "review-task-mi-1"
+
+    review_task = backend.get_task(review_id)
+    assert review_task is not None
+    assert review_task.get("mission_id") == mission_id
+
+
+def test_soldier_review_task_appended_to_mission_task_ids(tmp_path):
+    """Review task ID is appended to the parent mission's task_ids."""
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    mission_id = "mission-test-append"
+    _make_mission(backend, mission_id)
+
+    task = _make_done_task_with_mission(backend, "task-mi-2", mission_id=mission_id)
+    backend.update_mission(mission_id, {"task_ids": [task["id"]]})
+
+    soldier = Soldier.from_backend(
+        backend,
+        repo_path=str(tmp_path),
+        require_review=True,
+    )
+    review_id = soldier.create_review_task(task)
+    assert review_id == "review-task-mi-2"
+
+    mission = backend.get_mission(mission_id)
+    assert review_id in mission["task_ids"]
+
+
+def test_soldier_review_task_no_mission_id_when_parent_has_none(tmp_path):
+    """When parent task has no mission_id, review task also has no mission_id."""
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+
+    task = _make_done_task_with_mission(backend, "task-no-mission", mission_id=None)
+
+    soldier = Soldier.from_backend(
+        backend,
+        repo_path=str(tmp_path),
+        require_review=True,
+    )
+    review_id = soldier.create_review_task(task)
+    assert review_id == "review-task-no-mission"
+
+    review_task = backend.get_task(review_id)
+    assert review_task is not None
+    assert review_task.get("mission_id") is None
+
+
+def test_soldier_suppresses_review_for_cancelled_mission(tmp_path):
+    """Soldier does NOT create a review task when mission is CANCELLED."""
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    mission_id = "mission-cancelled"
+    _make_mission(backend, mission_id, status="cancelled")
+
+    task = _make_done_task_with_mission(backend, "task-cancelled", mission_id=mission_id)
+
+    soldier = Soldier.from_backend(
+        backend,
+        repo_path=str(tmp_path),
+        require_review=True,
+    )
+    review_id = soldier.create_review_task(task)
+    assert review_id is None
+
+    # Confirm no review task was created
+    review_task = backend.get_task("review-task-cancelled")
+    assert review_task is None


### PR DESCRIPTION
## Summary
- Soldier stamps `mission_id` on review tasks, uses `link_task_to_mission()` for atomic create+link
- Suppresses review-task creation for cancelled missions
- New `antfarm/core/report.py`: build_report, render_json/terminal/markdown (dependency-free)
- Cancelled missions show completed tasks; system: vs review: prefixes distinguished

## Test plan
- [x] 4 soldier tests + 17 report tests, 665 total pass, ruff clean
- [x] Code review: both APPROVED

Closes #165
Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)