### PR TITLE
fix(autoscaler): don't reap workers whose heartbeat is still fresh (#220)

### DIFF
--- a/antfarm/core/autoscaler.py
+++ b/antfarm/core/autoscaler.py
@@ -306,7 +306,20 @@ class Autoscaler:
         logger.warning("failed to start worker after retry — skipping")
 
     def _stop_idle_worker(self, role: str) -> bool:
-        """Stop one idle worker of the given role. Returns True if stopped."""
+        """Stop one idle worker of the given role. Returns True if stopped.
+
+        A worker is reap-eligible only when BOTH:
+        - colony-side status == "idle", AND
+        - last_heartbeat is older than poll_interval
+
+        This grace period protects workers that have just claimed a task via
+        pull() but whose heartbeat hasn't ticked yet — the colony-side status
+        stays "idle" until the first heartbeat arrives (~30s), and the
+        autoscaler's own poll can fire in that window.
+
+        If last_heartbeat is missing or unparseable, the worker is NOT reaped
+        (fail-safe: treat as fresh).
+        """
         colony_workers = self.backend.list_workers()
         colony_status_map = {w["worker_id"]: w for w in colony_workers}
 
@@ -316,11 +329,23 @@ class Autoscaler:
             if not self._pm.is_alive(name):
                 continue  # already exited
             cw = colony_status_map.get(mw.worker_id)
-            if cw and cw.get("status") == "idle":
-                self._pm.stop(name)
-                logger.info("autoscaler stopped idle worker name=%s role=%s", name, role)
-                del self.managed[name]
-                return True
+            if not (cw and cw.get("status") == "idle"):
+                continue
+            # Guard: only reap if last_heartbeat is older than poll_interval.
+            last_hb = cw.get("last_heartbeat")
+            if not last_hb:
+                continue  # no heartbeat recorded — treat as fresh, skip
+            try:
+                hb_dt = datetime.fromisoformat(last_hb)
+                age = (datetime.now(UTC) - hb_dt).total_seconds()
+            except (ValueError, TypeError):
+                continue  # unparseable — fail-safe, skip
+            if age < self.config.poll_interval:
+                continue  # heartbeat is still fresh — worker just registered or claimed
+            self._pm.stop(name)
+            logger.info("autoscaler stopped idle worker name=%s role=%s", name, role)
+            del self.managed[name]
+            return True
         return False
 
     def _cleanup_exited(self) -> None:

--- a/tests/test_autoscaler.py
+++ b/tests/test_autoscaler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 from antfarm.core.autoscaler import Autoscaler, AutoscalerConfig, ManagedWorker
@@ -34,6 +35,7 @@ def _worker(
     status: str = "idle",
     capabilities: list[str] | None = None,
     cooldown_until: str | None = None,
+    last_heartbeat: str | None = None,
 ) -> dict:
     w: dict = {
         "worker_id": worker_id,
@@ -42,7 +44,14 @@ def _worker(
     }
     if cooldown_until is not None:
         w["cooldown_until"] = cooldown_until
+    if last_heartbeat is not None:
+        w["last_heartbeat"] = last_heartbeat
     return w
+
+
+def _aged_hb(seconds_ago: float = 60.0) -> str:
+    """Return an ISO-8601 UTC timestamp `seconds_ago` seconds in the past."""
+    return (datetime.now(UTC) - timedelta(seconds=seconds_ago)).isoformat()
 
 
 def _make_autoscaler(_pm=None, **kwargs) -> Autoscaler:
@@ -268,9 +277,10 @@ class TestReconciliation:
         assert stopped is False
         pm.stop.assert_not_called()
 
-        # Colony says this worker is idle -> should stop
+        # Colony says this worker is idle with an aged heartbeat -> should stop.
+        # last_heartbeat must be older than poll_interval (default 30s); use 60s ago.
         a.backend.list_workers.return_value = [
-            _worker("local/auto-builder-1", status="idle"),
+            _worker("local/auto-builder-1", status="idle", last_heartbeat=_aged_hb(60)),
         ]
         stopped = a._stop_idle_worker("builder")
         assert stopped is True
@@ -290,6 +300,76 @@ class TestReconciliation:
         assert "dead" not in a.managed
         assert "alive" in a.managed
         pm.cleanup.assert_called_once_with("dead")
+
+    def test_stop_idle_worker_respects_fresh_claim_grace(self):
+        """Worker with status=idle but fresh last_heartbeat must NOT be reaped.
+
+        This guards against the race where pull() claims a task but the
+        worker's colony-side status hasn't been flipped yet (heartbeat fires
+        ~30s later). The autoscaler's own 30s poll must not kill the worker
+        during that window.
+        """
+        pm = _mock_pm()
+        pm.is_alive.return_value = True
+
+        a = _make_autoscaler(_pm=pm, poll_interval=30.0)
+        a.managed["auto-builder-1"] = ManagedWorker(
+            name="auto-builder-1",
+            role="builder",
+            worker_id="local/auto-builder-1",
+        )
+
+        # last_heartbeat is "now" — worker just registered or just claimed a task
+        a.backend.list_workers.return_value = [
+            _worker("local/auto-builder-1", status="idle", last_heartbeat=_aged_hb(0)),
+        ]
+        stopped = a._stop_idle_worker("builder")
+        assert stopped is False
+        pm.stop.assert_not_called()
+
+    def test_stop_idle_worker_reaps_truly_idle_worker(self):
+        """Worker with status=idle AND heartbeat older than poll_interval IS reaped."""
+        pm = _mock_pm()
+        pm.is_alive.return_value = True
+
+        a = _make_autoscaler(_pm=pm, poll_interval=30.0)
+        a.managed["auto-builder-1"] = ManagedWorker(
+            name="auto-builder-1",
+            role="builder",
+            worker_id="local/auto-builder-1",
+        )
+
+        # last_heartbeat is poll_interval + 5s ago — clearly idle
+        a.backend.list_workers.return_value = [
+            _worker(
+                "local/auto-builder-1",
+                status="idle",
+                last_heartbeat=_aged_hb(30.0 + 5),
+            ),
+        ]
+        stopped = a._stop_idle_worker("builder")
+        assert stopped is True
+        pm.stop.assert_called_once_with("auto-builder-1")
+
+    def test_stop_idle_worker_skips_worker_missing_last_heartbeat(self):
+        """Worker dict missing last_heartbeat must NOT be reaped (fail-safe)."""
+        pm = _mock_pm()
+        pm.is_alive.return_value = True
+
+        a = _make_autoscaler(_pm=pm)
+        a.managed["auto-builder-1"] = ManagedWorker(
+            name="auto-builder-1",
+            role="builder",
+            worker_id="local/auto-builder-1",
+        )
+
+        # No last_heartbeat key at all
+        a.backend.list_workers.return_value = [
+            _worker("local/auto-builder-1", status="idle"),
+        ]
+        stopped = a._stop_idle_worker("builder")
+        assert stopped is False
+        pm.stop.assert_not_called()
 
     def test_run_once_is_idempotent_when_at_desired(self):
         pm = _mock_pm()


### PR DESCRIPTION
## Summary
- Guards `_stop_idle_worker` with a `last_heartbeat` age check: a worker is now reap-eligible only when `status == "idle"` **AND** `last_heartbeat` is older than `poll_interval`.
- Workers with missing or unparseable `last_heartbeat` are skipped (fail-safe — treated as fresh).
- No schema changes, no protocol changes, no new worker-state transitions.

## Root cause
`pull()` claims a task atomically via `os.rename()` but does **not** update the worker's colony-side `status`. That flip comes via the heartbeat thread, which fires ~30s after start. The autoscaler's own 30s `poll_interval` could fire in that window and call `_stop_idle_worker`, seeing `status="idle"` and killing a worker that had literally just claimed a task.

## What changed
- `antfarm/core/autoscaler.py` — `_stop_idle_worker` now checks `last_heartbeat` age before reaping.
- `tests/test_autoscaler.py` — three new tests added:
  - `test_stop_idle_worker_respects_fresh_claim_grace` — fresh heartbeat prevents reap
  - `test_stop_idle_worker_reaps_truly_idle_worker` — aged heartbeat allows reap
  - `test_stop_idle_worker_skips_worker_missing_last_heartbeat` — missing heartbeat is fail-safe

## Tests adjusted
- `test_stop_idle_worker_respects_colony_state` — updated the "idle → should stop" case to include `last_heartbeat=_aged_hb(60)` (60 s ago, well past the 30s poll_interval). Previously it set `status="idle"` with no `last_heartbeat`, which encoded the buggy behaviour. Also added `_aged_hb()` helper and `last_heartbeat` param to `_worker()` factory.

## Test results
848 passed, 0 failed. `ruff check .` clean.

Closes #220