### PR TITLE
fix(worker): retry reviewer when [REVIEW_VERDICT] tags missing (#143)

### DIFF
--- a/antfarm/adapters/claude_code/agents/reviewer.md
+++ b/antfarm/adapters/claude_code/agents/reviewer.md
@@ -19,29 +19,59 @@ The task spec contains:
 
 ## Output
 
-Output your verdict between these tags:
+### MANDATORY FORMAT — READ THIS TWICE
+
+**Your verdict MUST be wrapped in `[REVIEW_VERDICT]` ... `[/REVIEW_VERDICT]` tags.**
+**The content between the tags MUST be a single valid JSON object.**
+**If you forget the tags, the colony cannot parse your verdict and the review will be retried or failed.**
+
+### Worked example 1 — pass
 
 ```
 [REVIEW_VERDICT]
 {
   "provider": "claude_code",
   "verdict": "pass",
-  "summary": "Brief summary of findings",
-  "findings": ["finding 1", "finding 2"],
+  "summary": "Scheduler dependency fix is clean, tests cover the regression.",
+  "findings": [],
   "severity": "low",
-  "reviewed_commit_sha": "<HEAD commit SHA of the branch>"
+  "reviewed_commit_sha": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"
 }
 [/REVIEW_VERDICT]
 ```
 
-### Verdict values:
+### Worked example 2 — needs_changes
+
+```
+[REVIEW_VERDICT]
+{
+  "provider": "claude_code",
+  "verdict": "needs_changes",
+  "summary": "Guard release path drops owner validation — security regression.",
+  "findings": [
+    "release_guard() no longer checks owner before os.unlink()",
+    "Missing test for owner mismatch rejection"
+  ],
+  "severity": "high",
+  "reviewed_commit_sha": "1122334455667788990011223344556677889900"
+}
+[/REVIEW_VERDICT]
+```
+
+### Verdict values
+
 - `"pass"` — code is safe to merge
 - `"needs_changes"` — issues found that must be fixed before merge
 - `"blocked"` — critical issues that block merge entirely
 
-### Rules:
+### Rules
+
 - Be thorough but fair. Minor style issues are not blockers.
 - Always include the reviewed commit SHA (run `git rev-parse HEAD` on the branch).
-- If tests fail, verdict must be "needs_changes" or "blocked".
-- If lint fails, verdict should be "needs_changes".
+- If tests fail, verdict must be `"needs_changes"` or `"blocked"`.
+- If lint fails, verdict should be `"needs_changes"`.
 - Focus on correctness, security, and adherence to the spec.
+
+### Final checklist — do NOT skip
+
+Before you finish: did you wrap your JSON in `[REVIEW_VERDICT]` ... `[/REVIEW_VERDICT]`? If not, STOP and redo. A reply without the tags is treated as a failed review.

--- a/antfarm/adapters/codex/agents/reviewer.md
+++ b/antfarm/adapters/codex/agents/reviewer.md
@@ -6,20 +6,49 @@ You are a code reviewer for the Antfarm orchestration system. Review the PR bran
 
 1. Read the diff for the branch specified in the task spec
 2. Run tests and linter
-3. Output a ReviewVerdict between [REVIEW_VERDICT] and [/REVIEW_VERDICT] tags
+3. Produce a ReviewVerdict
 
-## Output format
+## Output
+
+### MANDATORY FORMAT — READ THIS TWICE
+
+**Your verdict MUST be wrapped in `[REVIEW_VERDICT]` ... `[/REVIEW_VERDICT]` tags.**
+**The content between the tags MUST be a single valid JSON object.**
+**If you forget the tags, the colony cannot parse your verdict and the review will be retried or failed.**
+
+### Worked example 1 — pass
 
 ```
 [REVIEW_VERDICT]
 {
   "provider": "codex",
   "verdict": "pass",
-  "summary": "Brief summary",
+  "summary": "Scheduler dependency fix is clean, tests cover the regression.",
   "findings": [],
-  "reviewed_commit_sha": "<HEAD SHA>"
+  "reviewed_commit_sha": "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"
 }
 [/REVIEW_VERDICT]
 ```
 
-Verdict values: "pass", "needs_changes", "blocked"
+### Worked example 2 — needs_changes
+
+```
+[REVIEW_VERDICT]
+{
+  "provider": "codex",
+  "verdict": "needs_changes",
+  "summary": "Guard release path drops owner validation — security regression.",
+  "findings": [
+    "release_guard() no longer checks owner before os.unlink()",
+    "Missing test for owner mismatch rejection"
+  ],
+  "reviewed_commit_sha": "1122334455667788990011223344556677889900"
+}
+[/REVIEW_VERDICT]
+```
+
+Verdict values: `"pass"`, `"needs_changes"`, `"blocked"`.
+
+### Final checklist — do NOT skip
+
+Before you finish: did you wrap your JSON in `[REVIEW_VERDICT]` ... `[/REVIEW_VERDICT]`? If not, STOP and redo. A reply without the tags is treated as a failed review.

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -239,10 +239,19 @@ class Soldier:
                 results.append((task_id, MergeResult.NEEDS_REVIEW))
                 continue
 
-            # Review task exists — check if it's done with a verdict
+            # Review task exists — check its status.
             review_status = review_task.get("status", "")
+            if review_status == "blocked":
+                # Review task exhausted its retry budget without producing a
+                # parseable verdict. Kick back the *original* task with a
+                # clear reason so the build can be reattempted.
+                self.kickback_with_cascade(
+                    task_id, "review task completed without a ReviewVerdict"
+                )
+                results.append((task_id, MergeResult.FAILED))
+                continue
             if review_status != "done":
-                # Still in progress
+                # Still in progress (ready/active/kicked-back awaiting retry)
                 results.append((task_id, MergeResult.NEEDS_REVIEW))
                 continue
 

--- a/antfarm/core/worker.py
+++ b/antfarm/core/worker.py
@@ -482,7 +482,13 @@ class WorkerRuntime:
                         exc,
                     )
             else:
-                # Agent didn't produce parseable [REVIEW_VERDICT] tags
+                # Agent didn't produce parseable [REVIEW_VERDICT] tags.
+                # Trail a warning, then kickback the review task itself so
+                # another reviewer attempt runs. The kickback budget (2 total
+                # attempts) is enforced by FileBackend.kickback via
+                # max_attempts — once exhausted, the review task moves to
+                # blocked and Soldier.run_once_with_review kicks back the
+                # *original* task with a clear reason.
                 logger.warning(
                     "reviewer produced no verdict for %s", original_task_id
                 )
@@ -491,6 +497,27 @@ class WorkerRuntime:
                         task_id,
                         self.worker_id,
                         f"WARNING: no [REVIEW_VERDICT] tags in output for {original_task_id}",
+                    )
+                review_attempt_count = len(task.get("attempts", []))
+                retry_budget = 2
+                if review_attempt_count < retry_budget:
+                    logger.info(
+                        "retrying review task %s (attempt %d/%d)",
+                        task_id,
+                        review_attempt_count,
+                        retry_budget,
+                    )
+                else:
+                    logger.warning(
+                        "review task %s exhausted retry budget (%d attempts)",
+                        task_id,
+                        review_attempt_count,
+                    )
+                with contextlib.suppress(Exception):
+                    self.colony.kickback(
+                        task_id,
+                        reason="reviewer produced no [REVIEW_VERDICT] tags",
+                        max_attempts=retry_budget,
                     )
 
         return True

--- a/antfarm/core/worker.py
+++ b/antfarm/core/worker.py
@@ -642,10 +642,34 @@ class WorkerRuntime:
                 "1. Read the PR diff for the branch above\n"
                 "2. Check for bugs, security issues, and design problems\n"
                 "3. Run tests to verify correctness\n"
-                "4. Output your verdict between tags:\n"
-                '   [REVIEW_VERDICT]{"provider":"<agent>","verdict":"pass",'
-                '"summary":"...","findings":[],'
-                '"reviewed_commit_sha":"..."}[/REVIEW_VERDICT]\n'
+                "4. Produce a ReviewVerdict (see output format below)\n\n"
+                "## MANDATORY OUTPUT FORMAT — READ THIS TWICE\n"
+                "Your verdict MUST be wrapped in [REVIEW_VERDICT] ... "
+                "[/REVIEW_VERDICT] tags.\n"
+                "The content between the tags MUST be a single valid JSON "
+                "object.\n"
+                "If you forget the tags, the colony cannot parse your verdict "
+                "and the review will be retried or failed.\n\n"
+                "### Worked example 1 — pass\n"
+                "[REVIEW_VERDICT]\n"
+                '{"provider":"<agent>","verdict":"pass",'
+                '"summary":"Change is clean, tests cover the regression.",'
+                '"findings":[],'
+                '"reviewed_commit_sha":"a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0"}\n'
+                "[/REVIEW_VERDICT]\n\n"
+                "### Worked example 2 — needs_changes\n"
+                "[REVIEW_VERDICT]\n"
+                '{"provider":"<agent>","verdict":"needs_changes",'
+                '"summary":"Missing owner validation on release path.",'
+                '"findings":["release_guard drops owner check",'
+                '"no test for mismatch"],'
+                '"reviewed_commit_sha":"1122334455667788990011223344556677889900"}\n'
+                "[/REVIEW_VERDICT]\n\n"
+                'Verdict values: "pass", "needs_changes", "blocked".\n\n'
+                "### Final checklist — do NOT skip\n"
+                "Before you finish: did you wrap your JSON in [REVIEW_VERDICT]"
+                " ... [/REVIEW_VERDICT]? If not, STOP and redo. A reply "
+                "without the tags is treated as a failed review.\n"
             )
         else:
             prompt = (

--- a/tests/test_review_execution.py
+++ b/tests/test_review_execution.py
@@ -16,7 +16,12 @@ from antfarm.core.colony_client import ColonyClient
 from antfarm.core.models import Attempt, AttemptStatus, ReviewVerdict
 from antfarm.core.serve import get_app
 from antfarm.core.soldier import MergeResult, Soldier
-from antfarm.core.worker import _extract_branch_from_spec, _parse_review_verdict
+from antfarm.core.worker import (
+    AgentResult,
+    WorkerRuntime,
+    _extract_branch_from_spec,
+    _parse_review_verdict,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -487,6 +492,271 @@ class TestWorkerReviewParsing:
 
     def test_extract_branch_from_spec_missing(self):
         assert _extract_branch_from_spec("no branch here") is None
+
+
+# ===========================================================================
+# Missing [REVIEW_VERDICT] retry path (issue #143)
+# ===========================================================================
+
+
+class _FakeColony:
+    """Records every call made against a ColonyClient-like interface."""
+
+    def __init__(self, task: dict):
+        self.task = task
+        self.trail_calls: list[tuple[str, str, str]] = []
+        self.kickback_calls: list[dict] = []
+        self.harvest_calls: list[dict] = []
+        self.mark_harvest_pending_calls: list[tuple[str, str]] = []
+        self.store_review_verdict_calls: list[dict] = []
+        self.base_url = "http://fake"
+
+    def forage(self, worker_id):  # pragma: no cover - unused path
+        return self.task
+
+    def trail(self, task_id, worker_id, message):
+        self.trail_calls.append((task_id, worker_id, message))
+
+    def mark_harvest_pending(self, task_id, attempt_id):
+        self.mark_harvest_pending_calls.append((task_id, attempt_id))
+
+    def harvest(self, task_id, attempt_id, pr, branch, artifact=None):
+        self.harvest_calls.append({
+            "task_id": task_id,
+            "attempt_id": attempt_id,
+            "pr": pr,
+            "branch": branch,
+            "artifact": artifact,
+        })
+
+    def kickback(self, task_id, reason, max_attempts=None):
+        self.kickback_calls.append({
+            "task_id": task_id,
+            "reason": reason,
+            "max_attempts": max_attempts,
+        })
+
+    def get_task(self, task_id):
+        return None
+
+    def store_review_verdict(self, task_id, attempt_id, verdict):
+        self.store_review_verdict_calls.append({
+            "task_id": task_id,
+            "attempt_id": attempt_id,
+            "verdict": verdict,
+        })
+
+
+def _make_review_task(task_id: str, attempts: int) -> dict:
+    """Build a review task dict as it would look after forage."""
+    return {
+        "id": task_id,
+        "title": f"Review {task_id}",
+        "spec": "Review task\n\nBranch: feat/task-001\n",
+        "status": "active",
+        "current_attempt": f"att-{attempts:03d}",
+        "attempts": [
+            {"attempt_id": f"att-{i + 1:03d}", "status": "active"}
+            for i in range(attempts)
+        ],
+        "capabilities_required": ["review"],
+        "depends_on": [],
+        "priority": 10,
+    }
+
+
+def _make_worker_with_fake_colony(fake: _FakeColony) -> WorkerRuntime:
+    """Construct a WorkerRuntime and swap in a fake colony + stubs."""
+    runtime = WorkerRuntime.__new__(WorkerRuntime)
+    runtime.worker_id = "node-1/reviewer-1"
+    runtime.node_id = "node-1"
+    runtime.agent_type = "claude-code"
+    runtime.workspace_root = "/tmp/ws"
+    runtime.heartbeat_interval = 30.0
+    runtime.capabilities = ["review"]
+    runtime._token = None
+    runtime._last_task_id = None
+    runtime._max_idle_polls = 0
+    runtime.colony = fake
+    runtime._heartbeat_event = None
+    runtime._heartbeat_thread = None
+
+    class _WS:
+        def create(self, task_id, attempt_id):
+            return "/tmp/ws/fake"
+
+    runtime.workspace_mgr = _WS()
+    runtime._start_heartbeat_loop = lambda: None
+    runtime._stop_heartbeat_loop = lambda: None
+    runtime._build_artifact = lambda task, attempt_id, workspace, branch: {}
+    runtime._create_pr = lambda task, branch, workspace: ""
+    return runtime
+
+
+class TestMissingVerdictKickback:
+    def test_missing_verdict_triggers_kickback(self):
+        task = _make_review_task("review-task-001", attempts=1)
+        fake = _FakeColony(task)
+        worker = _make_worker_with_fake_colony(fake)
+        worker._launch_agent = lambda t, ws: AgentResult(
+            returncode=0,
+            stdout="I finished reviewing. Looks fine.",
+            stderr="",
+            branch="feat/task-001",
+        )
+        worker.colony.forage = lambda worker_id: task
+
+        assert worker._process_one_task() is True
+
+        assert any(
+            "no [REVIEW_VERDICT] tags" in msg
+            for _, _, msg in fake.trail_calls
+        ), f"expected missing-tag trail warning, got {fake.trail_calls}"
+
+        assert len(fake.kickback_calls) == 1
+        call = fake.kickback_calls[0]
+        assert call["task_id"] == "review-task-001"
+        assert "REVIEW_VERDICT" in call["reason"]
+        assert call["max_attempts"] == 2
+
+        assert fake.store_review_verdict_calls == []
+
+    def test_missing_verdict_second_attempt_marks_failed(self, soldier_env):
+        """When the review task exhausts its retry budget and becomes blocked,
+        Soldier.run_once_with_review kicks back the *original* task with the
+        'review task completed without a ReviewVerdict' reason."""
+        cc = soldier_env["cc"]
+        soldier = soldier_env["soldier"]
+        repo = soldier_env["repo"]
+        backend = soldier_env["backend"]
+
+        original = _carry_and_harvest_git(cc, repo, "task-r2", "feat/task-r2")
+        attempt_id = original["current_attempt"]
+
+        soldier.process_done_tasks()
+        review_id = "review-task-r2"
+        assert cc.get_task(review_id) is not None
+
+        reviewer_id = "reviewer-r2"
+        cc.register_worker(
+            worker_id=reviewer_id, node_id="n1",
+            agent_type="generic", workspace_root="/tmp/ws",
+            capabilities=["review"],
+        )
+
+        # First failed review attempt
+        rt = cc.forage(reviewer_id)
+        assert rt is not None and rt["id"] == review_id
+        cc.harvest(
+            task_id=review_id,
+            attempt_id=rt["current_attempt"],
+            pr="", branch="review-branch",
+        )
+        backend.kickback(
+            review_id,
+            "reviewer produced no [REVIEW_VERDICT] tags",
+            max_attempts=2,
+        )
+
+        review_after_1 = cc.get_task(review_id)
+        assert review_after_1["status"] == "ready"
+
+        # Second failed review attempt — exhausts budget
+        rt2 = cc.forage(reviewer_id)
+        assert rt2 is not None and rt2["id"] == review_id
+        cc.harvest(
+            task_id=review_id,
+            attempt_id=rt2["current_attempt"],
+            pr="", branch="review-branch",
+        )
+        backend.kickback(
+            review_id,
+            "reviewer produced no [REVIEW_VERDICT] tags",
+            max_attempts=2,
+        )
+
+        review_after_2 = cc.get_task(review_id)
+        assert review_after_2["status"] == "blocked", (
+            f"expected review task BLOCKED after budget, got "
+            f"{review_after_2['status']}"
+        )
+
+        # Soldier now sees the blocked review task and kicks back the original
+        results = soldier.run_once_with_review()
+        assert ("task-r2", MergeResult.FAILED) in results
+
+        original_after = cc.get_task("task-r2")
+        assert original_after["status"] == "ready"
+        assert original_after["current_attempt"] is None
+        trail_messages = [
+            e.get("message", "") for e in original_after.get("trail", [])
+        ]
+        assert any(
+            "review task completed without a ReviewVerdict" in m
+            for m in trail_messages
+        ), f"expected kickback reason in trail, got {trail_messages}"
+        for a in original_after["attempts"]:
+            if a["attempt_id"] == attempt_id:
+                assert a["status"] == "superseded"
+
+    def test_valid_verdict_unchanged(self):
+        """Regression: a well-formed verdict still harvests and does NOT
+        trigger the retry kickback path."""
+        task = _make_review_task("review-task-ok", attempts=1)
+        fake = _FakeColony(task)
+        fake.get_task = lambda tid: {  # type: ignore[assignment]
+            "id": "task-ok",
+            "current_attempt": "att-original",
+        }
+        worker = _make_worker_with_fake_colony(fake)
+        output = (
+            '[REVIEW_VERDICT]{"provider":"test","verdict":"pass",'
+            '"summary":"looks good","findings":[],'
+            '"reviewed_commit_sha":"abc123"}[/REVIEW_VERDICT]'
+        )
+        worker._launch_agent = lambda t, ws: AgentResult(
+            returncode=0, stdout=output, stderr="", branch="feat/task-ok",
+        )
+        worker.colony.forage = lambda worker_id: task
+
+        assert worker._process_one_task() is True
+
+        assert len(fake.harvest_calls) == 1
+        assert fake.kickback_calls == []
+        assert len(fake.store_review_verdict_calls) == 1
+
+    def test_reviewer_prompt_contains_mandatory_format(self):
+        """Snapshot test: the inline reviewer prompt builder output contains
+        the MANDATORY header and the [REVIEW_VERDICT] markers."""
+        task = _make_review_task("review-task-sn", attempts=1)
+        fake = _FakeColony(task)
+        worker = _make_worker_with_fake_colony(fake)
+
+        captured: dict = {}
+
+        def _fake_run(cmd, **kwargs):
+            captured["cmd"] = cmd
+
+            class _P:
+                returncode = 0
+                stdout = ""
+                stderr = ""
+
+            return _P()
+
+        import subprocess as _sp
+
+        orig = _sp.run
+        _sp.run = _fake_run  # type: ignore[assignment]
+        try:
+            worker._launch_agent(task, "/tmp/ws/fake")
+        finally:
+            _sp.run = orig
+
+        prompt = captured["cmd"][-1]
+        assert "MANDATORY" in prompt
+        assert "[REVIEW_VERDICT]" in prompt
+        assert "[/REVIEW_VERDICT]" in prompt
 
 
 # ===========================================================================


### PR DESCRIPTION
Closes #143.

## Summary

Two-pronged fix for the intermittent reviewer-omits-tags bug:

- **Prong 1 — stricter prompting (prompt change only).** Restructure the
  output section of both reviewer adapter prompts (`claude_code`, `codex`)
  and the inline reviewer prompt built by `worker.py` so the tag contract
  is impossible to miss: a bold MANDATORY FORMAT header, two worked
  examples (`pass` and `needs_changes`) with full tag wrapping, and a
  final "did you wrap the JSON?" checklist.
- **Prong 2 — bounded retry via existing kickback.** When a reviewer exits
  cleanly (rc=0) but `_parse_review_verdict()` returns `None`, the worker
  now kicks the review task back through the existing kickback path with
  `max_attempts=2` (initial + one retry). A second failure exhausts the
  budget via `FileBackend.kickback`'s existing logic and drives the
  review task to BLOCKED. `Soldier.run_once_with_review` learns to detect
  a BLOCKED review task and kicks back the *original* task with
  `"review task completed without a ReviewVerdict"`, so the build can be
  reattempted.

Splitting the fix across two commits lets future dogfooding empirically
test whether prompting alone was enough to close the gap.

### Rejected alternatives

- **Fallback parsing** (regex-salvage JSON from free text): too fragile,
  risks accepting verdicts the reviewer never intended to emit.
- **Post-processing hook** (second LLM call to re-format): adds cost and
  a new failure mode for the same problem.
- **Default to pass on missing tags**: unsafe — silently merges
  unreviewed code.

### Design notes

- Retry budget = 2 (one retry). Reuses `len(attempts)` on the review
  task, no new schema field.
- Worker-side kickback is wrapped in `contextlib.suppress(Exception)` so
  a colony error cannot crash the worker loop.
- Retry is logged at INFO; exhaustion is logged at WARNING.

## Test plan

- [x] New `tests/test_review_execution.py::TestMissingVerdictKickback`:
  - [x] `test_missing_verdict_triggers_kickback` — rc=0 + no tags causes
    `colony.kickback` with `max_attempts=2` and the "REVIEW_VERDICT"
    reason; trail warning still written.
  - [x] `test_missing_verdict_second_attempt_marks_failed` — two failed
    review attempts drive the review task to `blocked`;
    `Soldier.run_once_with_review` then kicks back the original task with
    the expected reason and supersedes the original attempt.
  - [x] `test_valid_verdict_unchanged` — regression: valid verdict still
    harvests and does not touch the kickback path.
  - [x] `test_reviewer_prompt_contains_mandatory_format` — inline prompt
    builder output contains `MANDATORY` + `[REVIEW_VERDICT]` markers.
- [x] `pytest tests/test_review_execution.py -x -q` — 30 passed.
- [x] `pytest tests/ -x -q` — 752 passed.
- [x] `ruff check .` — clean.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>