### PR TITLE
Harden register_worker stale-tolerant contract and logic

### DIFF
--- a/antfarm/core/backends/base.py
+++ b/antfarm/core/backends/base.py
@@ -348,7 +348,19 @@ class TaskBackend(ABC):
 
     @abstractmethod
     def register_worker(self, worker: dict) -> None:
-        """Register a worker.
+        """Register a worker. Stale-tolerant.
+
+        Contract:
+            - If no worker file exists for ``worker_id``: always succeeds.
+            - If a worker file exists and its heartbeat (file mtime) is older
+              than the backend's configured TTL: the stale file is overwritten
+              and registration succeeds.
+            - If a worker file exists and its heartbeat is within TTL (live):
+              registration is rejected with ValueError.
+
+        The check-and-write must be atomic so that two concurrent registrations
+        for the same ``worker_id`` cannot both observe "no prior worker" and
+        both succeed.
 
         Args:
             worker: Worker dict with 'worker_id', 'node_id', etc.

--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -793,19 +793,31 @@ class FileBackend(TaskBackend):
     # ------------------------------------------------------------------
 
     def register_worker(self, worker: dict) -> None:
-        """Register a worker.
+        """Register a worker. Stale-tolerant.
+
+        Behavior:
+            - No prior file for ``worker_id``: write and succeed.
+            - Prior file exists with mtime age > ``self._guard_ttl`` (stale):
+              overwrite and succeed.
+            - Prior file exists with mtime age <= ``self._guard_ttl`` (live):
+              raise ValueError.
+
+        The existence check and the write happen inside ``self._lock`` so that
+        two concurrent registrations for the same ``worker_id`` cannot both
+        observe the slot as empty/stale and both succeed (TOCTOU protection).
 
         Raises:
             ValueError: If a live (non-stale heartbeat) worker with the same ID exists.
         """
         worker_id = worker["worker_id"]
         worker_path = self._worker_path(worker_id)
-        if worker_path.exists():
-            stat = os.stat(str(worker_path))
-            age = datetime.now(UTC).timestamp() - stat.st_mtime
-            if age <= self._guard_ttl:
-                raise ValueError(f"Worker '{worker_id}' is already registered and live")
-        self._write_json(worker_path, worker)
+        with self._lock:
+            if worker_path.exists():
+                stat = os.stat(str(worker_path))
+                age = datetime.now(UTC).timestamp() - stat.st_mtime
+                if age <= self._guard_ttl:
+                    raise ValueError(f"Worker '{worker_id}' is already registered and live")
+            self._write_json(worker_path, worker)
 
     def deregister_worker(self, worker_id: str) -> None:
         """Deregister a worker. No-op if not found (idempotent)."""


### PR DESCRIPTION
Update `antfarm/core/backends/base.py` register_worker docstring to explicitly document the stale-tolerant contract: re-registration succeeds when the existing worker's heartbeat is older than the configured TTL, rejects (ValueError) when it is fresh, and always succeeds when no prior worker exists. In `antfarm/core/backends/file.py`, move the existing existence-and-mtime check inside `self._lock` to close the TOCTOU between check-and-write, and update the implementation docstring to match the n