### PR TITLE
fix(worker): builders poll on empty queue (#144)

### DIFF
--- a/antfarm/core/worker.py
+++ b/antfarm/core/worker.py
@@ -233,9 +233,22 @@ class WorkerRuntime:
         self.capabilities = capabilities or []
         self._token = token
         self._last_task_id: str | None = None
-        # Reviewer workers poll longer before exiting (wait for review tasks)
-        is_reviewer = "review" in (capabilities or [])
-        self._max_idle_polls = 10 if is_reviewer else 0  # 10 * 30s = 5min
+        # Polling is tiered by worker role so short-lived roles exit promptly
+        # while roles that wait on upstream tasks keep polling (#144).
+        caps = capabilities or []
+        if "review" in caps:
+            # Reviewers wait up to 5min for builders to harvest review tasks.
+            self._role = "reviewer"
+            self._max_idle_polls = 10  # 10 * 30s = 5min
+        elif "plan" in caps:
+            # Planners produce one batch of child tasks and exit promptly.
+            self._role = "planner"
+            self._max_idle_polls = 0
+        else:
+            # Builders wait up to 2.5min so they outlast a typical planner run
+            # and don't race the planner when started together (#144).
+            self._role = "builder"
+            self._max_idle_polls = 5  # 5 * 30s = 2.5min
 
         self.colony = ColonyClient(colony_url, client=client, token=token)
         self.workspace_mgr = WorkspaceManager(workspace_root, repo_path, integration_branch)
@@ -276,8 +289,8 @@ class WorkerRuntime:
                         logger.info("queue empty, worker exiting worker_id=%s", self.worker_id)
                         break
                     idle_polls += 1
-                    logger.debug("queue empty, polling (%d/%d) worker_id=%s",
-                                 idle_polls, max_idle_polls, self.worker_id)
+                    logger.debug("queue empty, polling (%d/%d) worker_id=%s role=%s",
+                                 idle_polls, max_idle_polls, self.worker_id, self._role)
                     time.sleep(30)
                 else:
                     idle_polls = 0  # reset on successful forage

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -50,6 +50,19 @@ class _StarletteTransport(httpx.BaseTransport):
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _no_sleep_between_polls(monkeypatch):
+    """Skip the 30s idle-poll sleep so worker tests run fast.
+
+    Builders/reviewers poll on an empty queue before exiting (#144). Tests
+    that exercise `.run()` against an empty queue would otherwise block on
+    `time.sleep(30)`.
+    """
+    import antfarm.core.worker as worker_mod
+
+    monkeypatch.setattr(worker_mod.time, "sleep", lambda _s: None)
+
+
 @pytest.fixture
 def backend(tmp_path):
     return FileBackend(root=str(tmp_path / ".antfarm"))
@@ -1243,3 +1256,75 @@ def test_task_artifact_plan_artifact_none_by_default():
 
     restored = TaskArtifact.from_dict(d)
     assert restored.plan_artifact is None
+
+
+# ---------------------------------------------------------------------------
+# Idle polling by role (#144)
+# ---------------------------------------------------------------------------
+
+
+def _make_runtime_with_caps(tmp_path, http_client, name, capabilities):
+    rt = WorkerRuntime(
+        colony_url="http://test",
+        node_id="node-1",
+        name=name,
+        agent_type="generic",
+        workspace_root=str(tmp_path / "workspaces"),
+        repo_path=str(tmp_path),
+        integration_branch="main",
+        heartbeat_interval=999.0,
+        capabilities=capabilities,
+        client=http_client,
+    )
+    rt.workspace_mgr.create = MagicMock(return_value=str(tmp_path / "ws"))
+    return rt
+
+
+def test_builder_polls_on_empty_queue(tmp_path, http_client):
+    """Builder workers poll 5 times (2.5min) before exiting on empty queue."""
+    rt = _make_runtime_with_caps(tmp_path, http_client, "builder-1", capabilities=[])
+
+    call_count = [0]
+
+    def fake_forage(worker_id):
+        call_count[0] += 1
+        return None
+
+    rt.colony.forage = fake_forage
+    rt.run()
+
+    # max_idle_polls=5 → one initial attempt + 5 retries = 6 forage calls
+    assert call_count[0] == 6
+
+
+def test_planner_exits_immediately_on_empty_queue(tmp_path, http_client):
+    """Planner workers exit after a single empty forage (max_idle_polls=0)."""
+    rt = _make_runtime_with_caps(tmp_path, http_client, "planner-1", capabilities=["plan"])
+
+    call_count = [0]
+
+    def fake_forage(worker_id):
+        call_count[0] += 1
+        return None
+
+    rt.colony.forage = fake_forage
+    rt.run()
+
+    assert call_count[0] == 1
+
+
+def test_reviewer_polls_unchanged(tmp_path, http_client):
+    """Reviewer polling (10 * 30s = 5min) is unchanged by the tiered logic."""
+    rt = _make_runtime_with_caps(tmp_path, http_client, "reviewer-1", capabilities=["review"])
+
+    call_count = [0]
+
+    def fake_forage(worker_id):
+        call_count[0] += 1
+        return None
+
+    rt.colony.forage = fake_forage
+    rt.run()
+
+    # max_idle_polls=10 → one initial attempt + 10 retries = 11 forage calls
+    assert call_count[0] == 11


### PR DESCRIPTION
## Summary
- Builders now poll the queue for up to 2.5 min before exiting when started with planners, matching the pattern reviewers already use.
- Polling is tiered by role: reviewers `max_idle_polls=10` (5 min, unchanged), builders `max_idle_polls=5` (2.5 min, new), planners `max_idle_polls=0` (exit promptly).
- The idle-poll debug log now includes `role=` so operators can see which tier is waiting.

## Context
Surfaced in the v0.5.8 dogfood: when a planner + builder were launched together, the builder foraged once, saw an empty queue, and exited before the planner finished spawning child tasks. The fix keeps the builder alive long enough to outlast a typical planner run. Closes #144.

## Test plan
- [x] New `test_builder_polls_on_empty_queue` — builder with no caps issues 6 forage calls (1 + 5 retries) before exit
- [x] New `test_planner_exits_immediately_on_empty_queue` — planner issues exactly 1 forage call
- [x] New `test_reviewer_polls_unchanged` — regression: reviewer still issues 11 forage calls (1 + 10 retries)
- [x] Autouse fixture monkeypatches `time.sleep` so existing worker tests that exercise empty-queue `.run()` no longer block on the new 30 s sleep
- [x] `pytest tests/test_worker.py -x -q` — 52 passed
- [x] `pytest tests/ -x -q` — 751 passed
- [x] `ruff check .` — clean