### PR TITLE
feat(doctor): tmux availability check + orphan session detection (#207)

### DIFF
--- a/antfarm/core/doctor.py
+++ b/antfarm/core/doctor.py
@@ -13,10 +13,13 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+
+from antfarm.core.process_manager import parse_session_name
 
 
 @dataclass
@@ -56,6 +59,8 @@ def run_doctor(backend, config: dict, fix: bool = False) -> list[Finding]:
     findings.extend(check_state_consistency(backend))
     findings.extend(check_dependency_cycles(backend))
     findings.extend(check_runner_health(backend, config))
+    findings.extend(check_tmux_available(config))
+    findings.extend(check_orphan_tmux_sessions(config))
 
     return findings
 
@@ -889,5 +894,97 @@ def check_runner_health(backend, config: dict, fix: bool = False) -> list[Findin
                 ),
                 auto_fixable=False,
             ))
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Check 12: tmux availability
+# ---------------------------------------------------------------------------
+
+
+def check_tmux_available(config: dict) -> list[Finding]:
+    """Warn when tmux is not installed.
+
+    Without tmux, workers fall back to subprocess.Popen — no real TTY,
+    no restart adoption. This is a degraded mode; users should know.
+    """
+    if shutil.which("tmux"):
+        return []
+    return [Finding(
+        severity="warning",
+        check="tmux_available",
+        message=(
+            "tmux not installed — worker spawning will use subprocess fallback "
+            "(less reliable)"
+        ),
+        auto_fixable=False,
+    )]
+
+
+# ---------------------------------------------------------------------------
+# Check 13: Orphan tmux sessions
+# ---------------------------------------------------------------------------
+
+_ANTFARM_TMUX_PREFIXES = ("auto-", "runner-")
+
+
+def check_orphan_tmux_sessions(config: dict) -> list[Finding]:
+    """Report tmux sessions with antfarm prefix that have no matching metadata.
+
+    A tmux session named "auto-builder-3" or "runner-planner-1" that has no
+    corresponding `{state_dir}/processes/{name}.json` file is an orphan —
+    typically the result of a crash that left the session but lost metadata,
+    or a metadata file that was removed while the session survived. Either
+    way, the autoscaler/runner will not adopt these on restart, so they'll
+    linger until killed manually.
+    """
+    if not shutil.which("tmux"):
+        return []
+
+    try:
+        result = subprocess.run(
+            ["tmux", "list-sessions", "-F", "#{session_name}"],
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+
+    # No tmux server running is not an error — just no sessions to check
+    if result.returncode != 0:
+        return []
+
+    data_dir = config.get("data_dir", ".antfarm")
+    processes_dir = os.path.join(data_dir, "processes")
+
+    findings: list[Finding] = []
+    for session_name in result.stdout.splitlines():
+        session_name = session_name.strip()
+        if not session_name:
+            continue
+
+        # Is this session one of ours?
+        matched_prefix = None
+        for prefix in _ANTFARM_TMUX_PREFIXES:
+            if parse_session_name(session_name, prefix) is not None:
+                matched_prefix = prefix
+                break
+        if matched_prefix is None:
+            continue
+
+        metadata_path = os.path.join(processes_dir, f"{session_name}.json")
+        if os.path.isfile(metadata_path):
+            continue
+
+        findings.append(Finding(
+            severity="warning",
+            check="orphan_tmux_session",
+            message=(
+                f"orphan tmux session: {session_name} "
+                f"(no matching metadata in {processes_dir})"
+            ),
+            auto_fixable=False,
+        ))
 
     return findings

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -174,7 +174,15 @@ def _start_autoscaler_thread(
     if _autoscaler_thread is not None and _autoscaler_thread.is_alive():
         return
 
+    import shutil as _shutil
+
     from antfarm.core.autoscaler import Autoscaler
+
+    if not _shutil.which("tmux"):
+        logger.warning(
+            "tmux not available — using subprocess fallback "
+            "(less reliable, no restart adoption)"
+        )
 
     _autoscaler_instance = Autoscaler(backend, autoscaler_config)
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -69,7 +69,13 @@ def _backdate(path: str | Path, seconds: int = 600) -> None:
 def test_healthy_colony_no_findings(setup):
     backend, config = setup
     findings = run_doctor(backend, config)
-    errors_warnings = [f for f in findings if f.severity in ("error", "warning")]
+    # `tmux_available` is environment-dependent (tmux may or may not be installed
+    # in CI). It's a legitimate warning in either case, but not a sign of an
+    # unhealthy colony under test.
+    errors_warnings = [
+        f for f in findings
+        if f.severity in ("error", "warning") and f.check != "tmux_available"
+    ]
     assert errors_warnings == [], f"Expected no errors/warnings, got: {errors_warnings}"
 
 
@@ -570,3 +576,111 @@ def test_doctor_runner_reachable(setup):
         findings = check_runner_health(backend, {})
 
     assert len(findings) == 0
+
+
+# ---------------------------------------------------------------------------
+# check_tmux_available
+# ---------------------------------------------------------------------------
+
+
+def test_tmux_available_returns_empty_when_installed():
+    from unittest.mock import patch
+
+    from antfarm.core.doctor import check_tmux_available
+
+    with patch("antfarm.core.doctor.shutil.which", return_value="/opt/bin/tmux"):
+        findings = check_tmux_available({})
+
+    assert findings == []
+
+
+def test_tmux_available_warns_when_missing():
+    from unittest.mock import patch
+
+    from antfarm.core.doctor import check_tmux_available
+
+    with patch("antfarm.core.doctor.shutil.which", return_value=None):
+        findings = check_tmux_available({})
+
+    assert len(findings) == 1
+    assert findings[0].severity == "warning"
+    assert findings[0].check == "tmux_available"
+    assert "subprocess fallback" in findings[0].message
+    assert findings[0].auto_fixable is False
+
+
+# ---------------------------------------------------------------------------
+# check_orphan_tmux_sessions
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_tmux_sessions_skipped_when_tmux_missing():
+    from unittest.mock import patch
+
+    from antfarm.core.doctor import check_orphan_tmux_sessions
+
+    with patch("antfarm.core.doctor.shutil.which", return_value=None):
+        findings = check_orphan_tmux_sessions({"data_dir": "/tmp/nonexistent"})
+
+    assert findings == []
+
+
+def test_orphan_tmux_sessions_empty_when_no_server(tmp_path):
+    """`tmux list-sessions` returns nonzero when no server is running — treat as no findings."""
+    from unittest.mock import MagicMock, patch
+
+    from antfarm.core.doctor import check_orphan_tmux_sessions
+
+    data_dir = str(tmp_path / ".antfarm")
+    fake_result = MagicMock(returncode=1, stdout="", stderr="no server running")
+
+    with patch("antfarm.core.doctor.shutil.which", return_value="/opt/bin/tmux"), \
+         patch("antfarm.core.doctor.subprocess.run", return_value=fake_result):
+        findings = check_orphan_tmux_sessions({"data_dir": data_dir})
+
+    assert findings == []
+
+
+def test_orphan_tmux_sessions_reports_sessions_without_metadata(tmp_path):
+    """antfarm-prefixed tmux sessions without metadata files are flagged as orphans."""
+    from unittest.mock import MagicMock, patch
+
+    from antfarm.core.doctor import check_orphan_tmux_sessions
+
+    data_dir = str(tmp_path / ".antfarm")
+    processes_dir = os.path.join(data_dir, "processes")
+    os.makedirs(processes_dir, exist_ok=True)
+    # Session with matching metadata (not orphaned)
+    with open(os.path.join(processes_dir, "auto-builder-1.json"), "w") as f:
+        f.write("{}")
+
+    # Simulate tmux listing: one orphan auto-, one orphan runner-, one with metadata, one unrelated
+    sessions = "auto-builder-1\nauto-builder-2\nrunner-planner-1\nmy-personal-session\n"
+    fake_result = MagicMock(returncode=0, stdout=sessions, stderr="")
+
+    with patch("antfarm.core.doctor.shutil.which", return_value="/opt/bin/tmux"), \
+         patch("antfarm.core.doctor.subprocess.run", return_value=fake_result):
+        findings = check_orphan_tmux_sessions({"data_dir": data_dir})
+
+    orphan_names = {f.message.split(":")[1].split("(")[0].strip() for f in findings}
+    assert orphan_names == {"auto-builder-2", "runner-planner-1"}
+    for f in findings:
+        assert f.severity == "warning"
+        assert f.check == "orphan_tmux_session"
+        assert f.auto_fixable is False
+
+
+def test_orphan_tmux_sessions_ignores_non_antfarm_prefixes(tmp_path):
+    from unittest.mock import MagicMock, patch
+
+    from antfarm.core.doctor import check_orphan_tmux_sessions
+
+    data_dir = str(tmp_path / ".antfarm")
+    sessions = "my-work\nmain\nvim-1\n"
+    fake_result = MagicMock(returncode=0, stdout=sessions, stderr="")
+
+    with patch("antfarm.core.doctor.shutil.which", return_value="/opt/bin/tmux"), \
+         patch("antfarm.core.doctor.subprocess.run", return_value=fake_result):
+        findings = check_orphan_tmux_sessions({"data_dir": data_dir})
+
+    assert findings == []


### PR DESCRIPTION
## Summary
- Add `check_tmux_available()`: warns when tmux isn't installed — workers will fall back to the less reliable subprocess.Popen path (no real TTY, no restart adoption)
- Add `check_orphan_tmux_sessions()`: flags tmux sessions with antfarm prefixes (`auto-`, `runner-`) whose ProcessMetadata file is missing — typically crashes or stale state that autoscaler/runner won't adopt
- Log a one-time warning at colony startup if tmux is missing

Closes #207. Part of #202 (v0.6.2).

## Test plan
- [x] Full suite green (`pytest tests/ -x -q`) — 824 passed, 5 skipped
- [x] Ruff clean (`ruff check .`)
- [x] 5 new tests:
  - tmux available → no finding
  - tmux missing → warning finding
  - orphan detection skipped when tmux missing
  - orphan detection empty when no tmux server running
  - orphan reports sessions with antfarm prefix but no metadata; ignores sessions with metadata or non-antfarm prefixes
- [x] Adjusted `test_healthy_colony_no_findings` to ignore env-dependent `tmux_available` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)