### PR TITLE
fix(soldier): re-review tasks when attempt SHA changes (#226)

### DIFF
--- a/antfarm/core/backends/base.py
+++ b/antfarm/core/backends/base.py
@@ -154,6 +154,30 @@ class TaskBackend(ABC):
         ...
 
     @abstractmethod
+    def rereview(
+        self,
+        review_task_id: str,
+        new_spec: str,
+        touches: list[str],
+    ) -> None:
+        """Re-ready an existing review task for a re-attempted parent task.
+
+        Used when the parent task has a new current_attempt (new SHA) that
+        needs re-review. Moves the review task back to the ready queue,
+        supersedes its current attempt (if any), and updates the spec/touches
+        to reference the new parent attempt.
+
+        Args:
+            review_task_id: ID of the existing review task (e.g. 'review-task-001').
+            new_spec: Replacement spec text referencing the new parent attempt.
+            touches: Replacement touches list.
+
+        Raises:
+            FileNotFoundError: If the review task does not exist.
+        """
+        ...
+
+    @abstractmethod
     def pause_task(self, task_id: str) -> None:
         """Pause an active task. Moves task to PAUSED state.
 

--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -476,6 +476,62 @@ class FileBackend(TaskBackend):
             data["updated_at"] = _now_iso()
             self._write_json(done_path, data)
 
+    def rereview(
+        self,
+        review_task_id: str,
+        new_spec: str,
+        touches: list[str],
+    ) -> None:
+        """Re-ready an existing review task with an updated spec.
+
+        Finds the review task wherever it currently sits (done/, active/,
+        ready/, paused/, blocked/), supersedes its current attempt if any,
+        updates spec + touches, appends a trail entry, and moves the file
+        back into ready/ (unless it is already there).
+        """
+        with self._lock:
+            path = self._find_task_path(review_task_id)
+            if path is None:
+                raise FileNotFoundError(
+                    f"Review task '{review_task_id}' not found"
+                )
+
+            data = self._read_json(path)
+            now = _now_iso()
+
+            current_attempt_id = data.get("current_attempt")
+            if current_attempt_id:
+                for a in data.get("attempts", []):
+                    if a.get("attempt_id") == current_attempt_id:
+                        if a.get("status") != AttemptStatus.SUPERSEDED.value:
+                            a["status"] = AttemptStatus.SUPERSEDED.value
+                            a["completed_at"] = now
+                        break
+                data["current_attempt"] = None
+
+            # Normalize touches: trim + dedupe (preserve case)
+            data["touches"] = list(
+                dict.fromkeys(t.strip() for t in (touches or []))
+            )
+            data["spec"] = new_spec
+
+            trail_entry = TrailEntry(
+                ts=now,
+                worker_id="system",
+                message="Re-review triggered: parent task has a new attempt",
+                action_type="rereview",
+            )
+            data.setdefault("trail", [])
+            data["trail"].append(trail_entry.to_dict())
+
+            data["status"] = TaskStatus.READY.value
+            data["updated_at"] = now
+
+            ready_path = self._ready_path(review_task_id)
+            self._write_json(path, data)
+            if path != ready_path:
+                os.rename(path, ready_path)
+
     def override_merge_order(self, task_id: str, position: int) -> None:
         """Set merge_override on a task in done/."""
         with self._lock:

--- a/antfarm/core/backends/github.py
+++ b/antfarm/core/backends/github.py
@@ -920,6 +920,14 @@ class GitHubBackend(TaskBackend):
             "guards": len(self._guards),
         }
 
+    def rereview(
+        self,
+        review_task_id: str,
+        new_spec: str,
+        touches: list[str],
+    ) -> None:
+        raise NotImplementedError(_GITHUB_BACKEND_MSG)
+
     # ------------------------------------------------------------------
     # Missions (not supported — stubs raise)
     # ------------------------------------------------------------------

--- a/antfarm/core/colony_client.py
+++ b/antfarm/core/colony_client.py
@@ -210,6 +210,19 @@ class ColonyClient:
         r = self._client.post(f"/tasks/{task_id}/merge", json={"attempt_id": attempt_id})
         r.raise_for_status()
 
+    def rereview(
+        self,
+        review_task_id: str,
+        new_spec: str,
+        touches: list[str],
+    ) -> None:
+        """Re-ready an existing review task with an updated spec and touches."""
+        r = self._client.post(
+            f"/tasks/{review_task_id}/rereview",
+            json={"spec": new_spec, "touches": list(touches or [])},
+        )
+        r.raise_for_status()
+
     def list_tasks(self, status: str | None = None) -> list[dict]:
         params = {"status": status} if status else {}
         r = self._client.get("/tasks", params=params)

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -280,6 +280,11 @@ class MergeRequest(BaseModel):
     attempt_id: str
 
 
+class RereviewRequest(BaseModel):
+    spec: str
+    touches: list[str] = []
+
+
 class ReassignRequest(BaseModel):
     worker_id: str
 
@@ -617,6 +622,16 @@ def get_app(
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return {"ok": True}
+
+    @app.post("/tasks/{task_id}/rereview", status_code=200)
+    def rereview_task(task_id: str, req: RereviewRequest):
+        """Re-ready an existing review task with an updated spec + touches."""
+        with _lock:
+            try:
+                _backend.rereview(task_id, req.spec, req.touches)
+            except FileNotFoundError as exc:
+                raise HTTPException(status_code=404, detail=str(exc)) from exc
         return {"ok": True}
 
     @app.post("/tasks/{task_id}/merge", status_code=200)

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -239,6 +239,36 @@ class Soldier:
                 results.append((task_id, MergeResult.NEEDS_REVIEW))
                 continue
 
+            # Review task exists — if its embedded Attempt-SHA differs from
+            # the parent's current attempt SHA, the review is stale
+            # (parent was re-attempted after this review was created).
+            # Re-ready the review task instead of consuming its stale
+            # verdict against the new attempt.
+            existing_sha = self._extract_attempt_sha_from_spec(
+                review_task.get("spec", "")
+            )
+            current_sha = self._current_attempt_sha(task)
+            if existing_sha and current_sha and existing_sha != current_sha:
+                try:
+                    new_spec = self._build_review_spec(task)
+                    self.colony.rereview(
+                        review_task_id, new_spec, task.get("touches", [])
+                    )
+                    logger.info(
+                        "re-readied review task %s for new attempt "
+                        "(sha %s -> %s) from run_once_with_review",
+                        review_task_id,
+                        existing_sha[:12],
+                        current_sha[:12],
+                    )
+                except Exception:
+                    logger.exception(
+                        "failed to re-review %s from run_once_with_review",
+                        review_task_id,
+                    )
+                results.append((task_id, MergeResult.NEEDS_REVIEW))
+                continue
+
             # Review task exists — check its status.
             review_status = review_task.get("status", "")
             if review_status == "blocked":
@@ -786,7 +816,21 @@ class Soldier:
                 existing.get("spec", "")
             )
             current_sha = self._current_attempt_sha(task)
-            if existing_sha and current_sha and existing_sha == current_sha:
+            if not existing_sha:
+                # Legacy review task predates the Attempt-SHA marker.
+                # Don't bounce it — leave it to complete on its own terms.
+                return None
+            if not current_sha:
+                # Pathological: parent attempt has neither head_commit_sha
+                # nor branch. Can't safely decide — leave the review alone.
+                logger.warning(
+                    "skipping re-review for %s: parent task %s has no "
+                    "head_commit_sha and no attempt branch",
+                    review_task_id,
+                    task_id,
+                )
+                return None
+            if existing_sha == current_sha:
                 # Already in flight or verdicted for this attempt
                 return None
             # SHA mismatch (re-attempt) — re-ready the existing review task
@@ -795,8 +839,8 @@ class Soldier:
                 logger.info(
                     "re-readied review task %s for new attempt (sha %s -> %s)",
                     review_task_id,
-                    (existing_sha or "?")[:12],
-                    (current_sha or "?")[:12],
+                    existing_sha[:12],
+                    current_sha[:12],
                 )
                 return review_task_id
             except Exception:

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -677,15 +677,89 @@ class Soldier:
 
         return True, "review passed"
 
-    def create_review_task(self, task: dict) -> str | None:
-        """Create a review task in the queue for a done task.
+    _SHA_MARKER = "Attempt-SHA:"
 
-        Idempotent: if review-{task_id} already exists, returns None without error.
+    @classmethod
+    def _extract_attempt_sha_from_spec(cls, spec: str) -> str:
+        """Return the embedded Attempt-SHA from a review task spec, or ''."""
+        if not spec:
+            return ""
+        marker = cls._SHA_MARKER
+        for raw in spec.splitlines():
+            line = raw.strip()
+            if line.startswith(marker):
+                return line[len(marker):].strip()
+        return ""
+
+    def _current_attempt_sha(self, task: dict) -> str:
+        """Return a stable per-attempt discriminator.
+
+        Prefers the artifact's head_commit_sha; falls back to the attempt's
+        branch name (branches are per-attempt in Antfarm: feat/<task>-<attempt>).
+        """
+        artifact_dict = self._get_attempt_artifact(task)
+        if artifact_dict:
+            sha = artifact_dict.get("head_commit_sha") or ""
+            if sha:
+                return sha
+        return self._get_attempt_branch(task) or ""
+
+    def _build_review_spec(self, task: dict) -> str:
+        """Build the review task spec for ``task``'s current attempt."""
+        task_id = task["id"]
+        branch = self._get_attempt_branch(task) or ""
+        pr = ""
+        for a in task.get("attempts", []):
+            if a.get("attempt_id") == task.get("current_attempt"):
+                pr = a.get("pr", "")
+                break
+        sha = self._current_attempt_sha(task)
+
+        artifact_dict = self._get_attempt_artifact(task)
+        review_pack_text = ""
+        if artifact_dict:
+            from antfarm.core.models import TaskArtifact
+            from antfarm.core.review_pack import generate_review_pack
+
+            try:
+                artifact = TaskArtifact.from_dict(artifact_dict)
+                review_pack_text = generate_review_pack(artifact, task.get("title", ""))
+            except Exception:
+                pass
+
+        spec = (
+            f"Review task {task_id}: '{task.get('title', '')}'\n\n"
+            f"Branch: {branch}\n"
+            f"PR: {pr}\n"
+            f"{self._SHA_MARKER} {sha}\n\n"
+        )
+        if review_pack_text:
+            spec += f"{review_pack_text}\n\n"
+        spec += (
+            "Instructions:\n"
+            "1. Read the PR diff\n"
+            "2. Check for bugs, security issues, and design problems\n"
+            "3. Run tests to verify\n"
+            "4. Produce a ReviewVerdict (pass/needs_changes/blocked)\n"
+            "5. Output verdict between [REVIEW_VERDICT] and [/REVIEW_VERDICT] tags\n"
+        )
+        return spec
+
+    def create_review_task(self, task: dict) -> str | None:
+        """Create (or re-ready) a review task for a done task.
+
+        If no review task exists, create a new one.
+        If a review task exists:
+          - Same attempt SHA as current → no-op (return None).
+          - Different SHA (parent re-attempted) → re-ready the existing
+            review task via ``backend.rereview`` with a fresh spec.
+
         Includes review pack in the spec when artifact is available.
         Propagates mission_id from the parent task to the review task.
         Suppresses review-task creation when the parent mission is CANCELLED.
 
-        Returns the review task ID, or None if creation failed or already exists.
+        Returns the review task ID, or None if no action was taken or
+        creation failed.
         """
         task_id = task["id"]
         review_task_id = f"review-{task_id}"
@@ -702,46 +776,32 @@ class Soldier:
                 )
                 return None
 
-        # Idempotency: skip if review task already exists
+        spec = self._build_review_spec(task)
+        touches = task.get("touches", [])
+
         existing = self.colony.get_task(review_task_id)
         if existing is not None:
-            return None
-
-        branch = self._get_attempt_branch(task) or ""
-        pr = ""
-        for a in task.get("attempts", []):
-            if a.get("attempt_id") == task.get("current_attempt"):
-                pr = a.get("pr", "")
-                break
-
-        # Build spec with review pack if artifact available
-        artifact_dict = self._get_attempt_artifact(task)
-        review_pack_text = ""
-        if artifact_dict:
-            from antfarm.core.models import TaskArtifact
-            from antfarm.core.review_pack import generate_review_pack
-
+            # Compare embedded SHA on existing review task vs current attempt
+            existing_sha = self._extract_attempt_sha_from_spec(
+                existing.get("spec", "")
+            )
+            current_sha = self._current_attempt_sha(task)
+            if existing_sha and current_sha and existing_sha == current_sha:
+                # Already in flight or verdicted for this attempt
+                return None
+            # SHA mismatch (re-attempt) — re-ready the existing review task
             try:
-                artifact = TaskArtifact.from_dict(artifact_dict)
-                review_pack_text = generate_review_pack(artifact, task.get("title", ""))
+                self.colony.rereview(review_task_id, spec, touches)
+                logger.info(
+                    "re-readied review task %s for new attempt (sha %s -> %s)",
+                    review_task_id,
+                    (existing_sha or "?")[:12],
+                    (current_sha or "?")[:12],
+                )
+                return review_task_id
             except Exception:
-                pass
-
-        spec = (
-            f"Review task {task_id}: '{task.get('title', '')}'\n\n"
-            f"Branch: {branch}\n"
-            f"PR: {pr}\n\n"
-        )
-        if review_pack_text:
-            spec += f"{review_pack_text}\n\n"
-        spec += (
-            "Instructions:\n"
-            "1. Read the PR diff\n"
-            "2. Check for bugs, security issues, and design problems\n"
-            "3. Run tests to verify\n"
-            "4. Produce a ReviewVerdict (pass/needs_changes/blocked)\n"
-            "5. Output verdict between [REVIEW_VERDICT] and [/REVIEW_VERDICT] tags\n"
-        )
+                logger.exception("failed to re-review %s", review_task_id)
+                return None
 
         try:
             self.colony.carry(
@@ -749,7 +809,7 @@ class Soldier:
                 title=f"Review: {task.get('title', task_id)}",
                 spec=spec,
                 depends_on=[],
-                touches=task.get("touches", []),
+                touches=touches,
                 priority=1,
                 complexity="S",
                 capabilities_required=["review"],
@@ -848,3 +908,11 @@ class _BackendAdapter:
 
     def get_mission(self, mission_id: str) -> dict | None:
         return self._backend.get_mission(mission_id)
+
+    def rereview(
+        self,
+        review_task_id: str,
+        new_spec: str,
+        touches: list[str],
+    ) -> None:
+        self._backend.rereview(review_task_id, new_spec, touches)

--- a/tests/test_soldier.py
+++ b/tests/test_soldier.py
@@ -806,3 +806,274 @@ def test_soldier_suppresses_review_for_cancelled_mission(tmp_path):
     # Confirm no review task was created
     review_task = backend.get_task("review-task-cancelled")
     assert review_task is None
+
+
+# ---------------------------------------------------------------------------
+# Re-review on SHA mismatch tests (#226)
+# ---------------------------------------------------------------------------
+
+
+def _set_attempt_artifact_sha(backend, task_id, sha: str) -> None:
+    """Inject a minimal artifact with ``head_commit_sha`` onto the current attempt."""
+    import json
+    from pathlib import Path
+
+    # Task is in done/ after harvest.
+    done_path = Path(backend._root) / "tasks" / "done" / f"{task_id}.json"
+    data = json.loads(done_path.read_text())
+    attempt_id = data["current_attempt"]
+    artifact = {
+        "task_id": task_id,
+        "attempt_id": attempt_id,
+        "worker_id": "w-test",
+        "branch": f"feat/{task_id}",
+        "pr_url": None,
+        "base_commit_sha": "0" * 40,
+        "head_commit_sha": sha,
+        "target_branch": "main",
+        "target_branch_sha_at_harvest": "0" * 40,
+    }
+    for a in data["attempts"]:
+        if a["attempt_id"] == attempt_id:
+            a["artifact"] = artifact
+            break
+    done_path.write_text(json.dumps(data, indent=2))
+
+
+def test_create_review_task_creates_when_no_prior_review(tmp_path):
+    """Baseline: with no prior review, create_review_task creates a new one."""
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    _make_done_task_with_mission(backend, "task-rr-new", mission_id=None)
+    _set_attempt_artifact_sha(backend, "task-rr-new", "a" * 40)
+    task = backend.get_task("task-rr-new")
+
+    soldier = Soldier.from_backend(backend, repo_path=str(tmp_path))
+    review_id = soldier.create_review_task(task)
+
+    assert review_id == "review-task-rr-new"
+    review = backend.get_task(review_id)
+    assert review is not None
+    assert review["status"] == "ready"
+    assert "Attempt-SHA:" in review["spec"]
+    assert "a" * 40 in review["spec"]
+
+
+def test_create_review_task_noops_when_sha_matches(tmp_path):
+    """Same SHA on the existing review spec → no-op (returns None)."""
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    _make_done_task_with_mission(backend, "task-rr-same", mission_id=None)
+    _set_attempt_artifact_sha(backend, "task-rr-same", "b" * 40)
+    task = backend.get_task("task-rr-same")
+
+    soldier = Soldier.from_backend(backend, repo_path=str(tmp_path))
+    first = soldier.create_review_task(task)
+    assert first == "review-task-rr-same"
+
+    review_before = backend.get_task("review-task-rr-same")
+    updated_at_before = review_before["updated_at"]
+    trail_len_before = len(review_before.get("trail", []))
+
+    # Second call with same SHA should no-op
+    second = soldier.create_review_task(task)
+    assert second is None
+
+    review_after = backend.get_task("review-task-rr-same")
+    assert review_after["updated_at"] == updated_at_before
+    assert len(review_after.get("trail", [])) == trail_len_before
+
+
+def test_create_review_task_noops_when_review_in_progress(tmp_path):
+    """Review task currently in active/ with matching SHA → no-op."""
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    _make_done_task_with_mission(backend, "task-rr-active", mission_id=None)
+    _set_attempt_artifact_sha(backend, "task-rr-active", "c" * 40)
+    task = backend.get_task("task-rr-active")
+
+    soldier = Soldier.from_backend(backend, repo_path=str(tmp_path))
+    review_id = soldier.create_review_task(task)
+    assert review_id == "review-task-rr-active"
+
+    # Simulate a reviewer picking up the review task
+    backend.register_worker(
+        {
+            "worker_id": "reviewer-1",
+            "node_id": "node-1",
+            "agent_type": "generic",
+            "workspace_root": "/tmp/ws",
+            "status": "idle",
+            "capabilities": ["review"],
+        }
+    )
+    pulled = backend.pull("reviewer-1")
+    assert pulled is not None and pulled["id"] == "review-task-rr-active"
+
+    # SHA still matches → no-op, review stays active
+    again = soldier.create_review_task(task)
+    assert again is None
+    review = backend.get_task("review-task-rr-active")
+    assert review["status"] == "active"
+
+
+def test_create_review_task_rereadies_on_sha_mismatch(tmp_path):
+    """Different SHA on re-attempt → re-ready review task, supersede old attempt."""
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    _make_done_task_with_mission(backend, "task-rr-mm", mission_id=None)
+    _set_attempt_artifact_sha(backend, "task-rr-mm", "a" * 40)
+    task = backend.get_task("task-rr-mm")
+
+    soldier = Soldier.from_backend(backend, repo_path=str(tmp_path))
+    soldier.create_review_task(task)
+
+    # Simulate reviewer claim — review task is now in active/
+    backend.register_worker(
+        {
+            "worker_id": "reviewer-1",
+            "node_id": "node-1",
+            "agent_type": "generic",
+            "workspace_root": "/tmp/ws",
+            "status": "idle",
+            "capabilities": ["review"],
+        }
+    )
+    backend.pull("reviewer-1")
+    review_before = backend.get_task("review-task-rr-mm")
+    old_attempt_id = review_before["current_attempt"]
+    assert review_before["status"] == "active"
+
+    # Parent task gets re-attempted with a new SHA (kickback + re-pull + re-harvest)
+    backend.kickback("task-rr-mm", "reattempt for test")
+    backend.heartbeat("w-task-rr-mm", {"status": "idle"})
+    backend.pull("w-task-rr-mm")
+    pulled = backend.get_task("task-rr-mm")
+    new_attempt_id = pulled["current_attempt"]
+    backend.mark_harvested(
+        "task-rr-mm", new_attempt_id, pr="PR-v2", branch="feat/task-rr-mm"
+    )
+    _set_attempt_artifact_sha(backend, "task-rr-mm", "b" * 40)
+    task = backend.get_task("task-rr-mm")
+
+    review_id = soldier.create_review_task(task)
+    assert review_id == "review-task-rr-mm"
+
+    review_after = backend.get_task("review-task-rr-mm")
+    assert review_after["status"] == "ready"
+    assert review_after["current_attempt"] is None
+    # Old attempt is superseded
+    for a in review_after["attempts"]:
+        if a["attempt_id"] == old_attempt_id:
+            assert a["status"] == "superseded"
+    # New SHA is embedded in the spec
+    assert "b" * 40 in review_after["spec"]
+    # Trail has a re-review entry
+    messages = [e["message"] for e in review_after.get("trail", [])]
+    assert any("Re-review" in m for m in messages)
+
+
+def test_rereview_is_idempotent(tmp_path):
+    """Calling rereview twice doesn't double-supersede the same attempt."""
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    _make_done_task_with_mission(backend, "task-rr-idem", mission_id=None)
+    _set_attempt_artifact_sha(backend, "task-rr-idem", "a" * 40)
+    task = backend.get_task("task-rr-idem")
+
+    soldier = Soldier.from_backend(backend, repo_path=str(tmp_path))
+    soldier.create_review_task(task)
+
+    # Reviewer picks it up, then parent is re-attempted (different SHA)
+    backend.register_worker(
+        {
+            "worker_id": "reviewer-1",
+            "node_id": "node-1",
+            "agent_type": "generic",
+            "workspace_root": "/tmp/ws",
+            "status": "idle",
+            "capabilities": ["review"],
+        }
+    )
+    backend.pull("reviewer-1")
+
+    new_spec = "updated spec body\nAttempt-SHA: " + ("b" * 40) + "\n"
+    backend.rereview("review-task-rr-idem", new_spec, touches=["x"])
+
+    first = backend.get_task("review-task-rr-idem")
+    assert first["status"] == "ready"
+    assert first["current_attempt"] is None
+    superseded_count_1 = sum(
+        1 for a in first["attempts"] if a["status"] == "superseded"
+    )
+
+    # Second rereview: already ready, no current_attempt → no new supersession
+    backend.rereview("review-task-rr-idem", new_spec, touches=["x"])
+    second = backend.get_task("review-task-rr-idem")
+    assert second["status"] == "ready"
+    assert second["current_attempt"] is None
+    superseded_count_2 = sum(
+        1 for a in second["attempts"] if a["status"] == "superseded"
+    )
+    assert superseded_count_2 == superseded_count_1
+
+
+def test_reattempt_end_to_end_flow(tmp_path):
+    """End-to-end: kickback → re-harvest re-readies review; passing verdict unblocks merge."""
+    from antfarm.core.models import ReviewVerdict
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    _make_done_task_with_mission(backend, "task-rr-e2e", mission_id=None)
+    _set_attempt_artifact_sha(backend, "task-rr-e2e", "a" * 40)
+    task = backend.get_task("task-rr-e2e")
+
+    soldier = Soldier.from_backend(backend, repo_path=str(tmp_path))
+    # First review task created
+    assert soldier.create_review_task(task) == "review-task-rr-e2e"
+
+    # Reviewer picks up, parent then gets kicked back (simulating failed review)
+    backend.register_worker(
+        {
+            "worker_id": "reviewer-1",
+            "node_id": "node-1",
+            "agent_type": "generic",
+            "workspace_root": "/tmp/ws",
+            "status": "idle",
+            "capabilities": ["review"],
+        }
+    )
+    backend.pull("reviewer-1")
+    backend.kickback("task-rr-e2e", "review requested changes")
+
+    # Re-pull parent → new attempt, harvest again with a new SHA
+    backend.heartbeat("w-task-rr-e2e", {"status": "idle"})
+    backend.pull("w-task-rr-e2e")
+    pulled = backend.get_task("task-rr-e2e")
+    new_attempt_id = pulled["current_attempt"]
+    backend.mark_harvested(
+        "task-rr-e2e",
+        new_attempt_id,
+        pr="PR-task-rr-e2e-v2",
+        branch="feat/task-rr-e2e",
+    )
+    _set_attempt_artifact_sha(backend, "task-rr-e2e", "b" * 40)
+    task = backend.get_task("task-rr-e2e")
+
+    # Before fix: this would no-op and deadlock. Now it re-readies the review.
+    assert soldier.create_review_task(task) == "review-task-rr-e2e"
+    review = backend.get_task("review-task-rr-e2e")
+    assert review["status"] == "ready"
+    assert "b" * 40 in review["spec"]
+
+    # Simulate a passing verdict on the *new* parent attempt
+    task = backend.get_task("task-rr-e2e")
+    attempt_id = task["current_attempt"]
+    verdict = ReviewVerdict(
+        provider="human",
+        verdict="pass",
+        summary="LGTM",
+        reviewed_commit_sha="b" * 40,
+    )
+    backend.store_review_verdict("task-rr-e2e", attempt_id, verdict.to_dict())
+
+    # Merge queue should now include the task (require_review + passing + fresh)
+    soldier_req = Soldier.from_backend(
+        backend, repo_path=str(tmp_path), require_review=True
+    )
+    ids = [t["id"] for t in soldier_req.get_merge_queue()]
+    assert "task-rr-e2e" in ids

--- a/tests/test_soldier.py
+++ b/tests/test_soldier.py
@@ -1077,3 +1077,182 @@ def test_reattempt_end_to_end_flow(tmp_path):
     )
     ids = [t["id"] for t in soldier_req.get_merge_queue()]
     assert "task-rr-e2e" in ids
+
+
+def test_create_review_task_noops_on_legacy_review_without_marker(tmp_path):
+    """Legacy review task without Attempt-SHA marker → no-op, leave untouched."""
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    _make_done_task_with_mission(backend, "task-rr-legacy", mission_id=None)
+    _set_attempt_artifact_sha(backend, "task-rr-legacy", "a" * 40)
+    task = backend.get_task("task-rr-legacy")
+
+    # Hand-craft a legacy review task (no Attempt-SHA marker in spec)
+    import json
+    from datetime import UTC, datetime
+    from pathlib import Path
+
+    now = datetime.now(UTC).isoformat()
+    legacy_review = {
+        "id": "review-task-rr-legacy",
+        "title": "Review: task-rr-legacy",
+        "spec": (
+            "Review task task-rr-legacy: 'Task task-rr-legacy'\n\n"
+            "Branch: feat/task-rr-legacy\n"
+            "PR: PR-task-rr-legacy\n\n"
+            "Instructions:\n"
+            "1. Read the PR diff\n"
+        ),
+        "complexity": "S",
+        "priority": 1,
+        "depends_on": [],
+        "touches": [],
+        "capabilities_required": ["review"],
+        "mission_id": None,
+        "created_by": "soldier",
+        "status": "active",
+        "current_attempt": "att-legacy",
+        "attempts": [
+            {
+                "attempt_id": "att-legacy",
+                "worker_id": "reviewer-1",
+                "status": "active",
+                "branch": None,
+                "pr": None,
+                "started_at": now,
+                "completed_at": None,
+            }
+        ],
+        "trail": [],
+        "signals": [],
+        "created_at": now,
+        "updated_at": now,
+    }
+    active_path = (
+        Path(backend._root) / "tasks" / "active" / "review-task-rr-legacy.json"
+    )
+    active_path.write_text(json.dumps(legacy_review, indent=2))
+
+    review_before = backend.get_task("review-task-rr-legacy")
+    updated_at_before = review_before["updated_at"]
+    trail_len_before = len(review_before.get("trail", []))
+
+    soldier = Soldier.from_backend(backend, repo_path=str(tmp_path))
+    result = soldier.create_review_task(task)
+    assert result is None
+
+    # Review task untouched — still in active/, same updated_at, same trail
+    review_after = backend.get_task("review-task-rr-legacy")
+    assert review_after["status"] == "active"
+    assert review_after["current_attempt"] == "att-legacy"
+    assert review_after["updated_at"] == updated_at_before
+    assert len(review_after.get("trail", [])) == trail_len_before
+    # Must still be in active/ folder (not bounced to ready/)
+    ready_path = (
+        Path(backend._root) / "tasks" / "ready" / "review-task-rr-legacy.json"
+    )
+    assert not ready_path.exists()
+    assert active_path.exists()
+
+
+def test_run_once_with_review_rereadies_on_sha_mismatch(tmp_path):
+    """run_once_with_review re-readies a stale done review instead of consuming its verdict."""
+    from antfarm.core.models import ReviewVerdict
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+
+    # 1. Parent task done with SHA 'a' (first attempt)
+    _make_done_task_with_mission(backend, "task-rr-roc", mission_id=None)
+    _set_attempt_artifact_sha(backend, "task-rr-roc", "a" * 40)
+    task = backend.get_task("task-rr-roc")
+
+    soldier = Soldier.from_backend(backend, repo_path=str(tmp_path))
+    assert soldier.create_review_task(task) == "review-task-rr-roc"
+
+    # 2. Reviewer claims + finishes the review with a passing verdict for SHA 'a'
+    backend.register_worker(
+        {
+            "worker_id": "reviewer-1",
+            "node_id": "node-1",
+            "agent_type": "generic",
+            "workspace_root": "/tmp/ws",
+            "status": "idle",
+            "capabilities": ["review"],
+        }
+    )
+    backend.pull("reviewer-1")
+    review_task = backend.get_task("review-task-rr-roc")
+    review_attempt_id = review_task["current_attempt"]
+    pass_verdict_for_a = ReviewVerdict(
+        provider="human",
+        verdict="pass",
+        summary="LGTM for a",
+        reviewed_commit_sha="a" * 40,
+    ).to_dict()
+    # Harvest the review task with a passing verdict artifact
+    import json
+    from pathlib import Path
+
+    backend.mark_harvested(
+        "review-task-rr-roc",
+        review_attempt_id,
+        pr="review-pr",
+        branch="feat/review-task-rr-roc",
+    )
+    # Inject a review verdict artifact so extract_verdict_from_review_task finds it
+    review_done_path = (
+        Path(backend._root) / "tasks" / "done" / "review-task-rr-roc.json"
+    )
+    rdata = json.loads(review_done_path.read_text())
+    for a in rdata["attempts"]:
+        if a["attempt_id"] == review_attempt_id:
+            a["artifact"] = {
+                "task_id": "review-task-rr-roc",
+                "attempt_id": review_attempt_id,
+                "worker_id": "reviewer-1",
+                "branch": "feat/review-task-rr-roc",
+                "pr_url": None,
+                "base_commit_sha": "0" * 40,
+                "head_commit_sha": "a" * 40,
+                "target_branch": "main",
+                "target_branch_sha_at_harvest": "0" * 40,
+                "review_verdict": pass_verdict_for_a,
+            }
+            break
+    review_done_path.write_text(json.dumps(rdata, indent=2))
+
+    # 3. Parent task gets kicked back + re-attempted with a NEW SHA 'b'.
+    # The old review in done/ is now STALE (refers to SHA 'a').
+    backend.kickback("task-rr-roc", "need changes")
+    backend.heartbeat("w-task-rr-roc", {"status": "idle"})
+    backend.pull("w-task-rr-roc")
+    pulled = backend.get_task("task-rr-roc")
+    new_attempt_id = pulled["current_attempt"]
+    backend.mark_harvested(
+        "task-rr-roc",
+        new_attempt_id,
+        pr="PR-task-rr-roc-v2",
+        branch="feat/task-rr-roc",
+    )
+    _set_attempt_artifact_sha(backend, "task-rr-roc", "b" * 40)
+
+    # Sanity: the new parent attempt has NO stored review verdict yet.
+    parent_before = backend.get_task("task-rr-roc")
+    for a in parent_before["attempts"]:
+        if a["attempt_id"] == new_attempt_id:
+            assert a.get("review_verdict") is None
+
+    # 4. run_once_with_review should re-ready the stale review, NOT consume
+    # its old verdict against the new attempt.
+    results = soldier.run_once_with_review()
+    assert results == [("task-rr-roc", MergeResult.NEEDS_REVIEW)]
+
+    review_after = backend.get_task("review-task-rr-roc")
+    assert review_after["status"] == "ready"
+    assert review_after["current_attempt"] is None
+    assert "b" * 40 in review_after["spec"]
+
+    # Parent attempt still has no verdict (we didn't inherit the stale one)
+    parent_after = backend.get_task("task-rr-roc")
+    for a in parent_after["attempts"]:
+        if a["attempt_id"] == new_attempt_id:
+            assert a.get("review_verdict") is None


### PR DESCRIPTION
## Root cause

When a task was kicked back and re-claimed, its `current_attempt` changed (new branch + commit SHA). But `create_review_task()` unconditionally no-opped as soon as it saw a pre-existing `review-{task_id}` in `done/` (idempotency guard), so no new review was triggered. `check_review_verdict()` looked only at the *current* attempt's verdict (None), causing `get_merge_queue()` to filter the task out. Result: entire mission deadlocked.

## Approach (Option B — re-ready on SHA mismatch)

Embed an `Attempt-SHA:` marker in the review task spec. On each `create_review_task()` call, compare that marker against the parent task's current-attempt SHA (from the artifact's `head_commit_sha`, falling back to the branch name since branches are per-attempt).

- Same SHA → no-op (current behavior).
- Different SHA → call a new backend method `rereview(review_task_id, new_spec, touches)` which atomically (under `_lock`) moves the review task file back to `ready/`, supersedes its current attempt, clears `current_attempt`, updates spec + touches, and appends a trail entry.

## Files changed

- `antfarm/core/backends/base.py` — abstract `rereview()`
- `antfarm/core/backends/file.py` — implementation under `_lock`; handles review task sitting in any state folder
- `antfarm/core/backends/github.py` — `NotImplementedError` stub matching existing pattern
- `antfarm/core/colony_client.py` — `rereview()` HTTP wrapper
- `antfarm/core/serve.py` — `POST /tasks/{task_id}/rereview` (guarded by `_lock`)
- `antfarm/core/soldier.py` — SHA-aware `create_review_task`, `_BackendAdapter.rereview` forwarder
- `tests/test_soldier.py` — 6 new tests

## New tests

- `test_create_review_task_creates_when_no_prior_review` — baseline sanity
- `test_create_review_task_noops_when_sha_matches` — idempotent on same SHA
- `test_create_review_task_noops_when_review_in_progress` — reviewer already claimed, same SHA → no-op
- `test_create_review_task_rereadies_on_sha_mismatch` — supersedes old attempt, moves to ready, embeds new SHA
- `test_rereview_is_idempotent` — second rereview on already-ready task doesn't double-supersede
- `test_reattempt_end_to_end_flow` — full loop: harvest → review → kickback → re-harvest → review re-readied → passing verdict unblocks merge queue

## Test plan

- [x] `ruff check .` clean
- [x] `pytest tests/ -x -q` — 854 passed
- [x] 6 new re-review tests added and passing

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)