### PR TITLE
fix(queen): write mission_context blob on build transition (#219)

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -41,12 +41,8 @@ def _auth_headers(token: str | None) -> dict:
     return {}
 
 
-def _post(
-    colony_url: str, path: str, payload: dict, token: str | None = None
-) -> dict | None:
-    r = httpx.post(
-        f"{colony_url.rstrip('/')}{path}", json=payload, headers=_auth_headers(token)
-    )
+def _post(colony_url: str, path: str, payload: dict, token: str | None = None) -> dict | None:
+    r = httpx.post(f"{colony_url.rstrip('/')}{path}", json=payload, headers=_auth_headers(token))
     r.raise_for_status()
     if r.status_code == 204:
         return None
@@ -178,6 +174,18 @@ def version():
     envvar="ANTFARM_GITHUB_TOKEN",
     help="GitHub personal access token (for --backend=github).",
 )
+@click.option(
+    "--repo-path",
+    default=".",
+    show_default=True,
+    help="Path to the git repo. Used by Queen to generate mission context.",
+)
+@click.option(
+    "--integration-branch",
+    default="main",
+    show_default=True,
+    help="Integration branch used by Queen when generating mission context.",
+)
 def colony(
     port: int,
     host: str,
@@ -195,8 +203,12 @@ def colony(
     backend: str,
     github_repo: str | None,
     github_token: str | None,
+    repo_path: str,
+    integration_branch: str,
 ):
     """Start the colony server."""
+    import os
+
     import uvicorn
 
     from antfarm.core.backends import get_backend
@@ -212,6 +224,22 @@ def colony(
         click.echo(f"Using GitHub Issues backend: {github_repo}")
     else:
         task_backend = get_backend("file", root=data_dir)
+
+    # Persist repo_path and integration_branch into config.json so Queen (and
+    # other daemons that read config.json) can pick them up.
+    os.makedirs(data_dir, exist_ok=True)
+    _config_path = os.path.join(data_dir, "config.json")
+    _existing: dict = {}
+    if os.path.exists(_config_path):
+        try:
+            with open(_config_path) as _f:
+                _existing = json.load(_f)
+        except (json.JSONDecodeError, OSError):
+            _existing = {}
+    _existing["repo_path"] = repo_path
+    _existing["integration_branch"] = integration_branch
+    with open(_config_path, "w") as _f:
+        json.dump(_existing, _f, indent=2)
 
     autoscaler_cfg = None
     if autoscaler:
@@ -254,9 +282,7 @@ def colony(
 
             config = FailoverConfig(backup_dest=backup_dest, interval_seconds=backup_interval)
             start_failover_daemon(data_dir, config)
-            click.echo(
-                f"Failover enabled: backing up to {backup_dest} every {backup_interval}s"
-            )
+            click.echo(f"Failover enabled: backing up to {backup_dest} every {backup_interval}s")
 
     uvicorn.run(app, host=host, port=port)
 
@@ -379,7 +405,9 @@ def worker():
 @click.option("--node", required=True, help="Node ID this worker belongs to.")
 @click.option("--repo-path", default=".", show_default=True, help="Path to git repo.")
 @click.option("--integration-branch", default="main", show_default=True, help="Integration branch.")
-@click.option("--capabilities", default=None, help="Comma-separated worker capabilities (e.g. gpu,docker).")  # noqa: E501
+@click.option(
+    "--capabilities", default=None, help="Comma-separated worker capabilities (e.g. gpu,docker)."
+)  # noqa: E501
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def worker_start(
@@ -432,8 +460,12 @@ def worker_start(
 @click.option("--spec", default=None, help="Task specification.")
 @click.option("--depends-on", multiple=True, help="Task IDs this task depends on.")
 @click.option("--touches", default=None, help="Comma-separated scope tags (e.g. api,db).")
-@click.option("--capabilities", default=None, help="Comma-separated capabilities required (e.g. gpu,docker).")  # noqa: E501
-@click.option("--priority", type=int, default=10, show_default=True, help="Priority (lower=higher).")  # noqa: E501
+@click.option(
+    "--capabilities", default=None, help="Comma-separated capabilities required (e.g. gpu,docker)."
+)  # noqa: E501
+@click.option(
+    "--priority", type=int, default=10, show_default=True, help="Priority (lower=higher)."
+)  # noqa: E501
 @click.option(
     "--complexity",
     default="M",
@@ -443,12 +475,19 @@ def worker_start(
 )
 @click.option("--file", "file_path", default=None, help="JSON file with task payload.")
 @click.option("--id", "task_id", default=None, help="Task ID (auto-generated if omitted).")
-@click.option("--type", "task_type", default=None, type=click.Choice(["plan"]),
-              help="Task type: 'plan' for planner decomposition.")
-@click.option("--issue", "issue_number", default=None, type=int,
-              help="GitHub issue number to link.")
-@click.option("--mission", "mission_id", default=None,
-              help="Attach this task to an existing mission.")
+@click.option(
+    "--type",
+    "task_type",
+    default=None,
+    type=click.Choice(["plan"]),
+    help="Task type: 'plan' for planner decomposition.",
+)
+@click.option(
+    "--issue", "issue_number", default=None, type=int, help="GitHub issue number to link."
+)
+@click.option(
+    "--mission", "mission_id", default=None, help="Attach this task to an existing mission."
+)
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def carry(
@@ -479,7 +518,9 @@ def carry(
             "spec": spec,
             "depends_on": list(depends_on),
             "touches": [t.strip() for t in touches.split(",")] if touches else [],
-            "capabilities_required": [c.strip() for c in capabilities.split(",")] if capabilities else [],  # noqa: E501
+            "capabilities_required": [c.strip() for c in capabilities.split(",")]
+            if capabilities
+            else [],  # noqa: E501
             "priority": priority,
             "complexity": complexity,
         }
@@ -638,7 +679,7 @@ def scent(task_id: str, poll_interval: float, colony_url: str, token: str | None
             r.raise_for_status()
             for line in r.iter_lines():
                 if line.startswith("data: "):
-                    raw = line[len("data: "):]
+                    raw = line[len("data: ") :]
                     try:
                         entry = json.loads(raw)
                         ts = entry.get("ts", "")
@@ -687,7 +728,9 @@ def doctor(fix: bool, data_dir: str):
 @click.option("--node", required=True, help="Node ID.")
 @click.option("--agent", required=True, help="Agent type.")
 @click.option("--workspace-root", default=None, help="Workspace root directory.")
-@click.option("--capabilities", default=None, help="Comma-separated worker capabilities (e.g. gpu,docker).")  # noqa: E501
+@click.option(
+    "--capabilities", default=None, help="Comma-separated worker capabilities (e.g. gpu,docker)."
+)  # noqa: E501
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def hatch(
@@ -704,13 +747,18 @@ def hatch(
     ws_root = workspace_root or f".antfarm/workspaces/{worker_name}"
     worker_id = f"{node}/{worker_name}"
     caps = [c.strip() for c in capabilities.split(",")] if capabilities else []
-    result = _post(colony_url, "/workers/register", {
-        "worker_id": worker_id,
-        "node_id": node,
-        "agent_type": agent,
-        "workspace_root": ws_root,
-        "capabilities": caps,
-    }, token=token)
+    result = _post(
+        colony_url,
+        "/workers/register",
+        {
+            "worker_id": worker_id,
+            "node_id": node,
+            "agent_type": agent,
+            "workspace_root": ws_root,
+            "capabilities": caps,
+        },
+        token=token,
+    )
     click.echo(f"Worker registered: {result}")
 
 
@@ -735,10 +783,15 @@ def forage(worker_id: str, colony_url: str, token: str | None):
 @TOKEN_OPTION
 def trail(task_id: str, message: str, worker_id: str, colony_url: str, token: str | None):
     """Append a trail entry to a task (low-level)."""
-    result = _post(colony_url, f"/tasks/{task_id}/trail", {
-        "worker_id": worker_id,
-        "message": message,
-    }, token=token)
+    result = _post(
+        colony_url,
+        f"/tasks/{task_id}/trail",
+        {
+            "worker_id": worker_id,
+            "message": message,
+        },
+        token=token,
+    )
     click.echo(f"Trail appended: {result}")
 
 
@@ -750,7 +803,11 @@ def trail(task_id: str, message: str, worker_id: str, colony_url: str, token: st
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def harvest(
-    task_id: str, pr: str, attempt: str | None, branch: str | None, colony_url: str,
+    task_id: str,
+    pr: str,
+    attempt: str | None,
+    branch: str | None,
+    colony_url: str,
     token: str | None,
 ):
     """Mark a task as harvested (completed) with a PR (low-level)."""
@@ -793,10 +850,15 @@ def release(resource: str, owner: str, colony_url: str, token: str | None):
 @TOKEN_OPTION
 def signal(task_id: str, message: str, worker_id: str, colony_url: str, token: str | None):
     """Send a signal message to a task (low-level)."""
-    result = _post(colony_url, f"/tasks/{task_id}/signal", {
-        "worker_id": worker_id,
-        "message": message,
-    }, token=token)
+    result = _post(
+        colony_url,
+        f"/tasks/{task_id}/signal",
+        {
+            "worker_id": worker_id,
+            "message": message,
+        },
+        token=token,
+    )
     click.echo(f"Signal sent: {result}")
 
 
@@ -1116,17 +1178,14 @@ def mission():
 
 
 @mission.command("create")
-@click.option("--spec", "spec_path", required=True, type=click.Path(exists=True),
-              help="Path to spec file.")
+@click.option(
+    "--spec", "spec_path", required=True, type=click.Path(exists=True), help="Path to spec file."
+)
 @click.option("--mission-id", default=None, help="Optional explicit mission id slug.")
-@click.option("--no-plan-review", is_flag=True, default=False,
-              help="Skip plan review step.")
-@click.option("--max-builders", type=int, default=None,
-              help="Max parallel builder workers.")
-@click.option("--max-attempts", type=int, default=None,
-              help="Max attempts per task.")
-@click.option("--integration-branch", default=None,
-              help="Integration branch for this mission.")
+@click.option("--no-plan-review", is_flag=True, default=False, help="Skip plan review step.")
+@click.option("--max-builders", type=int, default=None, help="Max parallel builder workers.")
+@click.option("--max-attempts", type=int, default=None, help="Max attempts per task.")
+@click.option("--integration-branch", default=None, help="Integration branch for this mission.")
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def mission_create(
@@ -1176,9 +1235,7 @@ def mission_status(mission_id: str, colony_url: str, token: str | None):
     config = data.get("config", {})
     completion_mode = config.get("completion_mode", "best_effort")
     if completion_mode == "all_or_nothing":
-        click.echo(
-            f"Completion: {completion_mode} (treated as best_effort in v0.6.0)"
-        )
+        click.echo(f"Completion: {completion_mode} (treated as best_effort in v0.6.0)")
     else:
         click.echo(f"Completion: {completion_mode}")
 
@@ -1194,8 +1251,14 @@ def mission_status(mission_id: str, colony_url: str, token: str | None):
 
 @mission.command("report")
 @click.argument("mission_id")
-@click.option("--format", "fmt", type=click.Choice(["terminal", "md", "json"]),
-              default="terminal", show_default=True, help="Output format.")
+@click.option(
+    "--format",
+    "fmt",
+    type=click.Choice(["terminal", "md", "json"]),
+    default="terminal",
+    show_default=True,
+    help="Output format.",
+)
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def mission_report(mission_id: str, fmt: str, colony_url: str, token: str | None):
@@ -1373,13 +1436,9 @@ def memory_recompute(data_dir: str):
 @click.option("--port", default=7434, type=int, show_default=True, help="Port to listen on.")
 @click.option("--max-workers", default=4, type=int, show_default=True, help="Max worker processes.")
 @click.option("--agent", default="claude-code", show_default=True, help="Agent type.")
-@click.option(
-    "--integration-branch", default="main", show_default=True, help="Integration branch."
-)
+@click.option("--integration-branch", default="main", show_default=True, help="Integration branch.")
 @click.option("--capabilities", default="", help="Comma-separated: gpu,docker")
-@click.option(
-    "--token", default=None, envvar="ANTFARM_TOKEN", help="Bearer token for colony auth."
-)
+@click.option("--token", default=None, envvar="ANTFARM_TOKEN", help="Bearer token for colony auth.")
 def runner(
     colony_url: str,
     repo_path: str,

--- a/antfarm/core/missions.py
+++ b/antfarm/core/missions.py
@@ -55,13 +55,10 @@ class MissionConfig:
 
     def __post_init__(self) -> None:
         if self.completion_mode not in VALID_COMPLETION_MODES:
-            raise ValueError(
-                f"completion_mode must be one of {VALID_COMPLETION_MODES}"
-            )
+            raise ValueError(f"completion_mode must be one of {VALID_COMPLETION_MODES}")
         if self.blocked_timeout_action not in VALID_BLOCKED_TIMEOUT_ACTIONS:
             raise ValueError(
-                f"blocked_timeout_action must be one of "
-                f"{VALID_BLOCKED_TIMEOUT_ACTIONS}"
+                f"blocked_timeout_action must be one of {VALID_BLOCKED_TIMEOUT_ACTIONS}"
             )
 
     def to_dict(self) -> dict:
@@ -293,6 +290,7 @@ class Mission:
     report: MissionReport | None
     last_progress_at: str
     re_plan_count: int = 0
+    mission_context_path: str | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -311,6 +309,7 @@ class Mission:
             "report": self.report.to_dict() if self.report else None,
             "last_progress_at": self.last_progress_at,
             "re_plan_count": self.re_plan_count,
+            "mission_context_path": self.mission_context_path,
         }
 
     @classmethod
@@ -322,9 +321,7 @@ class Mission:
             status=MissionStatus(data["status"]),
             plan_task_id=data.get("plan_task_id"),
             plan_artifact=(
-                PlanArtifact.from_dict(data["plan_artifact"])
-                if data.get("plan_artifact")
-                else None
+                PlanArtifact.from_dict(data["plan_artifact"]) if data.get("plan_artifact") else None
             ),
             task_ids=list(data.get("task_ids", [])),
             blocked_task_ids=list(data.get("blocked_task_ids", [])),
@@ -332,13 +329,10 @@ class Mission:
             created_at=data["created_at"],
             updated_at=data["updated_at"],
             completed_at=data.get("completed_at"),
-            report=(
-                MissionReport.from_dict(data["report"])
-                if data.get("report")
-                else None
-            ),
+            report=(MissionReport.from_dict(data["report"]) if data.get("report") else None),
             last_progress_at=data.get("last_progress_at", ""),
             re_plan_count=data.get("re_plan_count", 0),
+            mission_context_path=data.get("mission_context_path"),
         )
 
 
@@ -356,11 +350,7 @@ def is_infra_task(task: dict) -> bool:
     MUST use this function — do not reimplement the filter.
     """
     caps = task.get("capabilities_required", [])
-    return (
-        "plan" in caps
-        or "review" in caps
-        or task.get("id", "").startswith("review-")
-    )
+    return "plan" in caps or "review" in caps or task.get("id", "").startswith("review-")
 
 
 # ---------------------------------------------------------------------------
@@ -396,11 +386,13 @@ def link_task_to_mission(
         raise FileNotFoundError(f"mission '{mission_id}' not found")
     if mission["status"] in ("complete", "failed", "cancelled"):
         raise ValueError(
-            f"cannot add tasks to mission '{mission_id}' "
-            f"in terminal state '{mission['status']}'"
+            f"cannot add tasks to mission '{mission_id}' in terminal state '{mission['status']}'"
         )
     task_id = backend.carry(task_dict)
-    backend.update_mission(mission_id, {
-        "task_ids": mission["task_ids"] + [task_id],
-    })
+    backend.update_mission(
+        mission_id,
+        {
+            "task_ids": mission["task_ids"] + [task_id],
+        },
+    )
     return task_id

--- a/antfarm/core/queen.py
+++ b/antfarm/core/queen.py
@@ -49,7 +49,7 @@ class QueenConfig:
     active_interval: float = 10.0
     idle_interval: float = 60.0
     max_re_plans: int = 1
-    enable_mission_context: bool = False
+    enable_mission_context: bool = True
 
 
 class Queen:
@@ -304,9 +304,7 @@ class Queen:
         """Check for unblock (operator ran `antfarm unblock`) or timeout."""
         child_tasks = [self.backend.get_task(tid) for tid in mission["task_ids"]]
         child_tasks = [t for t in child_tasks if t is not None and not is_infra_task(t)]
-        in_flight = [
-            t for t in child_tasks if t["status"] in ("ready", "active", "done")
-        ]
+        in_flight = [t for t in child_tasks if t["status"] in ("ready", "active", "done")]
         if in_flight:
             self._transition(mission, MissionStatus.BUILDING)
             return
@@ -335,21 +333,16 @@ class Queen:
 
     # --- progress detection ---
 
-    def _had_progress_since_last_tick(
-        self, mission: dict, child_tasks: list[dict]
-    ) -> bool:
+    def _had_progress_since_last_tick(self, mission: dict, child_tasks: list[dict]) -> bool:
         """Detect if any child task changed status since last tick.
 
         Uses a hash of all child task statuses + attempt counts. Persists the
         hash on the mission so Queen is stateless between ticks.
         """
         status_snapshot = {
-            t["id"]: f"{t['status']}:{len(t.get('attempts', []))}"
-            for t in child_tasks
+            t["id"]: f"{t['status']}:{len(t.get('attempts', []))}" for t in child_tasks
         }
-        current_hash = hashlib.md5(
-            json.dumps(status_snapshot, sort_keys=True).encode()
-        ).hexdigest()
+        current_hash = hashlib.md5(json.dumps(status_snapshot, sort_keys=True).encode()).hexdigest()
 
         last_hash = mission.get("_last_task_status_hash")
         if last_hash is None or last_hash != current_hash:
@@ -397,17 +390,14 @@ class Queen:
             link_task_to_mission(self.backend, task, mission_id)
         return plan_task_id
 
-    def _create_plan_review_task(
-        self, mission: dict, artifact: PlanArtifact
-    ) -> str:
+    def _create_plan_review_task(self, mission: dict, artifact: PlanArtifact) -> str:
         """Create a review task for the plan. Returns the task ID."""
         mission_id = mission["mission_id"]
         review_task_id = f"review-plan-{mission_id}"
 
         proposed = artifact.proposed_tasks
         task_list = "\n".join(
-            f"  {i + 1}. {t.get('title', t.get('id', '?'))}"
-            for i, t in enumerate(proposed)
+            f"  {i + 1}. {t.get('title', t.get('id', '?'))}" for i, t in enumerate(proposed)
         )
 
         now = _now_iso()
@@ -486,9 +476,7 @@ class Queen:
             link_task_to_mission(self.backend, task, mission_id)
         return re_plan_task_id
 
-    def _spawn_child_tasks(
-        self, mission: dict, artifact: PlanArtifact
-    ) -> list[str]:
+    def _spawn_child_tasks(self, mission: dict, artifact: PlanArtifact) -> list[str]:
         """Create child tasks from the plan artifact. Deterministic IDs."""
         mission_id = mission["mission_id"]
         # Extract slug from mission_id: strip the numeric suffix
@@ -520,9 +508,7 @@ class Queen:
                 "priority": proposed.get("priority", 10),
                 "depends_on": resolved_deps,
                 "touches": proposed.get("touches", []),
-                "capabilities_required": proposed.get(
-                    "capabilities_required", []
-                ),
+                "capabilities_required": proposed.get("capabilities_required", []),
                 "created_by": "queen",
                 "status": "ready",
                 "current_attempt": None,
@@ -645,9 +631,7 @@ class Queen:
 
     # --- mission context ---
 
-    def _maybe_generate_context(
-        self, mission: dict, artifact: PlanArtifact | None = None
-    ) -> None:
+    def _maybe_generate_context(self, mission: dict, artifact: PlanArtifact | None = None) -> None:
         """Generate and store mission context blob if feature-flagged on."""
         if not self.config.enable_mission_context:
             return
@@ -669,9 +653,8 @@ class Queen:
                 mission=mission,
                 plan_artifact=plan_dict,
             )
-            store_mission_context(
-                self._data_dir, mission["mission_id"], context
-            )
+            path = store_mission_context(self._data_dir, mission["mission_id"], context)
+            self.backend.update_mission(mission["mission_id"], {"mission_context_path": path})
             logger.info(
                 "queen: stored mission context for %s (%d bytes)",
                 mission["mission_id"],
@@ -712,9 +695,7 @@ class Queen:
             MissionStatus.FAILED,
             extras={"completed_at": _now_iso(), "failure_reason": reason},
         )
-        logger.error(
-            "queen: mission %s FAILED: %s", mission["mission_id"], reason
-        )
+        logger.error("queen: mission %s FAILED: %s", mission["mission_id"], reason)
 
     # --- adaptive polling ---
 
@@ -736,10 +717,7 @@ class Queen:
     @staticmethod
     def _has_merged_attempt(task: dict) -> bool:
         """Return True if the task has at least one attempt with status MERGED."""
-        return any(
-            attempt.get("status") == "merged"
-            for attempt in task.get("attempts", [])
-        )
+        return any(attempt.get("status") == "merged" for attempt in task.get("attempts", []))
 
     @staticmethod
     def _get_current_artifact(task: dict) -> dict | None:

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -52,13 +52,15 @@ def _emit_event(event_type: str, task_id: str, detail: str = "") -> None:
     """Append an event to the SSE event bus."""
     global _event_counter
     _event_counter += 1
-    _event_queue.append({
-        "id": _event_counter,
-        "type": event_type,
-        "task_id": task_id,
-        "detail": detail,
-        "ts": _now_iso(),
-    })
+    _event_queue.append(
+        {
+            "id": _event_counter,
+            "type": event_type,
+            "task_id": task_id,
+            "detail": detail,
+            "ts": _now_iso(),
+        }
+    )
 
 
 def _start_soldier_thread(backend: TaskBackend, data_dir: str) -> None:
@@ -95,9 +97,7 @@ _doctor_thread: threading.Thread | None = None
 _doctor_status: str = "not started"
 
 
-def _start_doctor_thread(
-    backend: TaskBackend, data_dir: str, interval: float = 300.0
-) -> None:
+def _start_doctor_thread(backend: TaskBackend, data_dir: str, interval: float = 300.0) -> None:
     """Start the Doctor as a daemon thread (singleton guard)."""
     global _doctor_thread, _doctor_status
 
@@ -132,13 +132,16 @@ def _start_doctor_thread(
         except Exception as e:
             _doctor_status = f"error: {e}"
 
-    _doctor_thread = threading.Thread(
-        target=_doctor_loop, daemon=True, name="doctor"
-    )
+    _doctor_thread = threading.Thread(target=_doctor_loop, daemon=True, name="doctor")
     _doctor_thread.start()
 
 
-def _start_queen_thread(backend: TaskBackend) -> None:
+def _start_queen_thread(
+    backend: TaskBackend,
+    data_dir: str = ".antfarm",
+    repo_path: str = ".",
+    integration_branch: str = "main",
+) -> None:
     """Start the Queen as a daemon thread (singleton guard)."""
     global _queen_thread, _queen_status
 
@@ -147,7 +150,12 @@ def _start_queen_thread(backend: TaskBackend) -> None:
 
     from antfarm.core.queen import Queen
 
-    queen = Queen(backend)
+    queen = Queen(
+        backend,
+        data_dir=data_dir,
+        repo_path=repo_path,
+        integration_branch=integration_branch,
+    )
 
     def _queen_loop():
         global _queen_status
@@ -158,9 +166,7 @@ def _start_queen_thread(backend: TaskBackend) -> None:
             _queen_status = f"error: {e}"
             logger.error("queen thread crashed: %s", e)
 
-    _queen_thread = threading.Thread(
-        target=_queen_loop, daemon=True, name="queen"
-    )
+    _queen_thread = threading.Thread(target=_queen_loop, daemon=True, name="queen")
     _queen_thread.start()
 
 
@@ -194,9 +200,7 @@ def _start_autoscaler_thread(
             _autoscaler_status = f"error: {e}"
             logger.error("autoscaler thread crashed: %s", e)
 
-    _autoscaler_thread = threading.Thread(
-        target=_autoscaler_loop, daemon=True, name="autoscaler"
-    )
+    _autoscaler_thread = threading.Thread(target=_autoscaler_loop, daemon=True, name="autoscaler")
     _autoscaler_thread.start()
 
 
@@ -359,12 +363,16 @@ def get_app(
         _backend = FileBackend(root=data_dir)
 
     # Load max_attempts default from config
+    repo_path = "."
+    integration_branch = "main"
     config_path = os.path.join(data_dir, "config.json")
     if os.path.exists(config_path):
         try:
             with open(config_path) as f:
                 cfg = json.load(f)
             _max_attempts = cfg.get("max_attempts", 3)
+            repo_path = cfg.get("repo_path", repo_path)
+            integration_branch = cfg.get("integration_branch", integration_branch)
         except (json.JSONDecodeError, OSError):
             pass
 
@@ -387,7 +395,12 @@ def get_app(
         if isinstance(_backend, GitHubBackend):
             logger.info("queen: skipping — GitHubBackend not supported in v0.6.0")
         else:
-            _start_queen_thread(_backend)
+            _start_queen_thread(
+                _backend,
+                data_dir=data_dir,
+                repo_path=repo_path,
+                integration_branch=integration_branch,
+            )
 
     if autoscaler_config is not None and autoscaler_config.enabled:
         _start_autoscaler_thread(_backend, autoscaler_config)
@@ -599,15 +612,9 @@ def get_app(
     @app.post("/tasks/{task_id}/kickback", status_code=200)
     def kickback_task(task_id: str, req: KickbackRequest):
         """Return a task to ready (or blocked if max attempts exhausted)."""
-        effective = (
-            req.max_attempts
-            if req.max_attempts is not None
-            else _max_attempts
-        )
+        effective = req.max_attempts if req.max_attempts is not None else _max_attempts
         try:
-            _backend.kickback(
-                task_id, req.reason, max_attempts=effective
-            )
+            _backend.kickback(task_id, req.reason, max_attempts=effective)
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
         _emit_event("kickback", task_id, req.reason)
@@ -848,9 +855,7 @@ def get_app(
         """Get a mission by ID. Returns 404 if not found."""
         mission = _backend.get_mission(mission_id)
         if mission is None:
-            raise HTTPException(
-                status_code=404, detail=f"Mission '{mission_id}' not found"
-            )
+            raise HTTPException(status_code=404, detail=f"Mission '{mission_id}' not found")
         return mission
 
     @app.patch("/missions/{mission_id}", status_code=200)
@@ -867,9 +872,7 @@ def get_app(
         """Cancel a mission. Idempotent for terminal states."""
         mission = _backend.get_mission(mission_id)
         if mission is None:
-            raise HTTPException(
-                status_code=404, detail=f"Mission '{mission_id}' not found"
-            )
+            raise HTTPException(status_code=404, detail=f"Mission '{mission_id}' not found")
         terminal = {"complete", "failed", "cancelled"}
         if mission["status"] in terminal:
             return {"ok": True}
@@ -892,14 +895,10 @@ def get_app(
         """Return mission report or 404 if not yet generated."""
         mission = _backend.get_mission(mission_id)
         if mission is None:
-            raise HTTPException(
-                status_code=404, detail=f"Mission '{mission_id}' not found"
-            )
+            raise HTTPException(status_code=404, detail=f"Mission '{mission_id}' not found")
         report = mission.get("report")
         if report is None:
-            raise HTTPException(
-                status_code=404, detail=f"No report for mission '{mission_id}'"
-            )
+            raise HTTPException(status_code=404, detail=f"No report for mission '{mission_id}'")
         return report
 
     # ------------------------------------------------------------------

--- a/tests/test_mission_context.py
+++ b/tests/test_mission_context.py
@@ -186,7 +186,9 @@ def test_worker_prepends_context(tmp_path):
                 params=dict(request.url.params),
             )
             return httpx.Response(
-                resp.status_code, headers=dict(resp.headers), content=resp.content,
+                resp.status_code,
+                headers=dict(resp.headers),
+                content=resp.content,
             )
 
     http_client = httpx.Client(transport=_Transport(app), base_url="http://test")
@@ -205,16 +207,22 @@ def test_worker_prepends_context(tmp_path):
 
     # Create mission first, then carry a builder task linked to it
     tc = TestClient(app)
-    tc.post("/missions", json={
-        "mission_id": "mission-test-1",
-        "spec": "Build auth module",
-    })
-    tc.post("/tasks", json={
-        "id": "task-build-01",
-        "title": "Build auth",
-        "spec": "implement auth module",
-        "mission_id": "mission-test-1",
-    })
+    tc.post(
+        "/missions",
+        json={
+            "mission_id": "mission-test-1",
+            "spec": "Build auth module",
+        },
+    )
+    tc.post(
+        "/tasks",
+        json={
+            "id": "task-build-01",
+            "title": "Build auth",
+            "spec": "implement auth module",
+            "mission_id": "mission-test-1",
+        },
+    )
 
     captured_prompts: list[str] = []
 
@@ -236,6 +244,7 @@ def test_worker_prepends_context(tmp_path):
     rt._launch_agent = capturing_launch
 
     import antfarm.core.worker as worker_mod
+
     original_sleep = worker_mod.time.sleep
     worker_mod.time.sleep = lambda _s: None
     try:
@@ -281,7 +290,9 @@ def test_worker_skips_context_for_planner(tmp_path):
                 params=dict(request.url.params),
             )
             return httpx.Response(
-                resp.status_code, headers=dict(resp.headers), content=resp.content,
+                resp.status_code,
+                headers=dict(resp.headers),
+                content=resp.content,
             )
 
     http_client = httpx.Client(transport=_Transport(app), base_url="http://test")
@@ -301,17 +312,23 @@ def test_worker_skips_context_for_planner(tmp_path):
 
     # Create mission first, then carry a plan task
     tc = TestClient(app)
-    tc.post("/missions", json={
-        "mission_id": "mission-test-2",
-        "spec": "decompose the spec",
-    })
-    tc.post("/tasks", json={
-        "id": "plan-test-2",
-        "title": "Plan mission",
-        "spec": "decompose the spec",
-        "capabilities_required": ["plan"],
-        "mission_id": "mission-test-2",
-    })
+    tc.post(
+        "/missions",
+        json={
+            "mission_id": "mission-test-2",
+            "spec": "decompose the spec",
+        },
+    )
+    tc.post(
+        "/tasks",
+        json={
+            "id": "plan-test-2",
+            "title": "Plan mission",
+            "spec": "decompose the spec",
+            "capabilities_required": ["plan"],
+            "mission_id": "mission-test-2",
+        },
+    )
 
     context_was_fetched = []
 
@@ -329,6 +346,7 @@ def test_worker_skips_context_for_planner(tmp_path):
     rt._launch_agent = mock_launch
 
     import antfarm.core.worker as worker_mod
+
     worker_mod.time.sleep = lambda _s: None
     try:
         rt.run()
@@ -345,10 +363,10 @@ def test_worker_skips_context_for_planner(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_context_disabled_by_default():
-    """QueenConfig.enable_mission_context is False by default."""
+def test_context_enabled_by_default():
+    """QueenConfig.enable_mission_context is True by default (v0.6.1+)."""
     config = QueenConfig()
-    assert config.enable_mission_context is False
+    assert config.enable_mission_context is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_queen.py
+++ b/tests/test_queen.py
@@ -129,14 +129,16 @@ def _make_plan_artifact(
     """Create a PlanArtifact with N proposed tasks."""
     proposed = []
     for i in range(task_count):
-        proposed.append({
-            "title": f"Child task {i + 1}",
-            "spec": f"Implement part {i + 1}",
-            "touches": ["api"],
-            "depends_on": [],
-            "priority": 10,
-            "complexity": "M",
-        })
+        proposed.append(
+            {
+                "title": f"Child task {i + 1}",
+                "spec": f"Implement part {i + 1}",
+                "touches": ["api"],
+                "depends_on": [],
+                "priority": 10,
+                "complexity": "M",
+            }
+        )
     return PlanArtifact(
         plan_task_id=plan_task_id,
         attempt_id=attempt_id,
@@ -278,9 +280,7 @@ def test_queen_planning_harvested_no_review_spawns_children(env):
     backend = env["backend"]
     queen = env["queen"]
 
-    mission = _create_mission(
-        backend, config_overrides={"require_plan_review": False}
-    )
+    mission = _create_mission(backend, config_overrides={"require_plan_review": False})
     m = backend.get_mission(mission["mission_id"])
 
     # Create and harvest plan task
@@ -347,10 +347,7 @@ def test_queen_planning_plan_task_blocked_fails_mission(env):
     # Simulate plan task being blocked (max attempts exhausted)
     plan_task = backend.get_task(m["plan_task_id"])
     plan_task["status"] = "blocked"
-    plan_task["attempts"] = [
-        {"attempt_id": f"att-{i}", "status": "superseded"}
-        for i in range(3)
-    ]
+    plan_task["attempts"] = [{"attempt_id": f"att-{i}", "status": "superseded"} for i in range(3)]
     _force_task_state(backend, m["plan_task_id"], plan_task)
 
     m = backend.get_mission(mission["mission_id"])
@@ -402,10 +399,7 @@ def test_queen_planning_invalid_artifact_defers_to_kickback(env):
 
     # Check trail entry was appended
     plan_task = backend.get_task(m["plan_task_id"])
-    assert any(
-        "awaiting kickback" in e.get("message", "")
-        for e in plan_task.get("trail", [])
-    )
+    assert any("awaiting kickback" in e.get("message", "") for e in plan_task.get("trail", []))
 
 
 # ---------------------------------------------------------------------------
@@ -465,8 +459,7 @@ def test_queen_review_task_blocked_fails_with_system_prefix(env):
     review_task = backend.get_task(review_task_id)
     review_task["status"] = "blocked"
     review_task["attempts"] = [
-        {"attempt_id": f"att-r{i}", "status": "superseded"}
-        for i in range(3)
+        {"attempt_id": f"att-r{i}", "status": "superseded"} for i in range(3)
     ]
     _force_task_state(backend, review_task_id, review_task)
 
@@ -646,9 +639,7 @@ def test_queen_building_all_merged_completes(env):
     backend = env["backend"]
     queen = env["queen"]
 
-    mission = _create_mission(
-        backend, config_overrides={"require_plan_review": False}
-    )
+    mission = _create_mission(backend, config_overrides={"require_plan_review": False})
     m = backend.get_mission(mission["mission_id"])
 
     # Get to BUILDING state
@@ -707,9 +698,7 @@ def test_queen_building_mixed_merged_blocked_completes(env):
     backend = env["backend"]
     queen = env["queen"]
 
-    mission = _create_mission(
-        backend, config_overrides={"require_plan_review": False}
-    )
+    mission = _create_mission(backend, config_overrides={"require_plan_review": False})
     m = backend.get_mission(mission["mission_id"])
 
     queen._advance(m)
@@ -728,8 +717,15 @@ def test_queen_building_mixed_merged_blocked_completes(env):
     child1["status"] = "done"
     child1["current_attempt"] = "att-c0"
     child1["attempts"] = [
-        {"attempt_id": "att-c0", "status": "merged", "branch": "b", "pr": "p",
-         "started_at": _now_iso(), "completed_at": _now_iso(), "worker_id": "w"}
+        {
+            "attempt_id": "att-c0",
+            "status": "merged",
+            "branch": "b",
+            "pr": "p",
+            "started_at": _now_iso(),
+            "completed_at": _now_iso(),
+            "worker_id": "w",
+        }
     ]
     _force_task_state(backend, child1_id, child1)
 
@@ -739,8 +735,13 @@ def test_queen_building_mixed_merged_blocked_completes(env):
     child2["status"] = "blocked"
     child2["blocked_reason"] = "max attempts exhausted"
     child2["attempts"] = [
-        {"attempt_id": "att-c1", "status": "superseded",
-         "started_at": _now_iso(), "completed_at": _now_iso(), "worker_id": "w"}
+        {
+            "attempt_id": "att-c1",
+            "status": "superseded",
+            "started_at": _now_iso(),
+            "completed_at": _now_iso(),
+            "worker_id": "w",
+        }
     ]
     _force_task_state(backend, child2_id, child2)
 
@@ -761,9 +762,7 @@ def test_queen_building_some_in_flight_stays_building(env):
     backend = env["backend"]
     queen = env["queen"]
 
-    mission = _create_mission(
-        backend, config_overrides={"require_plan_review": False}
-    )
+    mission = _create_mission(backend, config_overrides={"require_plan_review": False})
     m = backend.get_mission(mission["mission_id"])
 
     queen._advance(m)
@@ -1027,8 +1026,15 @@ def test_queen_all_or_nothing_treated_as_best_effort(env):
     child1["status"] = "done"
     child1["current_attempt"] = "att-c0"
     child1["attempts"] = [
-        {"attempt_id": "att-c0", "status": "merged", "branch": "b", "pr": "p",
-         "started_at": _now_iso(), "completed_at": _now_iso(), "worker_id": "w"}
+        {
+            "attempt_id": "att-c0",
+            "status": "merged",
+            "branch": "b",
+            "pr": "p",
+            "started_at": _now_iso(),
+            "completed_at": _now_iso(),
+            "worker_id": "w",
+        }
     ]
     _force_task_state(backend, child1_id, child1)
 
@@ -1045,3 +1051,194 @@ def test_queen_all_or_nothing_treated_as_best_effort(env):
     m = backend.get_mission(mission["mission_id"])
     # all_or_nothing treated as best_effort in v0.6.0
     assert m["status"] == "complete"
+
+
+# ---------------------------------------------------------------------------
+# Mission context blob generation (issue #219)
+# ---------------------------------------------------------------------------
+
+
+def _make_queen_with_data_dir(backend, tmp_path, subdir: str = ".antfarm"):
+    """Build a Queen wired to a specific data_dir / repo_path for context tests."""
+    data_dir = str(tmp_path / subdir)
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir(exist_ok=True)
+    queen = Queen(
+        backend,
+        config=QueenConfig(),
+        data_dir=data_dir,
+        repo_path=str(repo_dir),
+        integration_branch="main",
+    )
+    return queen, data_dir
+
+
+def test_queen_writes_context_on_transition_to_building(env, tmp_path):
+    """When Queen flips a mission to BUILDING (no plan review), context is written."""
+    backend = env["backend"]
+    queen, data_dir = _make_queen_with_data_dir(backend, tmp_path)
+
+    mission = _create_mission(
+        backend,
+        config_overrides={"require_plan_review": False},
+    )
+    m = backend.get_mission(mission["mission_id"])
+
+    queen._advance(m)  # create plan task
+    m = backend.get_mission(mission["mission_id"])
+    artifact = _make_plan_artifact(plan_task_id=m["plan_task_id"])
+    _harvest_plan_task_with_artifact(backend, m["plan_task_id"], artifact)
+
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)  # transition to BUILDING, should write context
+
+    m = backend.get_mission(mission["mission_id"])
+    assert m["status"] == "building"
+
+    import os as _os
+
+    context_path = _os.path.join(data_dir, "missions", f"{mission['mission_id']}_context.md")
+    assert _os.path.isfile(context_path)
+    with open(context_path) as f:
+        body = f.read()
+    assert "Mission Context" in body
+
+
+def test_queen_writes_context_after_plan_review_pass(env, tmp_path):
+    """Review verdict=pass path writes the mission context blob."""
+    backend = env["backend"]
+    queen, data_dir = _make_queen_with_data_dir(backend, tmp_path)
+
+    mission = _create_mission(backend)
+    m = backend.get_mission(mission["mission_id"])
+
+    queen._advance(m)
+    m = backend.get_mission(mission["mission_id"])
+    artifact = _make_plan_artifact(plan_task_id=m["plan_task_id"])
+    _harvest_plan_task_with_artifact(backend, m["plan_task_id"], artifact)
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)  # to REVIEWING_PLAN
+
+    review_task_id = f"review-plan-{mission['mission_id']}"
+    _set_review_verdict_on_task(backend, review_task_id, _make_review_verdict("pass"))
+
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)  # review=pass → BUILDING
+
+    m = backend.get_mission(mission["mission_id"])
+    assert m["status"] == "building"
+
+    import os as _os
+
+    context_path = _os.path.join(data_dir, "missions", f"{mission['mission_id']}_context.md")
+    assert _os.path.isfile(context_path)
+
+
+def test_queen_writes_context_on_re_plan(env, tmp_path):
+    """After needs_changes → re-plan → PASS, context is (re)written."""
+    backend = env["backend"]
+    queen, data_dir = _make_queen_with_data_dir(backend, tmp_path)
+
+    mission = _create_mission(backend)
+    m = backend.get_mission(mission["mission_id"])
+
+    # Cycle 1: plan → review → needs_changes → re-plan
+    queen._advance(m)
+    m = backend.get_mission(mission["mission_id"])
+    artifact1 = _make_plan_artifact(plan_task_id=m["plan_task_id"])
+    _harvest_plan_task_with_artifact(backend, m["plan_task_id"], artifact1)
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)  # → REVIEWING_PLAN
+
+    review_task_id = f"review-plan-{mission['mission_id']}"
+    _set_review_verdict_on_task(
+        backend, review_task_id, _make_review_verdict("needs_changes", "fix it")
+    )
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)  # → PLANNING (re-plan)
+    m = backend.get_mission(mission["mission_id"])
+    assert m["status"] == "planning"
+    assert m["re_plan_count"] == 1
+
+    # Cycle 2: new plan completes, no-review path to BUILDING — flip
+    # require_plan_review so re-plan path has a simpler terminal transition.
+    # We harvest the re-plan task with a fresh artifact.
+    queen._advance(m)  # creates re-plan task
+    m = backend.get_mission(mission["mission_id"])
+    new_plan_task_id = m["plan_task_id"]
+    artifact2 = _make_plan_artifact(plan_task_id=new_plan_task_id, task_count=3)
+    _harvest_plan_task_with_artifact(backend, new_plan_task_id, artifact2)
+
+    # For the re-plan, require_plan_review defaults stay True, so go through
+    # reviewing again and mark pass.
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)  # → REVIEWING_PLAN
+    review_task_id2 = f"review-plan-{mission['mission_id']}"
+    # Reset review verdict with pass
+    _set_review_verdict_on_task(backend, review_task_id2, _make_review_verdict("pass"))
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)  # → BUILDING, writes context
+
+    m = backend.get_mission(mission["mission_id"])
+    assert m["status"] == "building"
+
+    import os as _os
+
+    context_path = _os.path.join(data_dir, "missions", f"{mission['mission_id']}_context.md")
+    assert _os.path.isfile(context_path)
+
+
+def test_queen_populates_mission_context_path(env, tmp_path):
+    """After writing context, mission.mission_context_path points to on-disk file."""
+    backend = env["backend"]
+    queen, data_dir = _make_queen_with_data_dir(backend, tmp_path)
+
+    mission = _create_mission(
+        backend,
+        config_overrides={"require_plan_review": False},
+    )
+    m = backend.get_mission(mission["mission_id"])
+
+    queen._advance(m)
+    m = backend.get_mission(mission["mission_id"])
+    artifact = _make_plan_artifact(plan_task_id=m["plan_task_id"])
+    _harvest_plan_task_with_artifact(backend, m["plan_task_id"], artifact)
+
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)
+
+    m = backend.get_mission(mission["mission_id"])
+    assert m.get("mission_context_path") is not None
+
+    import os as _os
+
+    assert _os.path.isfile(m["mission_context_path"])
+    # Must be under the configured data_dir, not the cwd
+    assert m["mission_context_path"].startswith(data_dir)
+
+
+def test_queen_context_written_in_correct_data_dir(env, tmp_path):
+    """Context file lands under configured data_dir, not ./.antfarm (cwd-relative)."""
+    backend = env["backend"]
+    queen, data_dir = _make_queen_with_data_dir(backend, tmp_path, subdir=".custom")
+
+    mission = _create_mission(
+        backend,
+        mission_id="mission-dirpath-001",
+        config_overrides={"require_plan_review": False},
+    )
+    m = backend.get_mission(mission["mission_id"])
+
+    queen._advance(m)
+    m = backend.get_mission(mission["mission_id"])
+    artifact = _make_plan_artifact(plan_task_id=m["plan_task_id"])
+    _harvest_plan_task_with_artifact(backend, m["plan_task_id"], artifact)
+
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)
+
+    import os as _os
+
+    # The context file must exist under the custom data_dir
+    expected = _os.path.join(data_dir, "missions", f"{mission['mission_id']}_context.md")
+    assert _os.path.isfile(expected)


### PR DESCRIPTION
## Summary

Two bugs prevented the Queen from ever writing the `mission_context` blob, so `GET /missions/{id}/context` always returned 404:

1. **Flag gated off.** `QueenConfig.enable_mission_context` defaulted to `False`, so `_maybe_generate_context()` short-circuited on every call. The call sites at `queen.py:186` and `queen.py:236` were correct but never executed. v0.6.1 already shipped the runner + autoscaler that satisfy the SPEC's gating condition, so the default now flips to `True`.
2. **Data dir not threaded.** `serve.py` constructed `Queen(backend)` with defaults, so even if the flag were on, the file would have landed in cwd-relative `./.antfarm/missions/` instead of the colony's configured `data_dir`. `serve.py` now reads `repo_path` and `integration_branch` from `config.json` (alongside the existing `max_attempts`) and passes them plus `data_dir` into the Queen.

Also:
- Persist the on-disk path to the mission record via a new `mission_context_path` field so callers don't have to guess the path.
- Add `mission_context_path` to the `Mission` dataclass (`to_dict` / `from_dict`).
- Add `--repo-path` / `--integration-branch` options to `antfarm colony` and write them into `.antfarm/config.json` so the Queen picks them up.

## Test plan

- [x] `ruff check .` clean
- [x] `pytest tests/ -x -q` all green (868 passed)
- [x] New tests in `tests/test_queen.py`:
  - [x] `test_queen_writes_context_on_transition_to_building` — no-review path writes the blob
  - [x] `test_queen_writes_context_after_plan_review_pass` — review=pass path writes the blob
  - [x] `test_queen_writes_context_on_re_plan` — re-plan cycle rewrites the blob
  - [x] `test_queen_populates_mission_context_path` — `mission.mission_context_path` points to the file
  - [x] `test_queen_context_written_in_correct_data_dir` — file lands under configured `data_dir`, not cwd
- [x] Updated `test_context_disabled_by_default` → `test_context_enabled_by_default` to match the flipped default
- [x] Existing `test_context_api_endpoint` still passes (endpoint returns the blob once written)

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)