### PR TITLE
fix(core): source __version__ from package metadata

### DIFF
--- a/antfarm/core/__init__.py
+++ b/antfarm/core/__init__.py
@@ -1,1 +1,7 @@
-__version__ = "0.6.1"
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
+try:
+    __version__ = _pkg_version("antfarm")
+except PackageNotFoundError:  # pragma: no cover - source checkout without install
+    __version__ = "0.0.0"


### PR DESCRIPTION
## Summary
- `antfarm/core/__init__.py` had `__version__ = "0.6.1"` hardcoded, which drifted from `pyproject.toml` (0.6.2) during the version bump in #212
- Switch to `importlib.metadata.version("antfarm")` so pyproject.toml is the single source of truth
- Fallback to `"0.0.0"` for source checkouts without install

## Test plan
- [x] `antfarm version` → `v0.6.2`
- [x] `ruff check .`

🤖 Generated with [Claude Code](https://claude.com/claude-code)