### PR TITLE
fix(cli): configure logging on CLI startup (#214)

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -200,7 +200,10 @@ def colony(
     import uvicorn
 
     from antfarm.core.backends import get_backend
+    from antfarm.core.logging_setup import setup_logging
     from antfarm.core.serve import get_app
+
+    setup_logging()
 
     if backend == "github":
         if not github_repo:
@@ -392,7 +395,10 @@ def worker_start(
     token: str | None,
 ):
     """Start a worker and enter the forage loop."""
+    from antfarm.core.logging_setup import setup_logging
     from antfarm.core.worker import WorkerRuntime
+
+    setup_logging()
 
     worker_name = name or worker_type
     ws_root = workspace_root or f".antfarm/workspaces/{worker_name}"
@@ -1395,7 +1401,10 @@ def runner(
     import os
     import socket
 
+    from antfarm.core.logging_setup import setup_logging
     from antfarm.core.runner import Runner
+
+    setup_logging()
 
     node_id = node or socket.gethostname()
     caps = [c.strip() for c in capabilities.split(",") if c.strip()] if capabilities else []

--- a/antfarm/core/logging_setup.py
+++ b/antfarm/core/logging_setup.py
@@ -1,0 +1,61 @@
+"""Central logging configuration for antfarm CLI entry points.
+
+Library modules use ``logger = logging.getLogger(__name__)`` and never
+touch the root logger. Long-lived CLI commands (``colony``, ``worker
+start``, ``runner``) call :func:`setup_logging` on startup so that
+``logger.info`` calls actually reach stderr.
+
+Level resolution order:
+1. Explicit ``level`` argument passed by the caller.
+2. ``ANTFARM_LOG_LEVEL`` environment variable (case-insensitive).
+3. Default: ``INFO``.
+
+Library code must never call this function. Tests import library modules
+directly and rely on the root logger being unconfigured.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+_FORMAT = "%(asctime)s %(name)s %(levelname)s: %(message)s"
+
+# Third-party loggers that are too noisy at DEBUG — pin them to WARNING
+# unless the user explicitly asks for more via ANTFARM_LOG_LEVEL.
+_NOISY_LIBS = ("httpcore", "httpx", "urllib3")
+
+
+def setup_logging(level: int | str | None = None) -> None:
+    """Configure the root logger for a CLI entry point.
+
+    Safe to call multiple times; subsequent calls are no-ops to avoid
+    duplicate handlers.
+
+    Args:
+        level: Override log level. If None, reads ``ANTFARM_LOG_LEVEL``
+            (default INFO).
+    """
+    root = logging.getLogger()
+    if getattr(root, "_antfarm_configured", False):
+        return
+
+    if level is None:
+        level = os.environ.get("ANTFARM_LOG_LEVEL", "INFO")
+    if isinstance(level, str):
+        level = level.upper()
+
+    logging.basicConfig(level=level, format=_FORMAT)
+    # basicConfig() is a no-op if the root logger already has a handler
+    # (e.g. pytest's LogCaptureHandler). Set the level explicitly so the
+    # configured level always takes effect.
+    root.setLevel(level)
+
+    # Silence noisy transport libraries unless the user explicitly asks
+    # for DEBUG via ANTFARM_LOG_LEVEL=DEBUG.
+    user_level = os.environ.get("ANTFARM_LOG_LEVEL", "").upper()
+    if user_level != "DEBUG":
+        for name in _NOISY_LIBS:
+            logging.getLogger(name).setLevel(logging.WARNING)
+
+    root._antfarm_configured = True  # type: ignore[attr-defined]

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,128 @@
+"""Tests for antfarm.core.logging_setup.
+
+Key invariants:
+- Library imports never install handlers on the root logger.
+- setup_logging() is idempotent (safe to call multiple times).
+- ANTFARM_LOG_LEVEL env var controls the level.
+- Noisy transport libs are pinned to WARNING unless user asks for DEBUG.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+@pytest.fixture
+def clean_root_logger():
+    """Reset the root logger before and after each test to avoid cross-test pollution."""
+    root = logging.getLogger()
+    original_handlers = list(root.handlers)
+    original_level = root.level
+    original_configured = getattr(root, "_antfarm_configured", False)
+
+    # Also reset the noisy-lib loggers so tests are order-independent.
+    noisy = ("httpcore", "httpx", "urllib3")
+    original_noisy_levels = {name: logging.getLogger(name).level for name in noisy}
+
+    # Start clean
+    root.handlers.clear()
+    if hasattr(root, "_antfarm_configured"):
+        delattr(root, "_antfarm_configured")
+    for name in noisy:
+        logging.getLogger(name).setLevel(logging.NOTSET)
+
+    yield
+
+    # Restore
+    root.handlers.clear()
+    root.handlers.extend(original_handlers)
+    root.setLevel(original_level)
+    if original_configured:
+        root._antfarm_configured = True  # type: ignore[attr-defined]
+    elif hasattr(root, "_antfarm_configured"):
+        delattr(root, "_antfarm_configured")
+    for name, lvl in original_noisy_levels.items():
+        logging.getLogger(name).setLevel(lvl)
+
+
+def test_library_import_does_not_call_setup(clean_root_logger):
+    """Importing antfarm library code must not call setup_logging()."""
+    # Explicit re-import via importlib to exercise module init code.
+    import importlib
+
+    import antfarm.core.autoscaler
+    import antfarm.core.serve
+    import antfarm.core.worker
+    importlib.reload(antfarm.core.worker)
+    importlib.reload(antfarm.core.serve)
+    importlib.reload(antfarm.core.autoscaler)
+
+    # The library must not have marked the root logger as antfarm-configured.
+    # (pytest may install its own LogCaptureHandler; we only care that our
+    #  setup_logging() wasn't called.)
+    assert not getattr(logging.getLogger(), "_antfarm_configured", False)
+
+
+def test_setup_logging_installs_handler(clean_root_logger, monkeypatch):
+    monkeypatch.delenv("ANTFARM_LOG_LEVEL", raising=False)
+    from antfarm.core.logging_setup import setup_logging
+
+    setup_logging()
+
+    root = logging.getLogger()
+    assert len(root.handlers) >= 1
+    assert root.level == logging.INFO
+
+
+def test_setup_logging_is_idempotent(clean_root_logger, monkeypatch):
+    monkeypatch.delenv("ANTFARM_LOG_LEVEL", raising=False)
+    from antfarm.core.logging_setup import setup_logging
+
+    setup_logging()
+    handler_count_after_first = len(logging.getLogger().handlers)
+
+    setup_logging()
+    setup_logging()
+    assert len(logging.getLogger().handlers) == handler_count_after_first
+
+
+def test_setup_logging_respects_env_var(clean_root_logger, monkeypatch):
+    monkeypatch.setenv("ANTFARM_LOG_LEVEL", "DEBUG")
+    from antfarm.core.logging_setup import setup_logging
+
+    setup_logging()
+
+    assert logging.getLogger().level == logging.DEBUG
+
+
+def test_setup_logging_respects_explicit_level(clean_root_logger, monkeypatch):
+    monkeypatch.setenv("ANTFARM_LOG_LEVEL", "DEBUG")  # should be overridden
+    from antfarm.core.logging_setup import setup_logging
+
+    setup_logging(level="WARNING")
+
+    assert logging.getLogger().level == logging.WARNING
+
+
+def test_noisy_libs_pinned_to_warning_at_info(clean_root_logger, monkeypatch):
+    monkeypatch.setenv("ANTFARM_LOG_LEVEL", "INFO")
+    from antfarm.core.logging_setup import setup_logging
+
+    setup_logging()
+
+    for name in ("httpcore", "httpx", "urllib3"):
+        assert logging.getLogger(name).level == logging.WARNING
+
+
+def test_noisy_libs_unmuted_at_debug(clean_root_logger, monkeypatch):
+    monkeypatch.setenv("ANTFARM_LOG_LEVEL", "DEBUG")
+    from antfarm.core.logging_setup import setup_logging
+
+    setup_logging()
+
+    # At DEBUG, we do NOT pin noisy libs — they inherit root level (DEBUG).
+    for name in ("httpcore", "httpx", "urllib3"):
+        # Level 0 means "inherit from root"
+        assert logging.getLogger(name).level in (logging.NOTSET, logging.DEBUG)


### PR DESCRIPTION
## Summary
- Add `antfarm.core.logging_setup.setup_logging()` helper: idempotent, honours `ANTFARM_LOG_LEVEL`, pins `httpcore`/`httpx`/`urllib3` to WARNING unless the user asks for DEBUG.
- Call it from the three long-lived CLI entry points: `colony`, `worker start`, `runner`.
- Library modules are untouched — tests that import library code still see an unconfigured root logger.

## Why
During dogfooding on v0.6.2, workers were dying silently with empty log files. Root cause: no entry point ever called `logging.basicConfig`, so every `logger.info(...)` was dropped on the floor. This made worker failures undiagnosable.

## Test plan
- [x] New `tests/test_logging_setup.py` (7 tests): idempotency, env var, explicit override, noisy-lib pinning at INFO, noisy-lib unmuting at DEBUG, and the invariant that importing library modules never configures the root logger.
- [x] Full suite: `pytest tests/ -x -q` → 845 passed.
- [x] `ruff check .` clean.

Closes #214

🤖 Generated with [Claude Code](https://claude.com/claude-code)