### PR TITLE
feat(cli): mission CLI commands (#171)

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -130,6 +130,30 @@ def version():
     help="Disable the built-in Doctor health-check daemon.",
 )
 @click.option(
+    "--no-queen",
+    is_flag=True,
+    default=False,
+    help="Disable the Queen mission controller.",
+)
+@click.option(
+    "--autoscaler/--no-autoscaler",
+    default=False,
+    show_default=True,
+    help="Enable/disable the single-host autoscaler.",
+)
+@click.option(
+    "--max-builders",
+    type=int,
+    default=None,
+    help="Maximum parallel builder workers (pass-through to AutoscalerConfig).",
+)
+@click.option(
+    "--max-reviewers",
+    type=int,
+    default=None,
+    help="Maximum parallel reviewer workers (pass-through to AutoscalerConfig).",
+)
+@click.option(
     "--backend",
     default="file",
     show_default=True,
@@ -157,6 +181,10 @@ def colony(
     backup_interval: int,
     no_soldier: bool,
     no_doctor: bool,
+    no_queen: bool,
+    autoscaler: bool,
+    max_builders: int | None,
+    max_reviewers: int | None,
     backend: str,
     github_repo: str | None,
     github_token: str | None,
@@ -175,12 +203,30 @@ def colony(
     else:
         task_backend = get_backend("file", root=data_dir)
 
+    autoscaler_cfg = None
+    if autoscaler:
+        from antfarm.core.autoscaler import AutoscalerConfig
+
+        autoscaler_cfg = AutoscalerConfig(
+            enabled=True,
+            data_dir=data_dir,
+            colony_url=f"http://127.0.0.1:{port}",
+        )
+        if max_builders is not None:
+            autoscaler_cfg.max_builders = max_builders
+        if max_reviewers is not None:
+            autoscaler_cfg.max_reviewers = max_reviewers
+        if auth_token:
+            autoscaler_cfg.token = auth_token
+
     app = get_app(
         task_backend,
         data_dir=data_dir,
         auth_secret=auth_token,
         enable_soldier=not no_soldier,
         enable_doctor=not no_doctor,
+        enable_queen=not no_queen,
+        autoscaler_config=autoscaler_cfg,
     )
     if auth_token:
         from antfarm.core.auth import generate_token
@@ -385,6 +431,8 @@ def worker_start(
               help="Task type: 'plan' for planner decomposition.")
 @click.option("--issue", "issue_number", default=None, type=int,
               help="GitHub issue number to link.")
+@click.option("--mission", "mission_id", default=None,
+              help="Attach this task to an existing mission.")
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def carry(
@@ -399,6 +447,7 @@ def carry(
     task_id: str | None,
     task_type: str | None,
     issue_number: int | None,
+    mission_id: str | None,
     colony_url: str,
     token: str | None,
 ):
@@ -430,6 +479,9 @@ def carry(
             payload["capabilities_required"].append("plan")
 
     payload["id"] = task_id
+
+    if mission_id:
+        payload["mission_id"] = mission_id
 
     # Append issue reference to spec so workers include it in commits
     if issue_number:
@@ -1035,6 +1087,163 @@ def plan(
             click.echo(f"  Created: {r}")
         except Exception as exc:
             click.echo(f"  Failed to carry task {i}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# mission
+# ---------------------------------------------------------------------------
+
+
+@main.group()
+def mission():
+    """Manage autonomous missions."""
+
+
+@mission.command("create")
+@click.option("--spec", "spec_path", required=True, type=click.Path(exists=True),
+              help="Path to spec file.")
+@click.option("--mission-id", default=None, help="Optional explicit mission id slug.")
+@click.option("--no-plan-review", is_flag=True, default=False,
+              help="Skip plan review step.")
+@click.option("--max-builders", type=int, default=None,
+              help="Max parallel builder workers.")
+@click.option("--max-attempts", type=int, default=None,
+              help="Max attempts per task.")
+@click.option("--integration-branch", default=None,
+              help="Integration branch for this mission.")
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def mission_create(
+    spec_path: str,
+    mission_id: str | None,
+    no_plan_review: bool,
+    max_builders: int | None,
+    max_attempts: int | None,
+    integration_branch: str | None,
+    colony_url: str,
+    token: str | None,
+):
+    """Create an autonomous mission from a spec file."""
+    with open(spec_path) as f:
+        spec_text = f.read()
+
+    payload: dict = {"spec": spec_text, "spec_file": spec_path}
+    config: dict = {}
+    if no_plan_review:
+        config["require_plan_review"] = False
+    if max_builders is not None:
+        config["max_parallel_builders"] = max_builders
+    if max_attempts is not None:
+        config["max_attempts"] = max_attempts
+    if integration_branch is not None:
+        config["integration_branch"] = integration_branch
+    if config:
+        payload["config"] = config
+    if mission_id:
+        payload["mission_id"] = mission_id
+
+    result = _post(colony_url, "/missions", payload, token=token)
+    click.echo(f"Mission created: {result}")
+
+
+@mission.command("status")
+@click.argument("mission_id")
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def mission_status(mission_id: str, colony_url: str, token: str | None):
+    """Show mission status overview."""
+    data = _get(colony_url, f"/missions/{mission_id}", token=token)
+
+    click.echo(f"Mission:    {data.get('mission_id', mission_id)}")
+    click.echo(f"Status:     {data.get('status', 'unknown')}")
+
+    config = data.get("config", {})
+    completion_mode = config.get("completion_mode", "best_effort")
+    if completion_mode == "all_or_nothing":
+        click.echo(
+            f"Completion: {completion_mode} (treated as best_effort in v0.6.0)"
+        )
+    else:
+        click.echo(f"Completion: {completion_mode}")
+
+    task_ids = data.get("task_ids", [])
+    click.echo(f"Tasks:      {len(task_ids)}")
+    click.echo(f"Created:    {data.get('created_at', 'unknown')}")
+
+    if data.get("plan_task_id"):
+        click.echo(f"Plan task:  {data['plan_task_id']}")
+    if data.get("spec_file"):
+        click.echo(f"Spec file:  {data['spec_file']}")
+
+
+@mission.command("report")
+@click.argument("mission_id")
+@click.option("--format", "fmt", type=click.Choice(["terminal", "md", "json"]),
+              default="terminal", show_default=True, help="Output format.")
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def mission_report(mission_id: str, fmt: str, colony_url: str, token: str | None):
+    """Show mission report."""
+    data = _get(colony_url, f"/missions/{mission_id}/report", token=token)
+
+    if fmt == "json":
+        click.echo(json.dumps(data, indent=2))
+    elif fmt == "md":
+        click.echo(f"# Mission Report: {data.get('mission_id', mission_id)}")
+        click.echo(f"\n**Status:** {data.get('status', 'unknown')}")
+        click.echo(f"**Duration:** {data.get('duration', 'unknown')}")
+        tasks = data.get("tasks", [])
+        if tasks:
+            click.echo("\n## Tasks\n")
+            for t in tasks:
+                status = t.get("status", "unknown")
+                click.echo(f"- **{t.get('title', t.get('id', '?'))}** — {status}")
+    else:
+        click.echo(f"Mission:  {data.get('mission_id', mission_id)}")
+        click.echo(f"Status:   {data.get('status', 'unknown')}")
+        click.echo(f"Duration: {data.get('duration', 'unknown')}")
+        tasks = data.get("tasks", [])
+        if tasks:
+            click.echo(f"\n{'Task':<30} {'Status':<12}")
+            click.echo("-" * 42)
+            for t in tasks:
+                title = t.get("title", t.get("id", "?"))[:28]
+                status = t.get("status", "unknown")
+                click.echo(f"{title:<30} {status:<12}")
+
+
+@mission.command("cancel")
+@click.argument("mission_id")
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def mission_cancel(mission_id: str, colony_url: str, token: str | None):
+    """Cancel a mission."""
+    _post(colony_url, f"/missions/{mission_id}/cancel", {}, token=token)
+    click.echo(f"Mission cancelled: {mission_id}")
+
+
+@mission.command("list")
+@click.option("--status", "status_filter", default=None, help="Filter by mission status.")
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def mission_list(status_filter: str | None, colony_url: str, token: str | None):
+    """List all missions."""
+    path = "/missions"
+    if status_filter:
+        path += f"?status={status_filter}"
+    data = _get(colony_url, path, token=token)
+
+    if not data:
+        click.echo("No missions found.")
+        return
+
+    click.echo(f"{'Mission ID':<35} {'Status':<15} {'Tasks'}")
+    click.echo("-" * 60)
+    for m in data:
+        mid = m.get("mission_id", "?")
+        status = m.get("status", "?")
+        task_count = len(m.get("task_ids", []))
+        click.echo(f"{mid:<35} {status:<15} {task_count}")
 
 
 # ---------------------------------------------------------------------------

--- a/antfarm/core/tui.py
+++ b/antfarm/core/tui.py
@@ -66,7 +66,7 @@ class AntfarmTUI:
                 pass
 
     def _build_display(self) -> Layout:
-        """Fetch status + tasks + workers and build the display."""
+        """Fetch status + tasks + workers + missions and build the display."""
         try:
             full = self._fetch("/status/full")
             status = full.get("status", {})
@@ -78,11 +78,18 @@ class AntfarmTUI:
             layout.update(Panel(f"[red]Connection error: {exc}[/red]", title="Antfarm TUI"))
             return layout
 
+        try:
+            missions = self._fetch("/missions")
+        except Exception:
+            missions = []
+
         snap = self._classify_tasks(tasks)
 
         layout = Layout()
+        missions_size = max(5, min(len(missions) + 4, 10)) if missions else 5
         layout.split_column(
             Layout(name="header", size=10),
+            Layout(name="missions", size=missions_size),
             Layout(name="workers", size=max(5, len(workers) + 5)),
             Layout(name="waiting", size=7),
             Layout(name="planning", size=5),
@@ -116,6 +123,13 @@ class AntfarmTUI:
             Panel(
                 self._render_summary(status, tasks, workers, snap, soldier_status),
                 title="[bold blue]Antfarm Colony[/bold blue]",
+            )
+        )
+
+        layout["missions"].update(
+            Panel(
+                self._render_missions(missions),
+                title=f"[bold bright_white]Missions ({len(missions)})[/bold bright_white]",
             )
         )
 
@@ -434,6 +448,84 @@ class AntfarmTUI:
         table.add_row("Pipeline", self._render_pipeline_bar(counts))
 
         return table
+
+    def _render_missions(self, missions: list[dict], max_shown: int = 5) -> Table:
+        """Render mission list with status, task counts, and progress time."""
+        table = Table(show_header=True, header_style="bold", box=None, padding=(0, 1))
+        table.add_column("ID", max_width=25, no_wrap=True)
+        table.add_column("Status", max_width=15, no_wrap=True)
+        table.add_column("Tasks", max_width=8, no_wrap=True)
+        table.add_column("Progress", max_width=20, no_wrap=True)
+
+        if not missions:
+            table.add_row("[dim]--[/dim]", "[dim]No active missions.[/dim]", "", "")
+            return table
+
+        status_style = {
+            "planning": "magenta",
+            "reviewing_plan": "magenta",
+            "building": "yellow",
+            "blocked": "red",
+            "complete": "green",
+            "failed": "red",
+            "cancelled": "dim",
+        }
+
+        shown = missions[:max_shown]
+        for m in shown:
+            mid = m.get("mission_id", "")
+            mstatus = m.get("status", "")
+            style = status_style.get(mstatus, "dim")
+
+            # Task counts: total / merged / blocked
+            task_ids = m.get("task_ids", [])
+            blocked_ids = m.get("blocked_task_ids", [])
+            total = len(task_ids)
+            blocked = len(blocked_ids)
+
+            # Derive merged count from report if available
+            report = m.get("report")
+            merged = report.get("merged_tasks", 0) if report else 0
+            tasks_text = f"{merged}/{total}"
+            if blocked > 0:
+                tasks_text += f" ({blocked}blk)"
+
+            # Progress column
+            progress = self._format_mission_progress(m)
+
+            table.add_row(
+                Text(mid[:23], style=style),
+                Text(mstatus, style=style),
+                Text(tasks_text, style="dim"),
+                Text(progress, style="dim"),
+            )
+
+        self._add_overflow_hint(table, len(missions), max_shown)
+        return table
+
+    def _format_mission_progress(self, mission: dict) -> str:
+        """Format progress column for a mission.
+
+        - complete/failed/cancelled: "done"
+        - blocked with last_progress_at: "stalled <elapsed>"
+        - active with last_progress_at: "<elapsed> ago"
+        - no last_progress_at: "--"
+        """
+        mstatus = mission.get("status", "")
+        if mstatus in ("complete", "failed", "cancelled"):
+            return "done"
+
+        last_progress = mission.get("last_progress_at", "")
+        if not last_progress:
+            return "--"
+
+        elapsed = self._format_elapsed_since(last_progress)
+        if not elapsed:
+            return "--"
+
+        if mstatus == "blocked":
+            return f"stalled {elapsed}"
+        return f"{elapsed} ago"
 
     def _render_pipeline_bar(self, counts: dict, width: int = 50) -> Text:
         """Render colored block chars representing pipeline distribution."""

--- a/tests/test_mission_cli.py
+++ b/tests/test_mission_cli.py
@@ -1,0 +1,412 @@
+"""Tests for the mission CLI commands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from antfarm.core.cli import main
+
+# ---------------------------------------------------------------------------
+# mission create
+# ---------------------------------------------------------------------------
+
+
+def test_mission_create_reads_spec_file_and_posts(tmp_path: Path):
+    """mission create reads spec file and POSTs to /missions."""
+    spec_file = tmp_path / "spec.md"
+    spec_file.write_text("Build an auth system")
+
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"mission_id": "mission-auth-123"}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission", "create",
+                "--spec", str(spec_file),
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "mission-auth-123" in result.output
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+        assert payload["spec"] == "Build an auth system"
+        assert payload["spec_file"] == str(spec_file)
+
+
+def test_mission_create_no_plan_review_flag_sets_config(tmp_path: Path):
+    """--no-plan-review sets require_plan_review=False in config."""
+    spec_file = tmp_path / "spec.md"
+    spec_file.write_text("spec content")
+
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"mission_id": "m1"}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission", "create",
+                "--spec", str(spec_file),
+                "--no-plan-review",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+        assert payload["config"]["require_plan_review"] is False
+
+
+def test_mission_create_max_builders_overrides_config(tmp_path: Path):
+    """--max-builders sets max_parallel_builders in config."""
+    spec_file = tmp_path / "spec.md"
+    spec_file.write_text("spec")
+
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"mission_id": "m1"}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission", "create",
+                "--spec", str(spec_file),
+                "--max-builders", "8",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+        assert payload["config"]["max_parallel_builders"] == 8
+
+
+# ---------------------------------------------------------------------------
+# mission status
+# ---------------------------------------------------------------------------
+
+
+def test_mission_status_formats_output():
+    """mission status shows formatted mission overview."""
+    runner = CliRunner()
+
+    mission_data = {
+        "mission_id": "mission-auth-123",
+        "status": "building",
+        "config": {"completion_mode": "best_effort"},
+        "task_ids": ["task-1", "task-2", "task-3"],
+        "created_at": "2026-04-09T10:00:00Z",
+        "plan_task_id": "plan-auth",
+        "spec_file": "spec.md",
+    }
+
+    with patch("antfarm.core.cli.httpx.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mission_data
+        mock_get.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            ["mission", "status", "mission-auth-123", "--colony-url", "http://localhost:7433"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "mission-auth-123" in result.output
+        assert "building" in result.output
+        assert "best_effort" in result.output
+        assert "3" in result.output
+
+
+def test_mission_status_shows_completion_mode_warning():
+    """all_or_nothing completion mode shows v0.6.0 warning."""
+    runner = CliRunner()
+
+    mission_data = {
+        "mission_id": "mission-strict",
+        "status": "building",
+        "config": {"completion_mode": "all_or_nothing"},
+        "task_ids": [],
+        "created_at": "2026-04-09T10:00:00Z",
+    }
+
+    with patch("antfarm.core.cli.httpx.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mission_data
+        mock_get.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            ["mission", "status", "mission-strict", "--colony-url", "http://localhost:7433"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "all_or_nothing" in result.output
+        assert "treated as best_effort in v0.6.0" in result.output
+
+
+# ---------------------------------------------------------------------------
+# mission report
+# ---------------------------------------------------------------------------
+
+
+def _mock_report_data():
+    return {
+        "mission_id": "mission-auth-123",
+        "status": "complete",
+        "duration": "2h 15m",
+        "tasks": [
+            {"id": "task-1", "title": "Auth endpoints", "status": "merged"},
+            {"id": "task-2", "title": "Auth tests", "status": "merged"},
+        ],
+    }
+
+
+def test_mission_report_terminal_format():
+    """mission report with terminal format shows table."""
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = _mock_report_data()
+        mock_get.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission", "report", "mission-auth-123",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "mission-auth-123" in result.output
+        assert "complete" in result.output
+        assert "Auth endpoints" in result.output
+
+
+def test_mission_report_markdown_format():
+    """mission report with md format shows markdown."""
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = _mock_report_data()
+        mock_get.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission", "report", "mission-auth-123",
+                "--format", "md",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "# Mission Report" in result.output
+        assert "**Status:**" in result.output
+        assert "Auth endpoints" in result.output
+
+
+def test_mission_report_json_format():
+    """mission report with json format outputs valid JSON."""
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = _mock_report_data()
+        mock_get.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission", "report", "mission-auth-123",
+                "--format", "json",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        assert parsed["mission_id"] == "mission-auth-123"
+        assert len(parsed["tasks"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# mission cancel
+# ---------------------------------------------------------------------------
+
+
+def test_mission_cancel_success():
+    """mission cancel POSTs to /missions/{id}/cancel."""
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            ["mission", "cancel", "mission-auth-123", "--colony-url", "http://localhost:7433"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "cancelled" in result.output.lower()
+        url = mock_post.call_args.args[0]
+        assert "missions/mission-auth-123/cancel" in url
+
+
+# ---------------------------------------------------------------------------
+# mission list
+# ---------------------------------------------------------------------------
+
+
+def test_mission_list_filters_by_status():
+    """mission list --status filters results."""
+    runner = CliRunner()
+
+    missions = [
+        {"mission_id": "m1", "status": "building", "task_ids": ["t1"]},
+    ]
+
+    with patch("antfarm.core.cli.httpx.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = missions
+        mock_get.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission", "list",
+                "--status", "building",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "m1" in result.output
+        assert "building" in result.output
+        url = mock_get.call_args.args[0]
+        assert "status=building" in url
+
+
+def test_mission_list_empty():
+    """mission list with no missions shows message."""
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = []
+        mock_get.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            ["mission", "list", "--colony-url", "http://localhost:7433"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "No missions found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# carry --mission
+# ---------------------------------------------------------------------------
+
+
+def test_carry_with_mission_option():
+    """carry --mission attaches mission_id to payload."""
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"task_id": "task-123"}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "carry",
+                "--title", "Auth endpoint",
+                "--spec", "Build the auth endpoint",
+                "--mission", "mission-auth-123",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+        assert payload["mission_id"] == "mission-auth-123"
+
+
+# ---------------------------------------------------------------------------
+# colony flags
+# ---------------------------------------------------------------------------
+
+
+def test_colony_autoscaler_flag_parsing():
+    """colony --autoscaler flag is accepted without error."""
+    runner = CliRunner()
+
+    with (
+        patch("uvicorn.run"),
+        patch("antfarm.core.backends.file.FileBackend"),
+        patch("antfarm.core.serve.get_app") as mock_get_app,
+    ):
+        mock_get_app.return_value = MagicMock()
+
+        result = runner.invoke(
+            main,
+            ["colony", "--autoscaler", "--port", "9000"],
+        )
+
+        assert result.exit_code == 0, result.output
+
+
+def test_colony_no_queen_flag():
+    """colony --no-queen passes enable_queen=False to get_app."""
+    runner = CliRunner()
+
+    with (
+        patch("uvicorn.run"),
+        patch("antfarm.core.backends.file.FileBackend"),
+        patch("antfarm.core.serve.get_app") as mock_get_app,
+    ):
+        mock_get_app.return_value = MagicMock()
+
+        result = runner.invoke(
+            main,
+            ["colony", "--no-queen", "--port", "9000"],
+        )
+
+        assert result.exit_code == 0, result.output
+        call_kwargs = mock_get_app.call_args
+        assert call_kwargs.kwargs.get("enable_queen") is False

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -591,3 +591,114 @@ def test_get_worker_type_reviewer_by_capability():
     tui = _make_tui()
     assert tui._get_worker_type({"agent_type": "claude-code",
                                   "capabilities": ["review"]}) == "reviewer"
+
+
+# ---------------------------------------------------------------------------
+# Mission panel
+# ---------------------------------------------------------------------------
+
+
+def _mission(
+    mission_id: str = "mission-auth",
+    status: str = "building",
+    task_ids: list | None = None,
+    blocked_task_ids: list | None = None,
+    last_progress_at: str = "2026-04-05T00:00:00+00:00",
+    report: dict | None = None,
+) -> dict:
+    return {
+        "mission_id": mission_id,
+        "status": status,
+        "task_ids": task_ids or [],
+        "blocked_task_ids": blocked_task_ids or [],
+        "last_progress_at": last_progress_at,
+        "report": report,
+    }
+
+
+def test_tui_mission_panel_renders_empty():
+    """Empty missions list shows 'No active missions.' placeholder."""
+    tui = _make_tui()
+    result = tui._render_missions([])
+    assert isinstance(result, Table)
+    assert result.row_count == 1
+
+
+def test_tui_mission_panel_renders_multi():
+    """Multiple missions render with correct row count."""
+    tui = _make_tui()
+    missions = [
+        _mission(mission_id="mission-auth", status="building",
+                 task_ids=["t1", "t2", "t3", "t4", "t5", "t6"],
+                 report={"merged_tasks": 4}),
+        _mission(mission_id="mission-api-v2", status="complete",
+                 task_ids=["t1", "t2", "t3", "t4"],
+                 report={"merged_tasks": 4}),
+        _mission(mission_id="mission-migrate", status="blocked",
+                 task_ids=["t1", "t2", "t3", "t4", "t5"],
+                 blocked_task_ids=["t3"]),
+    ]
+    result = tui._render_missions(missions)
+    assert isinstance(result, Table)
+    assert result.row_count == 3
+
+
+def test_tui_mission_panel_formats_progress_time():
+    """Progress column shows correct format per status."""
+    tui = _make_tui()
+
+    # Complete mission -> "done"
+    assert tui._format_mission_progress(
+        _mission(status="complete")
+    ) == "done"
+
+    # Failed mission -> "done"
+    assert tui._format_mission_progress(
+        _mission(status="failed")
+    ) == "done"
+
+    # Cancelled mission -> "done"
+    assert tui._format_mission_progress(
+        _mission(status="cancelled")
+    ) == "done"
+
+    # Blocked mission -> "stalled <time>"
+    result = tui._format_mission_progress(
+        _mission(status="blocked", last_progress_at="2026-04-05T00:00:00+00:00")
+    )
+    assert result.startswith("stalled ")
+
+    # Active mission -> "<time> ago"
+    result = tui._format_mission_progress(
+        _mission(status="building", last_progress_at="2026-04-05T00:00:00+00:00")
+    )
+    assert result.endswith(" ago")
+
+    # No last_progress_at -> "--"
+    assert tui._format_mission_progress(
+        _mission(status="building", last_progress_at="")
+    ) == "--"
+
+
+def test_tui_mission_panel_shows_blocked_count():
+    """Blocked task count appears in tasks column."""
+    tui = _make_tui()
+    missions = [
+        _mission(
+            task_ids=["t1", "t2", "t3"],
+            blocked_task_ids=["t2"],
+        ),
+    ]
+    result = tui._render_missions(missions)
+    assert isinstance(result, Table)
+    assert result.row_count == 1
+
+
+def test_tui_mission_panel_overflow():
+    """More than max_shown missions shows overflow hint."""
+    tui = _make_tui()
+    missions = [_mission(mission_id=f"mission-{i}") for i in range(8)]
+    result = tui._render_missions(missions, max_shown=5)
+    assert isinstance(result, Table)
+    # 5 shown + 1 overflow hint
+    assert result.row_count == 6


### PR DESCRIPTION
## Summary
- `antfarm mission create|status|report|cancel|list` commands
- `carry --mission`, `colony --autoscaler|--no-queen` flags
- completion_mode warning in status output, 14 new tests

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)