### PR TITLE
Extend API with node endpoints

### DIFF
--- a/antfarm/core/backends/base.py
+++ b/antfarm/core/backends/base.py
@@ -334,6 +334,16 @@ class TaskBackend(ABC):
         """
         ...
 
+    @abstractmethod
+    def list_nodes(self) -> list[dict]:
+        """Return all registered nodes."""
+        ...
+
+    @abstractmethod
+    def get_node(self, node_id: str) -> dict | None:
+        """Return a single node by ID, or None if not found."""
+        ...
+
     # --- Workers ---
 
     @abstractmethod

--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -768,6 +768,21 @@ class FileBackend(TaskBackend):
             else:
                 self._write_json(node_path, node)
 
+    def list_nodes(self) -> list[dict]:
+        """Return all registered nodes."""
+        nodes_dir = self._root / "nodes"
+        results = []
+        for p in sorted(nodes_dir.glob("*.json")):
+            results.append(self._read_json(p))
+        return results
+
+    def get_node(self, node_id: str) -> dict | None:
+        """Return a single node by ID, or None if not found."""
+        node_path = self._node_path(node_id)
+        if not node_path.exists():
+            return None
+        return self._read_json(node_path)
+
     # ------------------------------------------------------------------
     # Workers
     # ------------------------------------------------------------------

--- a/antfarm/core/backends/github.py
+++ b/antfarm/core/backends/github.py
@@ -852,6 +852,14 @@ class GitHubBackend(TaskBackend):
         else:
             self._nodes[node_id] = dict(node)
 
+    def list_nodes(self) -> list[dict]:
+        """Return all registered nodes."""
+        return list(self._nodes.values())
+
+    def get_node(self, node_id: str) -> dict | None:
+        """Return a single node by ID, or None if not found."""
+        return self._nodes.get(node_id)
+
     # ------------------------------------------------------------------
     # Workers
     # ------------------------------------------------------------------

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -20,7 +20,7 @@ from datetime import UTC, datetime
 
 from fastapi import FastAPI, HTTPException, Query, Response
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from antfarm.core.backends.base import TaskBackend
 
@@ -214,6 +214,9 @@ class CarryRequest(BaseModel):
 
 class NodeRequest(BaseModel):
     node_id: str
+    runner_url: str | None = None
+    max_workers: int = 4
+    capabilities: list[str] = Field(default_factory=list)
 
 
 class WorkerRegisterRequest(BaseModel):
@@ -385,9 +388,29 @@ def get_app(
     def register_node(req: NodeRequest):
         """Register a node. Idempotent — re-registering updates last_seen."""
         now = _now_iso()
-        node = {"node_id": req.node_id, "joined_at": now, "last_seen": now}
+        node = {
+            "node_id": req.node_id,
+            "joined_at": now,
+            "last_seen": now,
+            "runner_url": req.runner_url,
+            "max_workers": req.max_workers,
+            "capabilities": req.capabilities,
+        }
         _backend.register_node(node)
         return {"node_id": req.node_id}
+
+    @app.get("/nodes")
+    def list_nodes():
+        """List all registered nodes."""
+        return _backend.list_nodes()
+
+    @app.get("/nodes/{node_id}")
+    def get_node(node_id: str):
+        """Get a single node by ID, or 404."""
+        node = _backend.get_node(node_id)
+        if node is None:
+            raise HTTPException(status_code=404, detail=f"Node {node_id!r} not found")
+        return node
 
     # ------------------------------------------------------------------
     # Workers

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -221,6 +221,52 @@ def test_register_node_idempotent(client):
     assert r.json()["nodes"] == 1
 
 
+def test_register_node_extended(client):
+    r = client.post(
+        "/nodes",
+        json={
+            "node_id": "node-ext",
+            "runner_url": "http://mini-2:7433",
+            "max_workers": 2,
+            "capabilities": ["gpu", "large-context"],
+        },
+    )
+    assert r.status_code == 200
+    assert r.json()["node_id"] == "node-ext"
+
+    # Verify fields persisted
+    r = client.get("/nodes/node-ext")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["runner_url"] == "http://mini-2:7433"
+    assert data["max_workers"] == 2
+    assert data["capabilities"] == ["gpu", "large-context"]
+
+
+def test_get_nodes_list(client):
+    client.post("/nodes", json={"node_id": "node-a"})
+    client.post("/nodes", json={"node_id": "node-b"})
+
+    r = client.get("/nodes")
+    assert r.status_code == 200
+    nodes = r.json()
+    node_ids = [n["node_id"] for n in nodes]
+    assert "node-a" in node_ids
+    assert "node-b" in node_ids
+
+
+def test_get_node_detail(client):
+    client.post("/nodes", json={"node_id": "node-detail"})
+    r = client.get("/nodes/node-detail")
+    assert r.status_code == 200
+    assert r.json()["node_id"] == "node-detail"
+
+
+def test_get_node_not_found(client):
+    r = client.get("/nodes/nonexistent")
+    assert r.status_code == 404
+
+
 def test_signal_appends(client):
     _carry(client)
     task = _forage(client).json()


### PR DESCRIPTION
In antfarm/core/serve.py, extend the NodeRequest pydantic model (line ~215) to include runner_url: str | None = None, max_workers: int = 4, capabilities: list[str] = Field(default_factory=list). Update the register_node endpoint (line ~385) to pass the new fields into the node dict sent to backend.register_node(). Add GET /nodes endpoint returning backend.list_nodes() and GET /nodes/{node_id} returning backend.get_node(node_id) or 404. Add four tests in tests/test_serve.py: test_register_node_ex