### PR TITLE
Add list_nodes and get_node to backend ABC and FileBackend

### DIFF
--- a/antfarm/core/backends/base.py
+++ b/antfarm/core/backends/base.py
@@ -334,6 +334,27 @@ class TaskBackend(ABC):
         """
         ...
 
+    @abstractmethod
+    def list_nodes(self) -> list[dict]:
+        """List all registered nodes.
+
+        Returns:
+            List of node dicts.
+        """
+        ...
+
+    @abstractmethod
+    def get_node(self, node_id: str) -> dict | None:
+        """Get a single node by ID.
+
+        Args:
+            node_id: ID of the node.
+
+        Returns:
+            Node dict, or None if not found.
+        """
+        ...
+
     # --- Workers ---
 
     @abstractmethod

--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -757,16 +757,41 @@ class FileBackend(TaskBackend):
     # ------------------------------------------------------------------
 
     def register_node(self, node: dict) -> None:
-        """Register a node. Idempotent — updates last_seen if already exists."""
+        """Register a node. Idempotent — updates last_seen and merges new fields."""
         with self._lock:
             node_id = node["node_id"]
             node_path = self._node_path(node_id)
             if node_path.exists():
                 existing = self._read_json(node_path)
-                existing["last_seen"] = node.get("last_seen", _now_iso())
+                for key, value in node.items():
+                    if key == "node_id":
+                        continue
+                    existing[key] = value
+                if "last_seen" not in node:
+                    existing["last_seen"] = _now_iso()
                 self._write_json(node_path, existing)
             else:
                 self._write_json(node_path, node)
+
+    def list_nodes(self) -> list[dict]:
+        """List all registered nodes."""
+        nodes_dir = self._root / "nodes"
+        if not nodes_dir.exists():
+            return []
+        result = []
+        for path in sorted(nodes_dir.glob("*.json")):
+            try:
+                result.append(self._read_json(path))
+            except (json.JSONDecodeError, OSError):
+                continue
+        return result
+
+    def get_node(self, node_id: str) -> dict | None:
+        """Get a single node by ID. Returns None if not found."""
+        node_path = self._node_path(node_id)
+        if not node_path.exists():
+            return None
+        return self._read_json(node_path)
 
     # ------------------------------------------------------------------
     # Workers

--- a/tests/test_file_backend.py
+++ b/tests/test_file_backend.py
@@ -994,3 +994,59 @@ def test_unblock_does_not_reset_attempt_counter(
         backend.get_task("task-1")["status"] == TaskStatus.BLOCKED.value
     )
 
+
+# ---------------------------------------------------------------------------
+# Node list/get tests
+# ---------------------------------------------------------------------------
+
+
+def test_register_node_with_runner_url(backend: FileBackend) -> None:
+    now = datetime.now(UTC).isoformat()
+    node = {
+        "node_id": "node-r1",
+        "joined_at": now,
+        "last_seen": now,
+        "runner_url": "http://localhost:7433",
+        "max_workers": 4,
+        "capabilities": ["claude-code", "codex"],
+    }
+    backend.register_node(node)
+    data = backend.get_node("node-r1")
+    assert data is not None
+    assert data["runner_url"] == "http://localhost:7433"
+    assert data["max_workers"] == 4
+    assert data["capabilities"] == ["claude-code", "codex"]
+
+    # Re-register with updated fields — should merge
+    later = datetime.now(UTC).isoformat()
+    node_updated = {
+        "node_id": "node-r1",
+        "last_seen": later,
+        "runner_url": "http://newhost:8000",
+        "max_workers": 8,
+    }
+    backend.register_node(node_updated)
+    data = backend.get_node("node-r1")
+    assert data["runner_url"] == "http://newhost:8000"
+    assert data["max_workers"] == 8
+    assert data["last_seen"] == later
+    # Original fields preserved
+    assert data["joined_at"] == now
+    assert data["capabilities"] == ["claude-code", "codex"]
+
+
+def test_list_nodes(backend: FileBackend) -> None:
+    now = datetime.now(UTC).isoformat()
+    backend.register_node({"node_id": "node-a", "joined_at": now, "last_seen": now})
+    backend.register_node({"node_id": "node-b", "joined_at": now, "last_seen": now})
+
+    nodes = backend.list_nodes()
+    assert len(nodes) == 2
+    node_ids = {n["node_id"] for n in nodes}
+    assert node_ids == {"node-a", "node-b"}
+
+
+def test_list_nodes_empty(backend: FileBackend) -> None:
+    nodes = backend.list_nodes()
+    assert nodes == []
+


### PR DESCRIPTION
In antfarm/core/backends/base.py, add two abstract methods: list_nodes(self) -> list[dict] and get_node(self, node_id: str) -> dict | None. In antfarm/core/backends/file.py, implement list_nodes() to read all JSON files from the nodes/ directory and return as a list of dicts, and get_node() to read a single node file and return its dict or None. Also update register_node() (line ~759) to persist all fields from the node dict (currently it only writes the incoming dict on first create, but on upd