### PR TITLE
feat(autoscaler): single-host autoscaler daemon (#170)

### DIFF
--- a/antfarm/core/autoscaler.py
+++ b/antfarm/core/autoscaler.py
@@ -1,0 +1,308 @@
+"""Single-host autoscaler daemon for Antfarm.
+
+Starts and stops worker subprocesses based on queue state. Opt-in via
+``antfarm colony --autoscaler``. Manages its own workers only — manually
+started workers on other machines are untouched.
+
+Scope-aware: groups ready build tasks by ``touches`` overlap and caps
+builder count to the number of non-overlapping scope groups, preventing
+over-allocation to a single scope.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from antfarm.core.backends.base import TaskBackend
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AutoscalerConfig:
+    enabled: bool = False
+    agent_type: str = "claude-code"
+    node_id: str = "local"
+    repo_path: str = "."
+    integration_branch: str = "main"
+    workspace_root: str = "./.antfarm/workspaces"
+    max_builders: int = 4
+    max_reviewers: int = 2
+    token: str | None = None
+    poll_interval: float = 30.0
+    colony_url: str = "http://127.0.0.1:7433"
+    data_dir: str = ".antfarm"
+
+
+@dataclass
+class ManagedWorker:
+    name: str
+    role: str  # "planner" | "builder" | "reviewer"
+    worker_id: str
+    process: subprocess.Popen
+
+
+class Autoscaler:
+    """Single-host autoscaler that spawns/stops worker subprocesses."""
+
+    def __init__(
+        self,
+        backend: TaskBackend,
+        config: AutoscalerConfig,
+        clock=time.time,
+    ):
+        self.backend = backend
+        self.config = config
+        self._clock = clock
+        self.managed: dict[str, ManagedWorker] = {}
+        self._stopped = False
+        self._counter = 0
+
+    def run(self) -> None:
+        """Main loop: reconcile desired vs actual workers every poll interval."""
+        while not self._stopped:
+            try:
+                self._reconcile()
+            except Exception as e:
+                logger.exception("autoscaler reconcile failed: %s", e)
+            time.sleep(self.config.poll_interval)
+
+    def stop(self) -> None:
+        """Signal shutdown and terminate all managed workers."""
+        self._stopped = True
+        for mw in list(self.managed.values()):
+            if mw.process.poll() is None:
+                mw.process.terminate()
+
+    # ------------------------------------------------------------------
+    # Core reconciliation
+    # ------------------------------------------------------------------
+
+    def _reconcile(self) -> None:
+        self._cleanup_exited()
+        tasks = self.backend.list_tasks()
+        workers = self.backend.list_workers()
+        desired = self._compute_desired(tasks, workers)
+        actual = self._count_actual()
+        for role in ("planner", "builder", "reviewer"):
+            self._reconcile_role(role, desired[role], actual.get(role, 0))
+
+    def _compute_desired(
+        self, tasks: list[dict], workers: list[dict]
+    ) -> dict[str, int]:
+        ready_plan = [
+            t
+            for t in tasks
+            if t["status"] == "ready"
+            and "plan" in t.get("capabilities_required", [])
+        ]
+        ready_build = [
+            t
+            for t in tasks
+            if t["status"] == "ready" and not t.get("capabilities_required")
+        ]
+        ready_review = [
+            t
+            for t in tasks
+            if t["status"] == "ready"
+            and "review" in t.get("capabilities_required", [])
+        ]
+        done_unreviewed = [
+            t
+            for t in tasks
+            if t["status"] == "done"
+            and not t["id"].startswith("review-")
+            and not self._has_verdict(t)
+            and not self._has_merged_attempt(t)
+        ]
+
+        scope_groups = self._count_scope_groups(ready_build)
+
+        active_builders = [
+            w
+            for w in workers
+            if "review" not in w.get("capabilities", [])
+            and "plan" not in w.get("capabilities", [])
+            and w.get("status") != "offline"
+        ]
+        rate_limited = [w for w in active_builders if self._is_rate_limited(w)]
+
+        desired_builders = min(
+            scope_groups,
+            self.config.max_builders,
+            len(ready_build),
+        )
+        if rate_limited and len(rate_limited) > len(active_builders) // 2:
+            desired_builders = min(desired_builders, len(active_builders))
+
+        return {
+            "planner": 1 if ready_plan else 0,
+            "builder": desired_builders,
+            "reviewer": min(
+                max(
+                    1 if (done_unreviewed or ready_review) else 0,
+                    len(ready_review),
+                ),
+                self.config.max_reviewers,
+            ),
+        }
+
+    @staticmethod
+    def _count_scope_groups(tasks: list[dict]) -> int:
+        """Count non-overlapping scope groups (union-find by touches)."""
+        if not tasks:
+            return 0
+        groups: list[set[str]] = []
+        for t in tasks:
+            touches = set(t.get("touches", []))
+            if not touches:
+                groups.append(set())
+                continue
+            hit = None
+            for g in groups:
+                if g & touches:
+                    g.update(touches)
+                    hit = g
+                    break
+            if hit is None:
+                groups.append(touches)
+        return len(groups)
+
+    # ------------------------------------------------------------------
+    # Worker lifecycle
+    # ------------------------------------------------------------------
+
+    def _reconcile_role(self, role: str, desired: int, actual: int) -> None:
+        delta = desired - actual
+        while delta > 0:
+            self._start_worker(role)
+            delta -= 1
+        while delta < 0:
+            if not self._stop_idle_worker(role):
+                break  # no idle workers to stop this tick
+            delta += 1
+
+    def _start_worker(self, role: str) -> None:
+        """Spawn a new worker subprocess for the given role."""
+        self._counter += 1
+        name = f"auto-{role}-{self._counter}"
+        worker_id = f"{self.config.node_id}/{name}"
+
+        cmd = [
+            "antfarm",
+            "worker",
+            "start",
+            "--agent",
+            self.config.agent_type,
+            "--type",
+            role,
+            "--node",
+            self.config.node_id,
+            "--name",
+            name,
+            "--repo-path",
+            self.config.repo_path,
+            "--integration-branch",
+            self.config.integration_branch,
+            "--workspace-root",
+            self.config.workspace_root,
+            "--colony-url",
+            self.config.colony_url,
+        ]
+        if self.config.token:
+            cmd.extend(["--token", self.config.token])
+
+        # Log to .antfarm/logs/autoscaler-{name}.log
+        log_dir = os.path.join(self.config.data_dir, "logs")
+        os.makedirs(log_dir, exist_ok=True)
+        log_path = os.path.join(log_dir, f"autoscaler-{name}.log")
+        log_file = open(log_path, "a")  # noqa: SIM115
+
+        process = subprocess.Popen(
+            cmd,
+            stdout=log_file,
+            stderr=log_file,
+        )
+
+        self.managed[name] = ManagedWorker(
+            name=name,
+            role=role,
+            worker_id=worker_id,
+            process=process,
+        )
+        logger.info("autoscaler started worker name=%s role=%s pid=%d", name, role, process.pid)
+
+    def _stop_idle_worker(self, role: str) -> bool:
+        """Stop one idle worker of the given role. Returns True if stopped."""
+        colony_workers = self.backend.list_workers()
+        colony_status_map = {w["worker_id"]: w for w in colony_workers}
+
+        for name, mw in list(self.managed.items()):
+            if mw.role != role:
+                continue
+            if mw.process.poll() is not None:
+                continue  # already exited
+            cw = colony_status_map.get(mw.worker_id)
+            if cw and cw.get("status") == "idle":
+                mw.process.terminate()
+                logger.info("autoscaler stopped idle worker name=%s role=%s", name, role)
+                del self.managed[name]
+                return True
+        return False
+
+    def _cleanup_exited(self) -> None:
+        """Remove managed workers whose processes have exited."""
+        for name in list(self.managed):
+            mw = self.managed[name]
+            if mw.process.poll() is not None:
+                logger.info(
+                    "autoscaler cleaned up exited worker name=%s exit=%d",
+                    name,
+                    mw.process.returncode,
+                )
+                del self.managed[name]
+
+    def _count_actual(self) -> dict[str, int]:
+        """Count running managed workers by role."""
+        counts: dict[str, int] = {}
+        for mw in self.managed.values():
+            if mw.process.poll() is None:  # still running
+                counts[mw.role] = counts.get(mw.role, 0) + 1
+        return counts
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _has_verdict(task: dict) -> bool:
+        """Check if a task's current attempt has a review verdict."""
+        for att in task.get("attempts", []):
+            if att.get("attempt_id") == task.get("current_attempt"):
+                return bool(att.get("review_verdict"))
+        return False
+
+    @staticmethod
+    def _has_merged_attempt(task: dict) -> bool:
+        """Check if a task's current attempt has been merged."""
+        for att in task.get("attempts", []):
+            if att.get("attempt_id") == task.get("current_attempt"):
+                return att.get("status") == "merged"
+        return False
+
+    @staticmethod
+    def _is_rate_limited(worker: dict) -> bool:
+        """Check if a worker is currently rate-limited."""
+        cooldown = worker.get("cooldown_until")
+        if not cooldown:
+            return False
+        try:
+            cooldown_dt = datetime.fromisoformat(cooldown)
+            return cooldown_dt > datetime.now(UTC)
+        except (ValueError, TypeError):
+            return False

--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -130,6 +130,30 @@ def version():
     help="Disable the built-in Doctor health-check daemon.",
 )
 @click.option(
+    "--no-queen",
+    is_flag=True,
+    default=False,
+    help="Disable the Queen mission controller.",
+)
+@click.option(
+    "--autoscaler/--no-autoscaler",
+    default=False,
+    show_default=True,
+    help="Enable/disable the single-host autoscaler.",
+)
+@click.option(
+    "--max-builders",
+    type=int,
+    default=None,
+    help="Maximum parallel builder workers (pass-through to AutoscalerConfig).",
+)
+@click.option(
+    "--max-reviewers",
+    type=int,
+    default=None,
+    help="Maximum parallel reviewer workers (pass-through to AutoscalerConfig).",
+)
+@click.option(
     "--backend",
     default="file",
     show_default=True,
@@ -157,6 +181,10 @@ def colony(
     backup_interval: int,
     no_soldier: bool,
     no_doctor: bool,
+    no_queen: bool,
+    autoscaler: bool,
+    max_builders: int | None,
+    max_reviewers: int | None,
     backend: str,
     github_repo: str | None,
     github_token: str | None,
@@ -175,12 +203,30 @@ def colony(
     else:
         task_backend = get_backend("file", root=data_dir)
 
+    autoscaler_cfg = None
+    if autoscaler:
+        from antfarm.core.autoscaler import AutoscalerConfig
+
+        autoscaler_cfg = AutoscalerConfig(
+            enabled=True,
+            data_dir=data_dir,
+            colony_url=f"http://127.0.0.1:{port}",
+        )
+        if max_builders is not None:
+            autoscaler_cfg.max_builders = max_builders
+        if max_reviewers is not None:
+            autoscaler_cfg.max_reviewers = max_reviewers
+        if auth_token:
+            autoscaler_cfg.token = auth_token
+
     app = get_app(
         task_backend,
         data_dir=data_dir,
         auth_secret=auth_token,
         enable_soldier=not no_soldier,
         enable_doctor=not no_doctor,
+        enable_queen=not no_queen,
+        autoscaler_config=autoscaler_cfg,
     )
     if auth_token:
         from antfarm.core.auth import generate_token
@@ -385,6 +431,8 @@ def worker_start(
               help="Task type: 'plan' for planner decomposition.")
 @click.option("--issue", "issue_number", default=None, type=int,
               help="GitHub issue number to link.")
+@click.option("--mission", "mission_id", default=None,
+              help="Attach this task to an existing mission.")
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def carry(
@@ -399,6 +447,7 @@ def carry(
     task_id: str | None,
     task_type: str | None,
     issue_number: int | None,
+    mission_id: str | None,
     colony_url: str,
     token: str | None,
 ):
@@ -430,6 +479,9 @@ def carry(
             payload["capabilities_required"].append("plan")
 
     payload["id"] = task_id
+
+    if mission_id:
+        payload["mission_id"] = mission_id
 
     # Append issue reference to spec so workers include it in commits
     if issue_number:
@@ -1035,6 +1087,163 @@ def plan(
             click.echo(f"  Created: {r}")
         except Exception as exc:
             click.echo(f"  Failed to carry task {i}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# mission
+# ---------------------------------------------------------------------------
+
+
+@main.group()
+def mission():
+    """Manage autonomous missions."""
+
+
+@mission.command("create")
+@click.option("--spec", "spec_path", required=True, type=click.Path(exists=True),
+              help="Path to spec file.")
+@click.option("--mission-id", default=None, help="Optional explicit mission id slug.")
+@click.option("--no-plan-review", is_flag=True, default=False,
+              help="Skip plan review step.")
+@click.option("--max-builders", type=int, default=None,
+              help="Max parallel builder workers.")
+@click.option("--max-attempts", type=int, default=None,
+              help="Max attempts per task.")
+@click.option("--integration-branch", default=None,
+              help="Integration branch for this mission.")
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def mission_create(
+    spec_path: str,
+    mission_id: str | None,
+    no_plan_review: bool,
+    max_builders: int | None,
+    max_attempts: int | None,
+    integration_branch: str | None,
+    colony_url: str,
+    token: str | None,
+):
+    """Create an autonomous mission from a spec file."""
+    with open(spec_path) as f:
+        spec_text = f.read()
+
+    payload: dict = {"spec": spec_text, "spec_file": spec_path}
+    config: dict = {}
+    if no_plan_review:
+        config["require_plan_review"] = False
+    if max_builders is not None:
+        config["max_parallel_builders"] = max_builders
+    if max_attempts is not None:
+        config["max_attempts"] = max_attempts
+    if integration_branch is not None:
+        config["integration_branch"] = integration_branch
+    if config:
+        payload["config"] = config
+    if mission_id:
+        payload["mission_id"] = mission_id
+
+    result = _post(colony_url, "/missions", payload, token=token)
+    click.echo(f"Mission created: {result}")
+
+
+@mission.command("status")
+@click.argument("mission_id")
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def mission_status(mission_id: str, colony_url: str, token: str | None):
+    """Show mission status overview."""
+    data = _get(colony_url, f"/missions/{mission_id}", token=token)
+
+    click.echo(f"Mission:    {data.get('mission_id', mission_id)}")
+    click.echo(f"Status:     {data.get('status', 'unknown')}")
+
+    config = data.get("config", {})
+    completion_mode = config.get("completion_mode", "best_effort")
+    if completion_mode == "all_or_nothing":
+        click.echo(
+            f"Completion: {completion_mode} (treated as best_effort in v0.6.0)"
+        )
+    else:
+        click.echo(f"Completion: {completion_mode}")
+
+    task_ids = data.get("task_ids", [])
+    click.echo(f"Tasks:      {len(task_ids)}")
+    click.echo(f"Created:    {data.get('created_at', 'unknown')}")
+
+    if data.get("plan_task_id"):
+        click.echo(f"Plan task:  {data['plan_task_id']}")
+    if data.get("spec_file"):
+        click.echo(f"Spec file:  {data['spec_file']}")
+
+
+@mission.command("report")
+@click.argument("mission_id")
+@click.option("--format", "fmt", type=click.Choice(["terminal", "md", "json"]),
+              default="terminal", show_default=True, help="Output format.")
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def mission_report(mission_id: str, fmt: str, colony_url: str, token: str | None):
+    """Show mission report."""
+    data = _get(colony_url, f"/missions/{mission_id}/report", token=token)
+
+    if fmt == "json":
+        click.echo(json.dumps(data, indent=2))
+    elif fmt == "md":
+        click.echo(f"# Mission Report: {data.get('mission_id', mission_id)}")
+        click.echo(f"\n**Status:** {data.get('status', 'unknown')}")
+        click.echo(f"**Duration:** {data.get('duration', 'unknown')}")
+        tasks = data.get("tasks", [])
+        if tasks:
+            click.echo("\n## Tasks\n")
+            for t in tasks:
+                status = t.get("status", "unknown")
+                click.echo(f"- **{t.get('title', t.get('id', '?'))}** — {status}")
+    else:
+        click.echo(f"Mission:  {data.get('mission_id', mission_id)}")
+        click.echo(f"Status:   {data.get('status', 'unknown')}")
+        click.echo(f"Duration: {data.get('duration', 'unknown')}")
+        tasks = data.get("tasks", [])
+        if tasks:
+            click.echo(f"\n{'Task':<30} {'Status':<12}")
+            click.echo("-" * 42)
+            for t in tasks:
+                title = t.get("title", t.get("id", "?"))[:28]
+                status = t.get("status", "unknown")
+                click.echo(f"{title:<30} {status:<12}")
+
+
+@mission.command("cancel")
+@click.argument("mission_id")
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def mission_cancel(mission_id: str, colony_url: str, token: str | None):
+    """Cancel a mission."""
+    _post(colony_url, f"/missions/{mission_id}/cancel", {}, token=token)
+    click.echo(f"Mission cancelled: {mission_id}")
+
+
+@mission.command("list")
+@click.option("--status", "status_filter", default=None, help="Filter by mission status.")
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def mission_list(status_filter: str | None, colony_url: str, token: str | None):
+    """List all missions."""
+    path = "/missions"
+    if status_filter:
+        path += f"?status={status_filter}"
+    data = _get(colony_url, path, token=token)
+
+    if not data:
+        click.echo("No missions found.")
+        return
+
+    click.echo(f"{'Mission ID':<35} {'Status':<15} {'Tasks'}")
+    click.echo("-" * 60)
+    for m in data:
+        mid = m.get("mission_id", "?")
+        status = m.get("status", "?")
+        task_count = len(m.get("task_ids", []))
+        click.echo(f"{mid:<35} {status:<15} {task_count}")
 
 
 # ---------------------------------------------------------------------------

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -35,6 +35,10 @@ _soldier_thread: threading.Thread | None = None
 _queen_thread: threading.Thread | None = None
 _queen_status: str = "not started"
 
+_autoscaler_thread: threading.Thread | None = None
+_autoscaler_status: str = "not started"
+_autoscaler_instance = None
+
 # SSE event bus
 _event_queue: collections.deque = collections.deque(maxlen=1000)
 _event_counter: int = 0
@@ -160,6 +164,35 @@ def _start_queen_thread(backend: TaskBackend) -> None:
     _queen_thread.start()
 
 
+def _start_autoscaler_thread(
+    backend: TaskBackend,
+    autoscaler_config,
+) -> None:
+    """Start the Autoscaler as a daemon thread (singleton guard)."""
+    global _autoscaler_thread, _autoscaler_status, _autoscaler_instance
+
+    if _autoscaler_thread is not None and _autoscaler_thread.is_alive():
+        return
+
+    from antfarm.core.autoscaler import Autoscaler
+
+    _autoscaler_instance = Autoscaler(backend, autoscaler_config)
+
+    def _autoscaler_loop():
+        global _autoscaler_status
+        _autoscaler_status = "running"
+        try:
+            _autoscaler_instance.run()
+        except Exception as e:
+            _autoscaler_status = f"error: {e}"
+            logger.error("autoscaler thread crashed: %s", e)
+
+    _autoscaler_thread = threading.Thread(
+        target=_autoscaler_loop, daemon=True, name="autoscaler"
+    )
+    _autoscaler_thread.start()
+
+
 # ---------------------------------------------------------------------------
 # Request models
 # ---------------------------------------------------------------------------
@@ -280,6 +313,7 @@ def get_app(
     enable_soldier: bool = False,
     enable_doctor: bool = False,
     enable_queen: bool = True,
+    autoscaler_config=None,
 ) -> FastAPI:
     """Create and return the FastAPI application.
 
@@ -294,6 +328,8 @@ def get_app(
         enable_doctor: If True, start the Doctor health-check daemon thread.
         enable_queen: If True (default), start the Queen mission controller as
                       a daemon thread. Requires FileBackend — skips for GitHubBackend.
+        autoscaler_config: Optional AutoscalerConfig. When provided and
+                           ``enabled=True``, starts the Autoscaler daemon thread.
 
     Returns:
         Configured FastAPI application.
@@ -337,6 +373,9 @@ def get_app(
             logger.info("queen: skipping — GitHubBackend not supported in v0.6.0")
         else:
             _start_queen_thread(_backend)
+
+    if autoscaler_config is not None and autoscaler_config.enabled:
+        _start_autoscaler_thread(_backend, autoscaler_config)
 
     # ------------------------------------------------------------------
     # Nodes
@@ -887,6 +926,7 @@ def get_app(
         result["soldier"] = _soldier_status
         result["doctor"] = _doctor_status
         result["queen"] = _queen_status
+        result["autoscaler"] = _autoscaler_status
         return result
 
     @app.get("/status/full", status_code=200)
@@ -905,6 +945,7 @@ def get_app(
             "soldier": _soldier_status,
             "doctor": _doctor_status,
             "queen": _queen_status,
+            "autoscaler": _autoscaler_status,
         }
 
     # ------------------------------------------------------------------

--- a/antfarm/core/tui.py
+++ b/antfarm/core/tui.py
@@ -66,7 +66,7 @@ class AntfarmTUI:
                 pass
 
     def _build_display(self) -> Layout:
-        """Fetch status + tasks + workers and build the display."""
+        """Fetch status + tasks + workers + missions and build the display."""
         try:
             full = self._fetch("/status/full")
             status = full.get("status", {})
@@ -78,11 +78,18 @@ class AntfarmTUI:
             layout.update(Panel(f"[red]Connection error: {exc}[/red]", title="Antfarm TUI"))
             return layout
 
+        try:
+            missions = self._fetch("/missions")
+        except Exception:
+            missions = []
+
         snap = self._classify_tasks(tasks)
 
         layout = Layout()
+        missions_size = max(5, min(len(missions) + 4, 10)) if missions else 5
         layout.split_column(
             Layout(name="header", size=10),
+            Layout(name="missions", size=missions_size),
             Layout(name="workers", size=max(5, len(workers) + 5)),
             Layout(name="waiting", size=7),
             Layout(name="planning", size=5),
@@ -116,6 +123,13 @@ class AntfarmTUI:
             Panel(
                 self._render_summary(status, tasks, workers, snap, soldier_status),
                 title="[bold blue]Antfarm Colony[/bold blue]",
+            )
+        )
+
+        layout["missions"].update(
+            Panel(
+                self._render_missions(missions),
+                title=f"[bold bright_white]Missions ({len(missions)})[/bold bright_white]",
             )
         )
 
@@ -434,6 +448,84 @@ class AntfarmTUI:
         table.add_row("Pipeline", self._render_pipeline_bar(counts))
 
         return table
+
+    def _render_missions(self, missions: list[dict], max_shown: int = 5) -> Table:
+        """Render mission list with status, task counts, and progress time."""
+        table = Table(show_header=True, header_style="bold", box=None, padding=(0, 1))
+        table.add_column("ID", max_width=25, no_wrap=True)
+        table.add_column("Status", max_width=15, no_wrap=True)
+        table.add_column("Tasks", max_width=8, no_wrap=True)
+        table.add_column("Progress", max_width=20, no_wrap=True)
+
+        if not missions:
+            table.add_row("[dim]--[/dim]", "[dim]No active missions.[/dim]", "", "")
+            return table
+
+        status_style = {
+            "planning": "magenta",
+            "reviewing_plan": "magenta",
+            "building": "yellow",
+            "blocked": "red",
+            "complete": "green",
+            "failed": "red",
+            "cancelled": "dim",
+        }
+
+        shown = missions[:max_shown]
+        for m in shown:
+            mid = m.get("mission_id", "")
+            mstatus = m.get("status", "")
+            style = status_style.get(mstatus, "dim")
+
+            # Task counts: total / merged / blocked
+            task_ids = m.get("task_ids", [])
+            blocked_ids = m.get("blocked_task_ids", [])
+            total = len(task_ids)
+            blocked = len(blocked_ids)
+
+            # Derive merged count from report if available
+            report = m.get("report")
+            merged = report.get("merged_tasks", 0) if report else 0
+            tasks_text = f"{merged}/{total}"
+            if blocked > 0:
+                tasks_text += f" ({blocked}blk)"
+
+            # Progress column
+            progress = self._format_mission_progress(m)
+
+            table.add_row(
+                Text(mid[:23], style=style),
+                Text(mstatus, style=style),
+                Text(tasks_text, style="dim"),
+                Text(progress, style="dim"),
+            )
+
+        self._add_overflow_hint(table, len(missions), max_shown)
+        return table
+
+    def _format_mission_progress(self, mission: dict) -> str:
+        """Format progress column for a mission.
+
+        - complete/failed/cancelled: "done"
+        - blocked with last_progress_at: "stalled <elapsed>"
+        - active with last_progress_at: "<elapsed> ago"
+        - no last_progress_at: "--"
+        """
+        mstatus = mission.get("status", "")
+        if mstatus in ("complete", "failed", "cancelled"):
+            return "done"
+
+        last_progress = mission.get("last_progress_at", "")
+        if not last_progress:
+            return "--"
+
+        elapsed = self._format_elapsed_since(last_progress)
+        if not elapsed:
+            return "--"
+
+        if mstatus == "blocked":
+            return f"stalled {elapsed}"
+        return f"{elapsed} ago"
 
     def _render_pipeline_bar(self, counts: dict, width: int = 50) -> Text:
         """Render colored block chars representing pipeline distribution."""

--- a/tests/test_autoscaler.py
+++ b/tests/test_autoscaler.py
@@ -1,0 +1,471 @@
+"""Tests for antfarm.core.autoscaler — single-host autoscaler daemon."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from antfarm.core.autoscaler import Autoscaler, AutoscalerConfig
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _task(
+    task_id: str,
+    status: str = "ready",
+    touches: list[str] | None = None,
+    capabilities_required: list[str] | None = None,
+    attempts: list[dict] | None = None,
+    current_attempt: str | None = None,
+) -> dict:
+    return {
+        "id": task_id,
+        "status": status,
+        "touches": touches or [],
+        "capabilities_required": capabilities_required or [],
+        "attempts": attempts or [],
+        "current_attempt": current_attempt,
+    }
+
+
+def _worker(
+    worker_id: str,
+    status: str = "idle",
+    capabilities: list[str] | None = None,
+    cooldown_until: str | None = None,
+) -> dict:
+    w: dict = {
+        "worker_id": worker_id,
+        "status": status,
+        "capabilities": capabilities or [],
+    }
+    if cooldown_until is not None:
+        w["cooldown_until"] = cooldown_until
+    return w
+
+
+def _make_autoscaler(**kwargs) -> Autoscaler:
+    backend = MagicMock()
+    config = AutoscalerConfig(**kwargs)
+    return Autoscaler(backend, config)
+
+
+# ---------------------------------------------------------------------------
+# _compute_desired tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDesired:
+    def test_no_ready_tasks_returns_zeros(self):
+        a = _make_autoscaler()
+        result = a._compute_desired([], [])
+        assert result == {"planner": 0, "builder": 0, "reviewer": 0}
+
+    def test_only_plan_task_returns_one_planner(self):
+        a = _make_autoscaler()
+        tasks = [_task("t1", capabilities_required=["plan"])]
+        result = a._compute_desired(tasks, [])
+        assert result["planner"] == 1
+        assert result["builder"] == 0
+
+    def test_three_scope_groups_returns_three_builders(self):
+        a = _make_autoscaler(max_builders=10)
+        tasks = [
+            _task("t1", touches=["api"]),
+            _task("t2", touches=["db"]),
+            _task("t3", touches=["auth"]),
+        ]
+        result = a._compute_desired(tasks, [])
+        assert result["builder"] == 3
+
+    def test_overlapping_scopes_returns_one_builder(self):
+        a = _make_autoscaler(max_builders=10)
+        tasks = [
+            _task("t1", touches=["api", "db"]),
+            _task("t2", touches=["db", "auth"]),
+        ]
+        result = a._compute_desired(tasks, [])
+        assert result["builder"] == 1
+
+    def test_caps_at_max_builders(self):
+        a = _make_autoscaler(max_builders=2)
+        tasks = [
+            _task("t1", touches=["api"]),
+            _task("t2", touches=["db"]),
+            _task("t3", touches=["auth"]),
+            _task("t4", touches=["ui"]),
+        ]
+        result = a._compute_desired(tasks, [])
+        assert result["builder"] == 2
+
+    def test_caps_at_queue_depth(self):
+        a = _make_autoscaler(max_builders=10)
+        # Only 1 ready build task but 5 scope groups possible
+        tasks = [_task("t1", touches=["api"])]
+        result = a._compute_desired(tasks, [])
+        assert result["builder"] == 1
+
+    def test_rate_limited_majority_doesnt_scale_up(self):
+        a = _make_autoscaler(max_builders=10)
+        tasks = [
+            _task("t1", touches=["api"]),
+            _task("t2", touches=["db"]),
+            _task("t3", touches=["auth"]),
+        ]
+        # 3 active builders, 2 rate-limited (majority)
+        workers = [
+            _worker("w1", status="active", cooldown_until="2099-01-01T00:00:00+00:00"),
+            _worker("w2", status="active", cooldown_until="2099-01-01T00:00:00+00:00"),
+            _worker("w3", status="active"),
+        ]
+        result = a._compute_desired(tasks, workers)
+        # Should cap at current active count (3), not scale up
+        assert result["builder"] <= 3
+
+    def test_done_unreviewed_triggers_reviewer(self):
+        a = _make_autoscaler()
+        tasks = [
+            _task(
+                "t1",
+                status="done",
+                current_attempt="att-1",
+                attempts=[{"attempt_id": "att-1", "status": "done"}],
+            ),
+        ]
+        result = a._compute_desired(tasks, [])
+        assert result["reviewer"] >= 1
+
+    def test_review_task_triggers_reviewer(self):
+        a = _make_autoscaler()
+        tasks = [_task("r1", capabilities_required=["review"])]
+        result = a._compute_desired(tasks, [])
+        assert result["reviewer"] >= 1
+
+    def test_reviewer_caps_at_max(self):
+        a = _make_autoscaler(max_reviewers=1)
+        tasks = [
+            _task("r1", capabilities_required=["review"]),
+            _task("r2", capabilities_required=["review"]),
+            _task("r3", capabilities_required=["review"]),
+        ]
+        result = a._compute_desired(tasks, [])
+        assert result["reviewer"] == 1
+
+    def test_merged_attempt_not_counted_as_unreviewed(self):
+        a = _make_autoscaler()
+        tasks = [
+            _task(
+                "t1",
+                status="done",
+                current_attempt="att-1",
+                attempts=[{"attempt_id": "att-1", "status": "merged"}],
+            ),
+        ]
+        result = a._compute_desired(tasks, [])
+        assert result["reviewer"] == 0
+
+    def test_review_prefixed_tasks_not_counted_as_unreviewed(self):
+        a = _make_autoscaler()
+        tasks = [
+            _task("review-t1", status="done", current_attempt="att-1",
+                  attempts=[{"attempt_id": "att-1", "status": "done"}]),
+        ]
+        result = a._compute_desired(tasks, [])
+        assert result["reviewer"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _count_scope_groups tests
+# ---------------------------------------------------------------------------
+
+
+class TestCountScopeGroups:
+    def test_disjoint(self):
+        tasks = [
+            _task("t1", touches=["api"]),
+            _task("t2", touches=["db"]),
+            _task("t3", touches=["auth"]),
+        ]
+        assert Autoscaler._count_scope_groups(tasks) == 3
+
+    def test_overlapping(self):
+        tasks = [
+            _task("t1", touches=["api", "db"]),
+            _task("t2", touches=["db"]),
+        ]
+        assert Autoscaler._count_scope_groups(tasks) == 1
+
+    def test_transitively_overlapping(self):
+        # A,B share x; B,C share y; A,C share nothing directly -> 1 group
+        tasks = [
+            _task("t1", touches=["a", "x"]),
+            _task("t2", touches=["x", "y"]),
+            _task("t3", touches=["y", "c"]),
+        ]
+        assert Autoscaler._count_scope_groups(tasks) == 1
+
+    def test_empty(self):
+        assert Autoscaler._count_scope_groups([]) == 0
+
+    def test_no_touches_each_separate_group(self):
+        tasks = [_task("t1"), _task("t2")]
+        assert Autoscaler._count_scope_groups(tasks) == 2
+
+
+# ---------------------------------------------------------------------------
+# Reconciliation tests (with mocked Popen)
+# ---------------------------------------------------------------------------
+
+
+class TestReconciliation:
+    @patch("antfarm.core.autoscaler.subprocess.Popen")
+    @patch("antfarm.core.autoscaler.os.makedirs")
+    @patch("builtins.open", new_callable=MagicMock)
+    def test_reconcile_starts_workers_to_meet_desired(self, mock_open, mock_makedirs, mock_popen):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.pid = 12345
+        mock_popen.return_value = mock_proc
+
+        a = _make_autoscaler(max_builders=4)
+        a.backend.list_tasks.return_value = [
+            _task("t1", touches=["api"]),
+            _task("t2", touches=["db"]),
+        ]
+        a.backend.list_workers.return_value = []
+
+        a._reconcile()
+
+        # Should have started 2 builders (2 scope groups, 2 tasks)
+        builder_starts = [
+            call for call in mock_popen.call_args_list
+            if "--type" in call[0][0] and "builder" in call[0][0]
+        ]
+        assert len(builder_starts) == 2
+
+    @patch("antfarm.core.autoscaler.subprocess.Popen")
+    @patch("antfarm.core.autoscaler.os.makedirs")
+    @patch("builtins.open", new_callable=MagicMock)
+    def test_stop_idle_worker_respects_colony_state(self, mock_open, mock_makedirs, mock_popen):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None  # still running
+        mock_popen.return_value = mock_proc
+
+        a = _make_autoscaler()
+        # Simulate a managed worker
+        from antfarm.core.autoscaler import ManagedWorker
+
+        mw = ManagedWorker(
+            name="auto-builder-1",
+            role="builder",
+            worker_id="local/auto-builder-1",
+            process=mock_proc,
+        )
+        a.managed["auto-builder-1"] = mw
+
+        # Colony says this worker is active (not idle) -> should NOT stop
+        a.backend.list_workers.return_value = [
+            _worker("local/auto-builder-1", status="active"),
+        ]
+        stopped = a._stop_idle_worker("builder")
+        assert stopped is False
+        mock_proc.terminate.assert_not_called()
+
+        # Colony says this worker is idle -> should stop
+        a.backend.list_workers.return_value = [
+            _worker("local/auto-builder-1", status="idle"),
+        ]
+        stopped = a._stop_idle_worker("builder")
+        assert stopped is True
+        mock_proc.terminate.assert_called_once()
+
+    def test_cleanup_exited_removes_dead_workers(self):
+        a = _make_autoscaler()
+        from antfarm.core.autoscaler import ManagedWorker
+
+        dead_proc = MagicMock()
+        dead_proc.poll.return_value = 0
+        dead_proc.returncode = 0
+
+        alive_proc = MagicMock()
+        alive_proc.poll.return_value = None
+
+        a.managed["dead"] = ManagedWorker("dead", "builder", "local/dead", dead_proc)
+        a.managed["alive"] = ManagedWorker("alive", "builder", "local/alive", alive_proc)
+
+        a._cleanup_exited()
+
+        assert "dead" not in a.managed
+        assert "alive" in a.managed
+
+    @patch("antfarm.core.autoscaler.subprocess.Popen")
+    @patch("antfarm.core.autoscaler.os.makedirs")
+    @patch("builtins.open", new_callable=MagicMock)
+    def test_run_once_is_idempotent_when_at_desired(
+        self, mock_open, mock_makedirs, mock_popen
+    ):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.pid = 99
+        mock_popen.return_value = mock_proc
+
+        a = _make_autoscaler()
+        a.backend.list_tasks.return_value = [_task("t1", touches=["api"])]
+        a.backend.list_workers.return_value = []
+
+        # First reconcile starts workers
+        a._reconcile()
+        first_count = mock_popen.call_count
+
+        # Second reconcile should not start more (already at desired)
+        a._reconcile()
+        assert mock_popen.call_count == first_count
+
+
+# ---------------------------------------------------------------------------
+# Worker lifecycle helpers
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_has_verdict_true(self):
+        task = _task(
+            "t1",
+            current_attempt="att-1",
+            attempts=[
+                {"attempt_id": "att-1", "review_verdict": {"verdict": "pass"}},
+            ],
+        )
+        assert Autoscaler._has_verdict(task) is True
+
+    def test_has_verdict_false(self):
+        task = _task(
+            "t1",
+            current_attempt="att-1",
+            attempts=[{"attempt_id": "att-1"}],
+        )
+        assert Autoscaler._has_verdict(task) is False
+
+    def test_has_merged_attempt_true(self):
+        task = _task(
+            "t1",
+            current_attempt="att-1",
+            attempts=[{"attempt_id": "att-1", "status": "merged"}],
+        )
+        assert Autoscaler._has_merged_attempt(task) is True
+
+    def test_has_merged_attempt_false(self):
+        task = _task(
+            "t1",
+            current_attempt="att-1",
+            attempts=[{"attempt_id": "att-1", "status": "done"}],
+        )
+        assert Autoscaler._has_merged_attempt(task) is False
+
+    def test_is_rate_limited_true(self):
+        w = _worker("w1", cooldown_until="2099-01-01T00:00:00+00:00")
+        assert Autoscaler._is_rate_limited(w) is True
+
+    def test_is_rate_limited_false_expired(self):
+        w = _worker("w1", cooldown_until="2000-01-01T00:00:00+00:00")
+        assert Autoscaler._is_rate_limited(w) is False
+
+    def test_is_rate_limited_false_no_field(self):
+        w = _worker("w1")
+        assert Autoscaler._is_rate_limited(w) is False
+
+    def test_count_actual(self):
+        a = _make_autoscaler()
+        from antfarm.core.autoscaler import ManagedWorker
+
+        alive = MagicMock()
+        alive.poll.return_value = None
+        dead = MagicMock()
+        dead.poll.return_value = 1
+
+        a.managed["b1"] = ManagedWorker("b1", "builder", "local/b1", alive)
+        a.managed["b2"] = ManagedWorker("b2", "builder", "local/b2", dead)
+        a.managed["r1"] = ManagedWorker("r1", "reviewer", "local/r1", alive)
+
+        counts = a._count_actual()
+        assert counts["builder"] == 1
+        assert counts["reviewer"] == 1
+
+    def test_stop_terminates_all_managed(self):
+        a = _make_autoscaler()
+        from antfarm.core.autoscaler import ManagedWorker
+
+        proc = MagicMock()
+        proc.poll.return_value = None
+        a.managed["w1"] = ManagedWorker("w1", "builder", "local/w1", proc)
+
+        a.stop()
+        assert a._stopped is True
+        proc.terminate.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _start_worker tests
+# ---------------------------------------------------------------------------
+
+
+class TestStartWorker:
+    @patch("antfarm.core.autoscaler.subprocess.Popen")
+    @patch("antfarm.core.autoscaler.os.makedirs")
+    @patch("builtins.open", new_callable=MagicMock)
+    def test_start_worker_builds_correct_command(self, mock_open, mock_makedirs, mock_popen):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.pid = 42
+        mock_popen.return_value = mock_proc
+
+        a = _make_autoscaler(
+            agent_type="claude-code",
+            node_id="node-1",
+            repo_path="/repo",
+            integration_branch="dev",
+            workspace_root="/ws",
+            colony_url="http://localhost:7433",
+        )
+        a._start_worker("builder")
+
+        cmd = mock_popen.call_args[0][0]
+        assert "antfarm" in cmd
+        assert "--type" in cmd
+        idx = cmd.index("--type")
+        assert cmd[idx + 1] == "builder"
+        assert "--agent" in cmd
+        assert "claude-code" in cmd
+        assert "--node" in cmd
+        assert "node-1" in cmd
+
+    @patch("antfarm.core.autoscaler.subprocess.Popen")
+    @patch("antfarm.core.autoscaler.os.makedirs")
+    @patch("builtins.open", new_callable=MagicMock)
+    def test_start_worker_with_token(self, mock_open, mock_makedirs, mock_popen):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.pid = 42
+        mock_popen.return_value = mock_proc
+
+        a = _make_autoscaler(token="secret123")
+        a._start_worker("reviewer")
+
+        cmd = mock_popen.call_args[0][0]
+        assert "--token" in cmd
+        assert "secret123" in cmd
+
+    @patch("antfarm.core.autoscaler.subprocess.Popen")
+    @patch("antfarm.core.autoscaler.os.makedirs")
+    @patch("builtins.open", new_callable=MagicMock)
+    def test_start_worker_creates_log_dir(self, mock_open, mock_makedirs, mock_popen):
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        mock_proc.pid = 42
+        mock_popen.return_value = mock_proc
+
+        a = _make_autoscaler(data_dir="/data")
+        a._start_worker("planner")
+
+        mock_makedirs.assert_called_with("/data/logs", exist_ok=True)

--- a/tests/test_mission_cli.py
+++ b/tests/test_mission_cli.py
@@ -1,0 +1,412 @@
+"""Tests for the mission CLI commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from antfarm.core.cli import main
+
+# ---------------------------------------------------------------------------
+# mission create
+# ---------------------------------------------------------------------------
+
+
+def test_mission_create_reads_spec_file_and_posts(tmp_path: Path):
+    """mission create reads spec file and POSTs to /missions."""
+    spec_file = tmp_path / "spec.md"
+    spec_file.write_text("Build an auth system")
+
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"mission_id": "mission-auth-123"}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission", "create",
+                "--spec", str(spec_file),
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "mission-auth-123" in result.output
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+        assert payload["spec"] == "Build an auth system"
+        assert payload["spec_file"] == str(spec_file)
+
+
+def test_mission_create_no_plan_review_flag_sets_config(tmp_path: Path):
+    """--no-plan-review sets require_plan_review=False in config."""
+    spec_file = tmp_path / "spec.md"
+    spec_file.write_text("spec content")
+
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"mission_id": "m1"}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission", "create",
+                "--spec", str(spec_file),
+                "--no-plan-review",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+        assert payload["config"]["require_plan_review"] is False
+
+
+def test_mission_create_max_builders_overrides_config(tmp_path: Path):
+    """--max-builders sets max_parallel_builders in config."""
+    spec_file = tmp_path / "spec.md"
+    spec_file.write_text("spec")
+
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"mission_id": "m1"}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission", "create",
+                "--spec", str(spec_file),
+                "--max-builders", "8",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+        assert payload["config"]["max_parallel_builders"] == 8
+
+
+# ---------------------------------------------------------------------------
+# mission status
+# ---------------------------------------------------------------------------
+
+
+def test_mission_status_formats_output():
+    """mission status shows formatted mission overview."""
+    runner = CliRunner()
+
+    mission_data = {
+        "mission_id": "mission-auth-123",
+        "status": "building",
+        "config": {"completion_mode": "best_effort"},
+        "task_ids": ["task-1", "task-2", "task-3"],
+        "created_at": "2026-04-09T10:00:00Z",
+        "plan_task_id": "plan-auth",
+        "spec_file": "spec.md",
+    }
+
+    with patch("antfarm.core.cli.httpx.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mission_data
+        mock_get.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            ["mission", "status", "mission-auth-123", "--colony-url", "http://localhost:7433"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "mission-auth-123" in result.output
+        assert "building" in result.output
+        assert "best_effort" in result.output
+        assert "3" in result.output
+
+
+def test_mission_status_shows_completion_mode_warning():
+    """all_or_nothing completion mode shows v0.6.0 warning."""
+    runner = CliRunner()
+
+    mission_data = {
+        "mission_id": "mission-strict",
+        "status": "building",
+        "config": {"completion_mode": "all_or_nothing"},
+        "task_ids": [],
+        "created_at": "2026-04-09T10:00:00Z",
+    }
+
+    with patch("antfarm.core.cli.httpx.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mission_data
+        mock_get.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            ["mission", "status", "mission-strict", "--colony-url", "http://localhost:7433"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "all_or_nothing" in result.output
+        assert "treated as best_effort in v0.6.0" in result.output
+
+
+# ---------------------------------------------------------------------------
+# mission report
+# ---------------------------------------------------------------------------
+
+
+def _mock_report_data():
+    return {
+        "mission_id": "mission-auth-123",
+        "status": "complete",
+        "duration": "2h 15m",
+        "tasks": [
+            {"id": "task-1", "title": "Auth endpoints", "status": "merged"},
+            {"id": "task-2", "title": "Auth tests", "status": "merged"},
+        ],
+    }
+
+
+def test_mission_report_terminal_format():
+    """mission report with terminal format shows table."""
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = _mock_report_data()
+        mock_get.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission", "report", "mission-auth-123",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "mission-auth-123" in result.output
+        assert "complete" in result.output
+        assert "Auth endpoints" in result.output
+
+
+def test_mission_report_markdown_format():
+    """mission report with md format shows markdown."""
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = _mock_report_data()
+        mock_get.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission", "report", "mission-auth-123",
+                "--format", "md",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "# Mission Report" in result.output
+        assert "**Status:**" in result.output
+        assert "Auth endpoints" in result.output
+
+
+def test_mission_report_json_format():
+    """mission report with json format outputs valid JSON."""
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = _mock_report_data()
+        mock_get.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission", "report", "mission-auth-123",
+                "--format", "json",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert parsed["mission_id"] == "mission-auth-123"
+        assert len(parsed["tasks"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# mission cancel
+# ---------------------------------------------------------------------------
+
+
+def test_mission_cancel_success():
+    """mission cancel POSTs to /missions/{id}/cancel."""
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            ["mission", "cancel", "mission-auth-123", "--colony-url", "http://localhost:7433"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "cancelled" in result.output.lower()
+        url = mock_post.call_args.args[0]
+        assert "missions/mission-auth-123/cancel" in url
+
+
+# ---------------------------------------------------------------------------
+# mission list
+# ---------------------------------------------------------------------------
+
+
+def test_mission_list_filters_by_status():
+    """mission list --status filters results."""
+    runner = CliRunner()
+
+    missions = [
+        {"mission_id": "m1", "status": "building", "task_ids": ["t1"]},
+    ]
+
+    with patch("antfarm.core.cli.httpx.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = missions
+        mock_get.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission", "list",
+                "--status", "building",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "m1" in result.output
+        assert "building" in result.output
+        url = mock_get.call_args.args[0]
+        assert "status=building" in url
+
+
+def test_mission_list_empty():
+    """mission list with no missions shows message."""
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = []
+        mock_get.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            ["mission", "list", "--colony-url", "http://localhost:7433"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "No missions found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# carry --mission
+# ---------------------------------------------------------------------------
+
+
+def test_carry_with_mission_option():
+    """carry --mission attaches mission_id to payload."""
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"task_id": "task-123"}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "carry",
+                "--title", "Auth endpoint",
+                "--spec", "Build the auth endpoint",
+                "--mission", "mission-auth-123",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+        assert payload["mission_id"] == "mission-auth-123"
+
+
+# ---------------------------------------------------------------------------
+# colony flags
+# ---------------------------------------------------------------------------
+
+
+def test_colony_autoscaler_flag_parsing():
+    """colony --autoscaler flag is accepted without error."""
+    runner = CliRunner()
+
+    with (
+        patch("uvicorn.run"),
+        patch("antfarm.core.backends.file.FileBackend"),
+        patch("antfarm.core.serve.get_app") as mock_get_app,
+    ):
+        mock_get_app.return_value = MagicMock()
+
+        result = runner.invoke(
+            main,
+            ["colony", "--autoscaler", "--port", "9000"],
+        )
+
+        assert result.exit_code == 0, result.output
+
+
+def test_colony_no_queen_flag():
+    """colony --no-queen passes enable_queen=False to get_app."""
+    runner = CliRunner()
+
+    with (
+        patch("uvicorn.run"),
+        patch("antfarm.core.backends.file.FileBackend"),
+        patch("antfarm.core.serve.get_app") as mock_get_app,
+    ):
+        mock_get_app.return_value = MagicMock()
+
+        result = runner.invoke(
+            main,
+            ["colony", "--no-queen", "--port", "9000"],
+        )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_get_app.call_args
+        assert call_kwargs.kwargs.get("enable_queen") is False

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -591,3 +591,114 @@ def test_get_worker_type_reviewer_by_capability():
     tui = _make_tui()
     assert tui._get_worker_type({"agent_type": "claude-code",
                                   "capabilities": ["review"]}) == "reviewer"
+
+
+# ---------------------------------------------------------------------------
+# Mission panel
+# ---------------------------------------------------------------------------
+
+
+def _mission(
+    mission_id: str = "mission-auth",
+    status: str = "building",
+    task_ids: list | None = None,
+    blocked_task_ids: list | None = None,
+    last_progress_at: str = "2026-04-05T00:00:00+00:00",
+    report: dict | None = None,
+) -> dict:
+    return {
+        "mission_id": mission_id,
+        "status": status,
+        "task_ids": task_ids or [],
+        "blocked_task_ids": blocked_task_ids or [],
+        "last_progress_at": last_progress_at,
+        "report": report,
+    }
+
+
+def test_tui_mission_panel_renders_empty():
+    """Empty missions list shows 'No active missions.' placeholder."""
+    tui = _make_tui()
+    result = tui._render_missions([])
+    assert isinstance(result, Table)
+    assert result.row_count == 1
+
+
+def test_tui_mission_panel_renders_multi():
+    """Multiple missions render with correct row count."""
+    tui = _make_tui()
+    missions = [
+        _mission(mission_id="mission-auth", status="building",
+                 task_ids=["t1", "t2", "t3", "t4", "t5", "t6"],
+                 report={"merged_tasks": 4}),
+        _mission(mission_id="mission-api-v2", status="complete",
+                 task_ids=["t1", "t2", "t3", "t4"],
+                 report={"merged_tasks": 4}),
+        _mission(mission_id="mission-migrate", status="blocked",
+                 task_ids=["t1", "t2", "t3", "t4", "t5"],
+                 blocked_task_ids=["t3"]),
+    ]
+    result = tui._render_missions(missions)
+    assert isinstance(result, Table)
+    assert result.row_count == 3
+
+
+def test_tui_mission_panel_formats_progress_time():
+    """Progress column shows correct format per status."""
+    tui = _make_tui()
+
+    # Complete mission -> "done"
+    assert tui._format_mission_progress(
+        _mission(status="complete")
+    ) == "done"
+
+    # Failed mission -> "done"
+    assert tui._format_mission_progress(
+        _mission(status="failed")
+    ) == "done"
+
+    # Cancelled mission -> "done"
+    assert tui._format_mission_progress(
+        _mission(status="cancelled")
+    ) == "done"
+
+    # Blocked mission -> "stalled <time>"
+    result = tui._format_mission_progress(
+        _mission(status="blocked", last_progress_at="2026-04-05T00:00:00+00:00")
+    )
+    assert result.startswith("stalled ")
+
+    # Active mission -> "<time> ago"
+    result = tui._format_mission_progress(
+        _mission(status="building", last_progress_at="2026-04-05T00:00:00+00:00")
+    )
+    assert result.endswith(" ago")
+
+    # No last_progress_at -> "--"
+    assert tui._format_mission_progress(
+        _mission(status="building", last_progress_at="")
+    ) == "--"
+
+
+def test_tui_mission_panel_shows_blocked_count():
+    """Blocked task count appears in tasks column."""
+    tui = _make_tui()
+    missions = [
+        _mission(
+            task_ids=["t1", "t2", "t3"],
+            blocked_task_ids=["t2"],
+        ),
+    ]
+    result = tui._render_missions(missions)
+    assert isinstance(result, Table)
+    assert result.row_count == 1
+
+
+def test_tui_mission_panel_overflow():
+    """More than max_shown missions shows overflow hint."""
+    tui = _make_tui()
+    missions = [_mission(mission_id=f"mission-{i}") for i in range(8)]
+    result = tui._render_missions(missions, max_shown=5)
+    assert isinstance(result, Table)
+    # 5 shown + 1 overflow hint
+    assert result.row_count == 6


### PR DESCRIPTION
## Summary
- New `antfarm/core/autoscaler.py`: scope-aware worker spawning, subprocess lifecycle
- `_start_autoscaler_thread()` in serve.py (opt-in via --autoscaler)
- 33 new tests

## Test plan
- [x] 744 tests pass, ruff clean
- [x] Code review: APPROVED

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)