### PR TITLE
fix(doctor): orphan_tmux_session is informational, not a warning (#229)

### DIFF
--- a/antfarm/core/doctor.py
+++ b/antfarm/core/doctor.py
@@ -22,8 +22,8 @@ from pathlib import Path
 
 @dataclass
 class Finding:
-    severity: str       # "error", "warning", "info"
-    check: str          # e.g., "stale_worker", "stale_task"
+    severity: str  # "error", "warning", "info"
+    check: str  # e.g., "stale_worker", "stale_task"
     message: str
     auto_fixable: bool
     fixed: bool = False
@@ -111,12 +111,14 @@ def check_filesystem(config: dict, fix: bool = False) -> list[Finding]:
 
     # Check writability
     if not os.access(str(data_dir), os.W_OK):
-        findings.append(Finding(
-            severity="error",
-            check="filesystem",
-            message=f"data_dir is not writable: {data_dir}",
-            auto_fixable=False,
-        ))
+        findings.append(
+            Finding(
+                severity="error",
+                check="filesystem",
+                message=f"data_dir is not writable: {data_dir}",
+                auto_fixable=False,
+            )
+        )
 
     # Check subdirs
     for subdir in _REQUIRED_SUBDIRS:
@@ -133,12 +135,14 @@ def check_filesystem(config: dict, fix: bool = False) -> list[Finding]:
                 f.fixed = True
             findings.append(f)
         elif not os.access(str(subpath), os.W_OK):
-            findings.append(Finding(
-                severity="error",
-                check="filesystem",
-                message=f"Required subdirectory not writable: {subpath}",
-                auto_fixable=False,
-            ))
+            findings.append(
+                Finding(
+                    severity="error",
+                    check="filesystem",
+                    message=f"Required subdirectory not writable: {subpath}",
+                    auto_fixable=False,
+                )
+            )
 
     return findings
 
@@ -146,6 +150,7 @@ def check_filesystem(config: dict, fix: bool = False) -> list[Finding]:
 # ---------------------------------------------------------------------------
 # Check 2: Colony reachability
 # ---------------------------------------------------------------------------
+
 
 def check_colony_reachable(config: dict) -> list[Finding]:
     """If colony_url is configured, attempt GET /status.
@@ -158,42 +163,52 @@ def check_colony_reachable(config: dict) -> list[Finding]:
     """
     colony_url = config.get("colony_url")
     if not colony_url:
-        return [Finding(
-            severity="info",
-            check="colony_reachable",
-            message="colony_url not configured — skipping reachability check",
-            auto_fixable=False,
-        )]
+        return [
+            Finding(
+                severity="info",
+                check="colony_reachable",
+                message="colony_url not configured — skipping reachability check",
+                auto_fixable=False,
+            )
+        ]
 
     try:
         import urllib.request
+
         url = colony_url.rstrip("/") + "/status"
         with urllib.request.urlopen(url, timeout=5) as resp:  # noqa: S310
             if resp.status == 200:
-                return [Finding(
-                    severity="info",
+                return [
+                    Finding(
+                        severity="info",
+                        check="colony_reachable",
+                        message=f"Colony reachable at {colony_url}",
+                        auto_fixable=False,
+                    )
+                ]
+            return [
+                Finding(
+                    severity="warning",
                     check="colony_reachable",
-                    message=f"Colony reachable at {colony_url}",
+                    message=f"Colony returned HTTP {resp.status} from {url}",
                     auto_fixable=False,
-                )]
-            return [Finding(
+                )
+            ]
+    except Exception as exc:
+        return [
+            Finding(
                 severity="warning",
                 check="colony_reachable",
-                message=f"Colony returned HTTP {resp.status} from {url}",
+                message=f"Colony unreachable at {colony_url}: {exc}",
                 auto_fixable=False,
-            )]
-    except Exception as exc:
-        return [Finding(
-            severity="warning",
-            check="colony_reachable",
-            message=f"Colony unreachable at {colony_url}: {exc}",
-            auto_fixable=False,
-        )]
+            )
+        ]
 
 
 # ---------------------------------------------------------------------------
 # Check 3: Git config
 # ---------------------------------------------------------------------------
+
 
 def check_git_config() -> list[Finding]:
     """Verify we are inside a git work tree.
@@ -212,24 +227,29 @@ def check_git_config() -> list[Finding]:
         )
         if result.stdout.strip() == "true":
             return []
-        return [Finding(
-            severity="warning",
-            check="git_config",
-            message="Not inside a git work tree",
-            auto_fixable=False,
-        )]
+        return [
+            Finding(
+                severity="warning",
+                check="git_config",
+                message="Not inside a git work tree",
+                auto_fixable=False,
+            )
+        ]
     except subprocess.CalledProcessError as exc:
-        return [Finding(
-            severity="warning",
-            check="git_config",
-            message=f"git rev-parse failed: {exc}",
-            auto_fixable=False,
-        )]
+        return [
+            Finding(
+                severity="warning",
+                check="git_config",
+                message=f"git rev-parse failed: {exc}",
+                auto_fixable=False,
+            )
+        ]
 
 
 # ---------------------------------------------------------------------------
 # Check 4: Stale workers
 # ---------------------------------------------------------------------------
+
 
 def check_stale_workers(backend, config: dict, fix: bool = False) -> list[Finding]:
     """List worker files in data_dir/workers/. Check mtime vs worker_ttl.
@@ -282,6 +302,7 @@ def check_stale_workers(backend, config: dict, fix: bool = False) -> list[Findin
 # ---------------------------------------------------------------------------
 # Check 5: Stale tasks
 # ---------------------------------------------------------------------------
+
 
 def check_stale_tasks(backend, config: dict, fix: bool = False) -> list[Finding]:
     """List tasks in active/. Check if current_attempt's worker is live.
@@ -341,9 +362,7 @@ def check_stale_tasks(backend, config: dict, fix: bool = False) -> list[Finding]
             f = Finding(
                 severity="warning",
                 check="stale_task",
-                message=(
-                    f"Task '{task_id}' is active but worker '{worker_id}' is dead/missing"
-                ),
+                message=(f"Task '{task_id}' is active but worker '{worker_id}' is dead/missing"),
                 auto_fixable=True,
             )
             if fix:
@@ -387,11 +406,13 @@ def _recover_stale_task(
 
     # Add trail entry
     data.setdefault("trail", [])
-    data["trail"].append({
-        "ts": now,
-        "worker_id": "doctor",
-        "message": "recovered by doctor",
-    })
+    data["trail"].append(
+        {
+            "ts": now,
+            "worker_id": "doctor",
+            "message": "recovered by doctor",
+        }
+    )
 
     # Write to ready/ atomically, then delete from active/
     ready_path = data_dir / "tasks" / "ready" / task_file.name
@@ -404,6 +425,7 @@ def _recover_stale_task(
 # ---------------------------------------------------------------------------
 # Check 6: Stale guards
 # ---------------------------------------------------------------------------
+
 
 def check_stale_guards(backend, config: dict, fix: bool = False) -> list[Finding]:
     """List guard files in data_dir/guards/. Check mtime vs guard_ttl AND owner liveness.
@@ -473,6 +495,7 @@ def check_stale_guards(backend, config: dict, fix: bool = False) -> list[Finding
 # Check 7: Workspace conflicts
 # ---------------------------------------------------------------------------
 
+
 def check_workspace_conflicts(backend) -> list[Finding]:
     """Check if any active workers share the same workspace_root.
 
@@ -507,14 +530,14 @@ def check_workspace_conflicts(backend) -> list[Finding]:
 
     for ws_root, worker_ids in workspace_to_workers.items():
         if len(worker_ids) > 1:
-            findings.append(Finding(
-                severity="warning",
-                check="workspace_conflict",
-                message=(
-                    f"Workers {worker_ids} share workspace_root '{ws_root}'"
-                ),
-                auto_fixable=False,
-            ))
+            findings.append(
+                Finding(
+                    severity="warning",
+                    check="workspace_conflict",
+                    message=(f"Workers {worker_ids} share workspace_root '{ws_root}'"),
+                    auto_fixable=False,
+                )
+            )
 
     return findings
 
@@ -522,6 +545,7 @@ def check_workspace_conflicts(backend) -> list[Finding]:
 # ---------------------------------------------------------------------------
 # Check 8: Orphan workspaces
 # ---------------------------------------------------------------------------
+
 
 def _worktree_is_clean(path: str) -> bool:
     """Check if a worktree is provably clean (safe to delete).
@@ -533,7 +557,9 @@ def _worktree_is_clean(path: str) -> bool:
         # Check for uncommitted changes
         status = subprocess.run(
             ["git", "-C", path, "status", "--porcelain"],
-            capture_output=True, text=True, check=True,
+            capture_output=True,
+            text=True,
+            check=True,
         )
         if status.stdout.strip():
             return False  # has uncommitted changes
@@ -541,7 +567,9 @@ def _worktree_is_clean(path: str) -> bool:
         # Check for unpushed commits — requires upstream to be configured
         log = subprocess.run(
             ["git", "-C", path, "log", "@{u}..", "--oneline"],
-            capture_output=True, text=True, check=False,
+            capture_output=True,
+            text=True,
+            check=False,
         )
         if log.returncode != 0:
             return False  # no upstream configured or git error — keep it
@@ -586,46 +614,56 @@ def check_orphan_workspaces(config: dict, fix: bool = False) -> list[Finding]:
                 try:
                     subprocess.run(
                         ["git", "worktree", "remove", str(entry)],
-                        capture_output=True, text=True, check=True,
+                        capture_output=True,
+                        text=True,
+                        check=True,
                         cwd=repo_path,
                     )
-                    findings.append(Finding(
-                        severity="info",
-                        check="orphan_workspace",
-                        message=f"Orphan worktree auto-deleted (clean): {entry}",
-                        auto_fixable=True,
-                        fixed=True,
-                    ))
+                    findings.append(
+                        Finding(
+                            severity="info",
+                            check="orphan_workspace",
+                            message=f"Orphan worktree auto-deleted (clean): {entry}",
+                            auto_fixable=True,
+                            fixed=True,
+                        )
+                    )
                 except subprocess.CalledProcessError:
-                    findings.append(Finding(
+                    findings.append(
+                        Finding(
+                            severity="info",
+                            check="orphan_workspace",
+                            message=(
+                                f"Worktree directory found with no associated active task: "
+                                f"{entry} (removal failed)"
+                            ),
+                            auto_fixable=False,
+                        )
+                    )
+            elif fix:
+                findings.append(
+                    Finding(
                         severity="info",
                         check="orphan_workspace",
                         message=(
-                            f"Worktree directory found with no associated active task: "
-                            f"{entry} (removal failed)"
+                            f"Orphan worktree kept: has changes or could not verify "
+                            f"clean state: {entry}"
                         ),
-                        auto_fixable=False,
-                    ))
-            elif fix:
-                findings.append(Finding(
-                    severity="info",
-                    check="orphan_workspace",
-                    message=(
-                        f"Orphan worktree kept: has changes or could not verify "
-                        f"clean state: {entry}"
-                    ),
-                    auto_fixable=True,
-                    fixed=False,
-                ))
+                        auto_fixable=True,
+                        fixed=False,
+                    )
+                )
             else:
-                findings.append(Finding(
-                    severity="info",
-                    check="orphan_workspace",
-                    message=(
-                        f"Worktree directory found with no associated active task: {entry}"
-                    ),
-                    auto_fixable=True,
-                ))
+                findings.append(
+                    Finding(
+                        severity="info",
+                        check="orphan_workspace",
+                        message=(
+                            f"Worktree directory found with no associated active task: {entry}"
+                        ),
+                        auto_fixable=True,
+                    )
+                )
 
     return findings
 
@@ -633,6 +671,7 @@ def check_orphan_workspaces(config: dict, fix: bool = False) -> list[Finding]:
 # ---------------------------------------------------------------------------
 # Check 9: State consistency
 # ---------------------------------------------------------------------------
+
 
 def check_state_consistency(backend) -> list[Finding]:
     """Read task files directly and check for state inconsistencies.
@@ -671,83 +710,87 @@ def check_state_consistency(backend) -> list[Finding]:
             try:
                 data = json.loads(task_file.read_text())
             except (json.JSONDecodeError, OSError) as exc:
-                findings.append(Finding(
-                    severity="error",
-                    check="state_consistency",
-                    message=f"Malformed JSON in {task_file.name}: {exc}",
-                    auto_fixable=False,
-                ))
+                findings.append(
+                    Finding(
+                        severity="error",
+                        check="state_consistency",
+                        message=f"Malformed JSON in {task_file.name}: {exc}",
+                        auto_fixable=False,
+                    )
+                )
                 continue
 
             status = data.get("status", "")
 
             # (a) status field doesn't match folder
             if status != folder_name:
-                findings.append(Finding(
-                    severity="error",
-                    check="state_consistency",
-                    message=(
-                        f"Task '{task_id}' is in {folder_name}/ but status='{status}'"
-                    ),
-                    auto_fixable=False,
-                ))
+                findings.append(
+                    Finding(
+                        severity="error",
+                        check="state_consistency",
+                        message=(f"Task '{task_id}' is in {folder_name}/ but status='{status}'"),
+                        auto_fixable=False,
+                    )
+                )
 
             # (b) task in active/ with no current_attempt
             if folder_name == "active" and not data.get("current_attempt"):
-                findings.append(Finding(
-                    severity="error",
-                    check="state_consistency",
-                    message=f"Task '{task_id}' is in active/ but has no current_attempt",
-                    auto_fixable=False,
-                ))
+                findings.append(
+                    Finding(
+                        severity="error",
+                        check="state_consistency",
+                        message=f"Task '{task_id}' is in active/ but has no current_attempt",
+                        auto_fixable=False,
+                    )
+                )
 
             # (c) more than one ACTIVE attempt
-            active_attempts = [
-                a for a in data.get("attempts", [])
-                if a.get("status") == "active"
-            ]
+            active_attempts = [a for a in data.get("attempts", []) if a.get("status") == "active"]
             if len(active_attempts) > 1:
-                findings.append(Finding(
-                    severity="error",
-                    check="state_consistency",
-                    message=(
-                        f"Task '{task_id}' has {len(active_attempts)} active attempts "
-                        f"(should be at most 1)"
-                    ),
-                    auto_fixable=False,
-                ))
+                findings.append(
+                    Finding(
+                        severity="error",
+                        check="state_consistency",
+                        message=(
+                            f"Task '{task_id}' has {len(active_attempts)} active attempts "
+                            f"(should be at most 1)"
+                        ),
+                        auto_fixable=False,
+                    )
+                )
 
             # (e) done task with current_attempt pointing to non-existent attempt
             current = data.get("current_attempt")
             if current and folder_name == "done":
                 attempt_ids = {a.get("attempt_id") for a in data.get("attempts", [])}
                 if current not in attempt_ids:
-                    findings.append(Finding(
-                        severity="error",
-                        check="state_consistency",
-                        message=(
-                            f"Task '{task_id}' in done/ has current_attempt='{current}' "
-                            f"but no matching attempt exists"
-                        ),
-                        auto_fixable=False,
-                    ))
+                    findings.append(
+                        Finding(
+                            severity="error",
+                            check="state_consistency",
+                            message=(
+                                f"Task '{task_id}' in done/ has current_attempt='{current}' "
+                                f"but no matching attempt exists"
+                            ),
+                            auto_fixable=False,
+                        )
+                    )
 
             # (f) merged attempt is current_attempt while task status is ready
             if current and folder_name == "ready":
                 for attempt in data.get("attempts", []):
-                    if (
-                        attempt.get("attempt_id") == current
-                        and attempt.get("status") == "merged"
-                    ):
-                        findings.append(Finding(
-                            severity="error",
-                            check="state_consistency",
-                            message=(
-                                f"Task '{task_id}' in ready/ has a merged attempt "
-                                f"as current_attempt — invalid state"
-                            ),
-                            auto_fixable=False,
-                        ))
+                    if attempt.get("attempt_id") == current and attempt.get("status") == "merged":
+                        findings.append(
+                            Finding(
+                                severity="error",
+                                check="state_consistency",
+                                message=(
+                                    f"Task '{task_id}' in ready/ has a merged attempt "
+                                    f"as current_attempt — invalid state"
+                                ),
+                                auto_fixable=False,
+                            )
+                        )
 
     return findings
 
@@ -755,6 +798,7 @@ def check_state_consistency(backend) -> list[Finding]:
 # ---------------------------------------------------------------------------
 # Check 10: Dependency cycles
 # ---------------------------------------------------------------------------
+
 
 def check_dependency_cycles(backend) -> list[Finding]:
     """Load all tasks, build dependency graph, detect cycles and dangling refs.
@@ -772,12 +816,14 @@ def check_dependency_cycles(backend) -> list[Finding]:
     try:
         all_tasks = backend.list_tasks()
     except Exception as exc:
-        findings.append(Finding(
-            severity="error",
-            check="dependency_cycles",
-            message=f"Could not load tasks for dependency check: {exc}",
-            auto_fixable=False,
-        ))
+        findings.append(
+            Finding(
+                severity="error",
+                check="dependency_cycles",
+                message=f"Could not load tasks for dependency check: {exc}",
+                auto_fixable=False,
+            )
+        )
         return findings
 
     task_ids = {t["id"] for t in all_tasks}
@@ -787,12 +833,14 @@ def check_dependency_cycles(backend) -> list[Finding]:
     for task_id, task_deps in deps.items():
         for dep in task_deps:
             if dep not in task_ids:
-                findings.append(Finding(
-                    severity="warning",
-                    check="dangling_dependency",
-                    message=f"Task '{task_id}' depends on non-existent task '{dep}'",
-                    auto_fixable=False,
-                ))
+                findings.append(
+                    Finding(
+                        severity="warning",
+                        check="dangling_dependency",
+                        message=f"Task '{task_id}' depends on non-existent task '{dep}'",
+                        auto_fixable=False,
+                    )
+                )
 
     # DFS cycle detection
     WHITE, GRAY, BLACK = 0, 1, 2
@@ -812,15 +860,17 @@ def check_dependency_cycles(backend) -> list[Finding]:
                 cycle_key = "->".join(sorted(cycle_nodes))
                 if cycle_key not in cycle_reported:
                     cycle_reported.add(cycle_key)
-                    findings.append(Finding(
-                        severity="error",
-                        check="dependency_cycles",
-                        message=(
-                            f"Dependency cycle detected: "
-                            f"{' -> '.join(cycle_nodes)} -> {neighbor}"
-                        ),
-                        auto_fixable=False,
-                    ))
+                    findings.append(
+                        Finding(
+                            severity="error",
+                            check="dependency_cycles",
+                            message=(
+                                f"Dependency cycle detected: "
+                                f"{' -> '.join(cycle_nodes)} -> {neighbor}"
+                            ),
+                            auto_fixable=False,
+                        )
+                    )
             elif color[neighbor] == WHITE:
                 dfs(neighbor, path)
         path.pop()
@@ -836,6 +886,7 @@ def check_dependency_cycles(backend) -> list[Finding]:
 # ---------------------------------------------------------------------------
 # Check 11: Runner health
 # ---------------------------------------------------------------------------
+
 
 def check_runner_health(backend, config: dict, fix: bool = False) -> list[Finding]:
     """Check reachability of all nodes with runner_url.
@@ -874,24 +925,25 @@ def check_runner_health(backend, config: dict, fix: bool = False) -> list[Findin
             with urllib.request.urlopen(url, timeout=3) as resp:  # noqa: S310
                 if resp.status == 200:
                     continue
-                findings.append(Finding(
+                findings.append(
+                    Finding(
+                        severity="warning",
+                        check="runner_health",
+                        message=(
+                            f"Runner on node '{node_id}' returned HTTP {resp.status} from {url}"
+                        ),
+                        auto_fixable=False,
+                    )
+                )
+        except Exception as exc:
+            findings.append(
+                Finding(
                     severity="warning",
                     check="runner_health",
-                    message=(
-                        f"Runner on node '{node_id}' returned HTTP {resp.status} "
-                        f"from {url}"
-                    ),
+                    message=(f"Runner on node '{node_id}' unreachable at {runner_url}: {exc}"),
                     auto_fixable=False,
-                ))
-        except Exception as exc:
-            findings.append(Finding(
-                severity="warning",
-                check="runner_health",
-                message=(
-                    f"Runner on node '{node_id}' unreachable at {runner_url}: {exc}"
-                ),
-                auto_fixable=False,
-            ))
+                )
+            )
 
     return findings
 
@@ -899,6 +951,7 @@ def check_runner_health(backend, config: dict, fix: bool = False) -> list[Findin
 # ---------------------------------------------------------------------------
 # Check 12: tmux availability
 # ---------------------------------------------------------------------------
+
 
 def check_tmux_available(config: dict) -> list[Finding]:
     """Warn if tmux is not installed — workers will fall back to unreliable subprocess mode.
@@ -911,14 +964,16 @@ def check_tmux_available(config: dict) -> list[Finding]:
     """
     if shutil.which("tmux"):
         return []
-    return [Finding(
-        severity="warning",
-        check="tmux_available",
-        message=(
-            "tmux not installed — worker spawning will use subprocess fallback (less reliable)"
-        ),
-        auto_fixable=False,
-    )]
+    return [
+        Finding(
+            severity="warning",
+            check="tmux_available",
+            message=(
+                "tmux not installed — worker spawning will use subprocess fallback (less reliable)"
+            ),
+            auto_fixable=False,
+        )
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -935,6 +990,13 @@ def check_orphan_tmux_sessions(config: dict) -> list[Finding]:
     (``auto-`` or ``runner-``) but whose ProcessMetadata file is absent from
     ``{state_dir}/processes/{name}.json``.  This can happen when the colony
     process crashed before writing metadata, or after a manual ``tmux kill-server``.
+
+    Severity is ``info``, not ``warning``, because we cannot reliably distinguish
+    our own orphan from a live session owned by a peer colony (different
+    ``data_dir`` on the same host) from tmux alone. Users running ``antfarm
+    doctor`` still see the finding, but automated gates (e.g. the Soldier merge
+    gate's "no errors/warnings" assertion) do not fire spuriously on hosts that
+    run multiple colonies or host long-lived dogfood sessions.
 
     Args:
         config: Doctor config dict. Uses ``data_dir`` to locate process metadata.
@@ -978,11 +1040,13 @@ def check_orphan_tmux_sessions(config: dict) -> list[Finding]:
             if metadata_file.exists():
                 continue
 
-        findings.append(Finding(
-            severity="warning",
-            check="orphan_tmux_session",
-            message=f"orphan tmux session: {name} (no matching metadata)",
-            auto_fixable=False,
-        ))
+        findings.append(
+            Finding(
+                severity="info",
+                check="orphan_tmux_session",
+                message=f"orphan tmux session: {name} (no matching metadata)",
+                auto_fixable=False,
+            )
+        )
 
     return findings

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -71,9 +71,18 @@ def test_healthy_colony_no_findings(setup):
     findings = run_doctor(backend, config)
     # Exclude tmux_available: it fires in CI/minimal environments where tmux
     # is not installed — this is expected and not a colony health issue.
+    #
+    # orphan_tmux_session is also tolerated here (defense in depth): it is an
+    # ``info``-severity finding so the severity filter below already skips it,
+    # but we list it explicitly so the intent is code, not just comment. This
+    # matters when the test host has live tmux sessions owned by a peer colony
+    # (different data_dir on the same machine) — those are not failures of the
+    # colony under test.
     errors_warnings = [
-        f for f in findings
-        if f.severity in ("error", "warning") and f.check != "tmux_available"
+        f
+        for f in findings
+        if f.severity in ("error", "warning")
+        and f.check not in ("tmux_available", "orphan_tmux_session")
     ]
     assert errors_warnings == [], f"Expected no errors/warnings, got: {errors_warnings}"
 
@@ -348,6 +357,7 @@ def test_filesystem_check_creates_dirs(setup):
 
     # Delete a required subdir
     import shutil
+
     shutil.rmtree(str(data_dir / "guards"))
     assert not (data_dir / "guards").exists()
 
@@ -389,35 +399,36 @@ def test_orphan_worktree_clean_deleted_on_fix(setup, tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(["git", "init"], cwd=str(repo), capture_output=True, check=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@test"], cwd=str(repo), capture_output=True
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test"], cwd=str(repo), capture_output=True
-    )
+    subprocess.run(["git", "config", "user.email", "test@test"], cwd=str(repo), capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=str(repo), capture_output=True)
     (repo / "file.txt").write_text("init")
     subprocess.run(["git", "add", "."], cwd=str(repo), capture_output=True, check=True)
-    subprocess.run(
-        ["git", "commit", "-m", "init"], cwd=str(repo), capture_output=True, check=True
-    )
+    subprocess.run(["git", "commit", "-m", "init"], cwd=str(repo), capture_output=True, check=True)
 
     # Create a bare remote so worktree has an upstream
     bare = tmp_path / "bare.git"
     subprocess.run(
         ["git", "clone", "--bare", str(repo), str(bare)],
-        capture_output=True, check=True,
+        capture_output=True,
+        check=True,
     )
     subprocess.run(
         ["git", "remote", "add", "origin", str(bare)],
-        cwd=str(repo), capture_output=True, check=True,
+        cwd=str(repo),
+        capture_output=True,
+        check=True,
     )
     subprocess.run(
         ["git", "push", "-u", "origin", "main"],
-        cwd=str(repo), capture_output=True, check=False,
+        cwd=str(repo),
+        capture_output=True,
+        check=False,
     )
     subprocess.run(
         ["git", "push", "-u", "origin", "master"],
-        cwd=str(repo), capture_output=True, check=False,
+        cwd=str(repo),
+        capture_output=True,
+        check=False,
     )
 
     # Create a worktree with upstream tracking
@@ -426,12 +437,16 @@ def test_orphan_worktree_clean_deleted_on_fix(setup, tmp_path):
     wt_path = ws_root / "task-orphan-att-001"
     subprocess.run(
         ["git", "worktree", "add", "-b", "feat/orphan", str(wt_path)],
-        cwd=str(repo), capture_output=True, check=True,
+        cwd=str(repo),
+        capture_output=True,
+        check=True,
     )
     # Push the branch so it has an upstream
     subprocess.run(
         ["git", "push", "-u", "origin", "feat/orphan"],
-        cwd=str(wt_path), capture_output=True, check=True,
+        cwd=str(wt_path),
+        capture_output=True,
+        check=True,
     )
     assert wt_path.exists()
 
@@ -457,23 +472,19 @@ def test_worktree_is_clean_no_upstream_returns_false(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(["git", "init"], cwd=str(repo), capture_output=True, check=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@test"], cwd=str(repo), capture_output=True
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test"], cwd=str(repo), capture_output=True
-    )
+    subprocess.run(["git", "config", "user.email", "test@test"], cwd=str(repo), capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=str(repo), capture_output=True)
     (repo / "file.txt").write_text("init")
     subprocess.run(["git", "add", "."], cwd=str(repo), capture_output=True, check=True)
-    subprocess.run(
-        ["git", "commit", "-m", "init"], cwd=str(repo), capture_output=True, check=True
-    )
+    subprocess.run(["git", "commit", "-m", "init"], cwd=str(repo), capture_output=True, check=True)
 
     # Create a worktree (no remote/upstream)
     wt_path = tmp_path / "workspaces" / "task-orphan-att-001"
     subprocess.run(
         ["git", "worktree", "add", "-b", "feat/orphan", str(wt_path)],
-        cwd=str(repo), capture_output=True, check=True,
+        cwd=str(repo),
+        capture_output=True,
+        check=True,
     )
     assert wt_path.exists()
 
@@ -490,22 +501,18 @@ def test_worktree_is_clean_dirty_returns_false(tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(["git", "init"], cwd=str(repo), capture_output=True, check=True)
-    subprocess.run(
-        ["git", "config", "user.email", "test@test"], cwd=str(repo), capture_output=True
-    )
-    subprocess.run(
-        ["git", "config", "user.name", "Test"], cwd=str(repo), capture_output=True
-    )
+    subprocess.run(["git", "config", "user.email", "test@test"], cwd=str(repo), capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=str(repo), capture_output=True)
     (repo / "file.txt").write_text("init")
     subprocess.run(["git", "add", "."], cwd=str(repo), capture_output=True, check=True)
-    subprocess.run(
-        ["git", "commit", "-m", "init"], cwd=str(repo), capture_output=True, check=True
-    )
+    subprocess.run(["git", "commit", "-m", "init"], cwd=str(repo), capture_output=True, check=True)
 
     wt_path = tmp_path / "workspaces" / "task-dirty"
     subprocess.run(
         ["git", "worktree", "add", "-b", "feat/dirty", str(wt_path)],
-        cwd=str(repo), capture_output=True, check=True,
+        cwd=str(repo),
+        capture_output=True,
+        check=True,
     )
 
     # Create uncommitted changes
@@ -638,7 +645,7 @@ def test_check_orphan_tmux_sessions_no_tmux():
 
 
 def test_check_orphan_tmux_sessions_detects_orphans(tmp_path):
-    """Antfarm-prefixed session without metadata emits warning; one WITH metadata does not."""
+    """Antfarm-prefixed session without metadata emits info finding; one WITH metadata does not."""
     from unittest.mock import MagicMock, patch
 
     from antfarm.core.doctor import check_orphan_tmux_sessions
@@ -670,7 +677,7 @@ def test_check_orphan_tmux_sessions_detects_orphans(tmp_path):
     orphan_checks = [f for f in findings if f.check == "orphan_tmux_session"]
     assert len(orphan_checks) == 1
     assert "auto-planner-2" in orphan_checks[0].message
-    assert orphan_checks[0].severity == "warning"
+    assert orphan_checks[0].severity == "info"
     assert orphan_checks[0].auto_fixable is False
 
 
@@ -691,3 +698,60 @@ def test_check_orphan_tmux_sessions_no_server():
         findings = check_orphan_tmux_sessions({})
 
     assert findings == []
+
+
+# ---------------------------------------------------------------------------
+# Regression: peer-colony tmux sessions must not trip the Soldier merge gate
+# ---------------------------------------------------------------------------
+
+
+def test_run_doctor_on_colony_with_peer_auto_tmux_sessions_produces_no_warnings(setup, monkeypatch):
+    """Peer-colony tmux sessions must not raise error/warning findings.
+
+    Scenario: another antfarm colony (different data_dir, same host) owns live
+    ``auto-*`` tmux sessions. From this colony's point of view those sessions
+    have no matching metadata in its own ``processes/`` directory, so
+    ``check_orphan_tmux_sessions`` will flag them. The finding must be
+    ``info`` severity so that the Soldier merge gate — which treats any
+    error/warning as blocking — does not kick back every PR during dogfooding.
+    """
+    import subprocess as real_subprocess
+    from unittest.mock import MagicMock
+
+    import antfarm.core.doctor as doctor_mod
+
+    backend, config = setup
+
+    # Simulate a peer colony's sessions appearing in `tmux ls` output.
+    tmux_result = MagicMock()
+    tmux_result.returncode = 0
+    tmux_result.stdout = "auto-reviewer-99\nauto-builder-42\n"
+
+    real_run = real_subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):
+        # Only intercept the tmux list-sessions call — delegate everything else
+        # (e.g., git rev-parse for git_config) to the real subprocess.run so
+        # unrelated checks behave normally.
+        if isinstance(cmd, (list, tuple)) and cmd and cmd[0] == "tmux":
+            return tmux_result
+        return real_run(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(doctor_mod.shutil, "which", lambda _name: "/usr/bin/tmux")
+    monkeypatch.setattr(doctor_mod.subprocess, "run", fake_run)
+
+    findings = run_doctor(backend, config, fix=False)
+
+    orphan_findings = [f for f in findings if f.check == "orphan_tmux_session"]
+    assert len(orphan_findings) == 2, (
+        f"expected both peer sessions to be flagged, got: {orphan_findings}"
+    )
+    assert all(f.severity == "info" for f in orphan_findings), (
+        f"peer-session findings must be info-severity, got: {orphan_findings}"
+    )
+
+    # The real regression guard: Soldier's gate asserts no errors/warnings.
+    blocking = [f for f in findings if f.severity in ("error", "warning")]
+    assert blocking == [], (
+        f"peer-colony tmux sessions must not produce error/warning findings: {blocking}"
+    )


### PR DESCRIPTION
## Summary

- `check_orphan_tmux_sessions` emitted `warning` findings for any antfarm-prefixed tmux session (`auto-*`, `runner-*`) without matching metadata in this colony's `data_dir/processes/`. From `tmux ls` alone we cannot tell whether such a session is a true orphan of THIS colony (e.g., survived a crash) or a live session owned by a peer colony sharing the same host under a different `data_dir`. Emitting `warning` in the ambiguous case caused `test_healthy_colony_no_findings` to fail on any host with live dogfood tmux sessions, which in turn made the Soldier merge gate's "no errors/warnings" assertion kick back every PR during dogfooding — deadlocking missions.
- Downgrades the finding's severity from `warning` to `info`. The finding is still produced (users running `antfarm doctor` still see it), but automated gates stop firing spuriously.

## Root cause

`antfarm/core/doctor.py:982` — the `Finding` constructed by `check_orphan_tmux_sessions` used `severity="warning"`. Since the check genuinely cannot distinguish a peer colony's live session from our own orphan, `info` is the honest severity.

## Changes

- `antfarm/core/doctor.py` — change `severity="warning"` → `severity="info"` in the `orphan_tmux_session` Finding. Expand the `check_orphan_tmux_sessions` docstring to explain the severity choice.
- `tests/test_doctor.py`
  - `test_healthy_colony_no_findings`: add `orphan_tmux_session` to the skip-list alongside `tmux_available` (defense in depth — it's already `info` so the `("error", "warning")` filter skips it; the explicit skip documents intent).
  - `test_check_orphan_tmux_sessions_detects_orphans`: update severity assertion from `"warning"` to `"info"` and adjust the docstring.
  - New test `test_run_doctor_on_colony_with_peer_auto_tmux_sessions_produces_no_warnings`: regression guard. Mocks `tmux list-sessions` to return `auto-reviewer-99` / `auto-builder-42` (no matching metadata in the test colony's `data_dir`), runs `run_doctor`, and asserts (a) both peer sessions show up as `info`-severity `orphan_tmux_session` findings and (b) no `error`/`warning` findings are produced — i.e., the Soldier merge gate would pass on this host.

## Test Plan

- [x] `pytest tests/ -x -q` — 863 passed
- [x] `ruff check .` — All checks passed
- [x] `ruff format .` — no changes

Closes #229