### PR TITLE
Extend Node dataclass with new fields

### DIFF
--- a/antfarm/core/models.py
+++ b/antfarm/core/models.py
@@ -528,12 +528,18 @@ class Node:
     node_id: str
     joined_at: str
     last_seen: str
+    runner_url: str | None = None
+    max_workers: int = 4
+    capabilities: list[str] = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return {
             "node_id": self.node_id,
             "joined_at": self.joined_at,
             "last_seen": self.last_seen,
+            "runner_url": self.runner_url,
+            "max_workers": self.max_workers,
+            "capabilities": list(self.capabilities),
         }
 
     @classmethod
@@ -542,4 +548,7 @@ class Node:
             node_id=data["node_id"],
             joined_at=data["joined_at"],
             last_seen=data["last_seen"],
+            runner_url=data.get("runner_url"),
+            max_workers=data.get("max_workers", 4),
+            capabilities=list(data.get("capabilities", [])),
         )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -434,6 +434,35 @@ def test_task_mission_id_roundtrip():
     assert restored == task
 
 
+def test_node_roundtrip_extended():
+    node = Node(
+        node_id="node-1",
+        joined_at="2026-04-04T08:00:00Z",
+        last_seen="2026-04-04T10:00:00Z",
+        runner_url="http://localhost:7433",
+        max_workers=8,
+        capabilities=["claude-code", "codex"],
+    )
+    d = node.to_dict()
+    assert d["runner_url"] == "http://localhost:7433"
+    assert d["max_workers"] == 8
+    assert d["capabilities"] == ["claude-code", "codex"]
+    restored = Node.from_dict(d)
+    assert restored == node
+
+
+def test_node_backward_compat():
+    data = {
+        "node_id": "node-old",
+        "joined_at": "2026-04-04T08:00:00Z",
+        "last_seen": "2026-04-04T10:00:00Z",
+    }
+    node = Node.from_dict(data)
+    assert node.runner_url is None
+    assert node.max_workers == 4
+    assert node.capabilities == []
+
+
 def test_task_mission_id_default_none():
     task = Task(
         id="t-no-mission",


### PR DESCRIPTION
In antfarm/core/models.py, add three fields to the Node dataclass (line ~527): runner_url: str | None = None, max_workers: int = 4, capabilities: list[str] = field(default_factory=list). Update to_dict() to include the new fields. Update from_dict() to use .get() with defaults so old JSON without these fields still deserializes correctly. Add two tests in tests/test_models.py: test_node_roundtrip_extended (verify new fields serialize and deserialize) and test_node_backward_compat (verify from_di