### PR TITLE
Harden register_worker stale-tolerant contract and logic

### DIFF
--- a/antfarm/core/backends/base.py
+++ b/antfarm/core/backends/base.py
@@ -348,7 +348,21 @@ class TaskBackend(ABC):
 
     @abstractmethod
     def register_worker(self, worker: dict) -> None:
-        """Register a worker.
+        """Register a worker (stale-tolerant).
+
+        Contract:
+        - If no worker record with this ID exists, registration succeeds.
+        - If a record exists but the worker's last heartbeat is older than
+          the backend's stale TTL, the prior record is overwritten and
+          registration succeeds. This lets a name be reused after a
+          colony restart when the previous worker died without
+          deregistering.
+        - If a record exists and the heartbeat is fresh (within the stale
+          TTL), registration is rejected with ValueError. This prevents
+          two concurrent workers from claiming the same ID.
+
+        Implementations must perform the staleness check and the write
+        atomically (e.g., under a lock) to avoid a TOCTOU race.
 
         Args:
             worker: Worker dict with 'worker_id', 'node_id', etc.

--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -793,19 +793,29 @@ class FileBackend(TaskBackend):
     # ------------------------------------------------------------------
 
     def register_worker(self, worker: dict) -> None:
-        """Register a worker.
+        """Register a worker (stale-tolerant).
+
+        Re-registration is allowed when the existing worker file's mtime is
+        older than ``self._guard_ttl`` (the stale heartbeat TTL); the prior
+        record is overwritten. When the existing file is fresh, registration
+        raises ValueError. When no file exists, registration succeeds.
+
+        The existence-and-mtime check and the file write are performed under
+        ``self._lock`` to close the TOCTOU window between deciding the prior
+        record is stale and overwriting it.
 
         Raises:
             ValueError: If a live (non-stale heartbeat) worker with the same ID exists.
         """
         worker_id = worker["worker_id"]
         worker_path = self._worker_path(worker_id)
-        if worker_path.exists():
-            stat = os.stat(str(worker_path))
-            age = datetime.now(UTC).timestamp() - stat.st_mtime
-            if age <= self._guard_ttl:
-                raise ValueError(f"Worker '{worker_id}' is already registered and live")
-        self._write_json(worker_path, worker)
+        with self._lock:
+            if worker_path.exists():
+                stat = os.stat(str(worker_path))
+                age = datetime.now(UTC).timestamp() - stat.st_mtime
+                if age <= self._guard_ttl:
+                    raise ValueError(f"Worker '{worker_id}' is already registered and live")
+            self._write_json(worker_path, worker)
 
     def deregister_worker(self, worker_id: str) -> None:
         """Deregister a worker. No-op if not found (idempotent)."""


### PR DESCRIPTION
Update `antfarm/core/backends/base.py` register_worker docstring to explicitly document the stale-tolerant contract: re-registration succeeds when the existing worker's heartbeat is older than the configured TTL, rejects (ValueError) when it is fresh, and always succeeds when no prior worker exists. In `antfarm/core/backends/file.py`, move the existing existence-and-mtime check inside `self._lock` to close the TOCTOU between check-and-write, and update the implementation docstring to match the n