### PR TITLE
Update CHANGELOG with fix #194 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- `register_worker` tolerates stale prior registrations — overwrites worker files whose heartbeat has expired instead of returning 409, preventing autoscaler crashes on colony restart (#194)
+
 ## [0.6.2] - 2026-04-16
 
 ### Added


### PR DESCRIPTION
Add a `### Fixed` entry under the `[Unreleased]` section of `CHANGELOG.md` describing the stale-tolerant `register_worker` behavior and reference issue #194. One bullet, following existing CHANGELOG style (imperative mood, brief). Do not bump the version number.