### PR TITLE
fix(backend): close superseded-attempt PRs on kickback/rereview/resume/reassign (#222)

### DIFF
--- a/antfarm/core/backends/base.py
+++ b/antfarm/core/backends/base.py
@@ -4,6 +4,15 @@ Defines the TaskBackend interface with explicit mutation methods.
 No generic update(**fields) — each method enforces a valid state transition.
 
 Backend implementations: FileBackend (v0.1), PostgresBackend (v0.2+).
+
+Superseded-PR hygiene:
+    Whenever an implementation transitions an attempt to SUPERSEDED
+    (``kickback``, ``rereview``, ``resume_task``, ``reassign_task``), it
+    SHOULD close the PR associated with that attempt so duplicate PRs do
+    not accumulate. PR close MUST happen outside any internal lock — a
+    subprocess call inside a backend lock would stall every other worker
+    for its duration. Implementations typically delegate to
+    ``antfarm.core.pr_ops.PROps`` injected at construction time.
 """
 
 from abc import ABC, abstractmethod

--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -18,6 +18,7 @@ Scheduling is delegated entirely to scheduler.select_task().
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
@@ -34,6 +35,7 @@ from antfarm.core.models import (
     TaskStatus,
     TrailEntry,
 )
+from antfarm.core.pr_ops import NullPROps, PROps
 from antfarm.core.rate_limiter import is_worker_rate_limited
 from antfarm.core.scheduler import select_task
 
@@ -53,13 +55,38 @@ class FileBackend(TaskBackend):
     Args:
         root: Path to the .antfarm directory. Created if it doesn't exist.
         guard_ttl: Seconds before a guard is considered stale (default 300).
+        pr_ops: Optional PROps implementation used to close superseded PRs when
+            an attempt transitions to SUPERSEDED. Defaults to NullPROps (no-op)
+            so tests and environments without ``gh`` are unaffected.
     """
 
-    def __init__(self, root: str | Path, guard_ttl: int = _GUARD_TTL_SECONDS) -> None:
+    def __init__(
+        self,
+        root: str | Path,
+        guard_ttl: int = _GUARD_TTL_SECONDS,
+        pr_ops: PROps | None = None,
+    ) -> None:
         self._root = Path(root)
         self._guard_ttl = guard_ttl
         self._lock = threading.Lock()
+        self._pr_ops: PROps = pr_ops or NullPROps()
         self._init_dirs()
+
+    def _close_superseded_pr(self, attempt: dict | None, reason: str) -> None:
+        """Close the PR on a superseded attempt, outside any backend lock.
+
+        Must be invoked AFTER releasing ``self._lock`` — PR close shells out to
+        ``gh`` and could otherwise block every other worker for the subprocess
+        duration.
+        """
+        if not attempt:
+            return
+        pr = attempt.get("pr")
+        if not pr:
+            return
+        # Never let PR close break a state transition — swallow any error.
+        with contextlib.suppress(Exception):
+            self._pr_ops.close_pr(pr, comment=f"Superseded by antfarm: {reason}")
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -356,6 +383,7 @@ class FileBackend(TaskBackend):
         to BLOCKED instead of READY. Per-task ``max_attempts`` overrides the
         function parameter.
         """
+        superseded_attempt: dict | None = None
         with self._lock:
             done_path = self._done_path(task_id)
             if not done_path.exists():
@@ -371,6 +399,7 @@ class FileBackend(TaskBackend):
                     a["status"] = AttemptStatus.SUPERSEDED.value
                     a["completed_at"] = now
                     worker_id = a.get("worker_id") or "system"
+                    superseded_attempt = dict(a)
                     break
 
             # Add failure trail entry
@@ -408,6 +437,10 @@ class FileBackend(TaskBackend):
                 data["status"] = TaskStatus.READY.value
                 self._write_json(done_path, data)
                 os.rename(done_path, self._ready_path(task_id))
+
+        # Close the superseded PR OUTSIDE the lock — gh subprocess would otherwise
+        # stall every other worker for its duration.
+        self._close_superseded_pr(superseded_attempt, reason)
 
     def mark_harvest_pending(self, task_id: str, attempt_id: str) -> None:
         """Transition task from ACTIVE to HARVEST_PENDING.
@@ -489,6 +522,7 @@ class FileBackend(TaskBackend):
         updates spec + touches, appends a trail entry, and moves the file
         back into ready/ (unless it is already there).
         """
+        superseded_attempt: dict | None = None
         with self._lock:
             path = self._find_task_path(review_task_id)
             if path is None:
@@ -506,6 +540,7 @@ class FileBackend(TaskBackend):
                         if a.get("status") != AttemptStatus.SUPERSEDED.value:
                             a["status"] = AttemptStatus.SUPERSEDED.value
                             a["completed_at"] = now
+                            superseded_attempt = dict(a)
                         break
                 data["current_attempt"] = None
 
@@ -531,6 +566,12 @@ class FileBackend(TaskBackend):
             self._write_json(path, data)
             if path != ready_path:
                 os.rename(path, ready_path)
+
+        # Close the superseded PR OUTSIDE the lock.
+        self._close_superseded_pr(
+            superseded_attempt,
+            "re-review triggered by new parent attempt",
+        )
 
     def override_merge_order(self, task_id: str, position: int) -> None:
         """Set merge_override on a task in done/."""
@@ -577,6 +618,7 @@ class FileBackend(TaskBackend):
 
         Supersedes the current attempt so the task re-enters the queue cleanly.
         """
+        superseded_attempt: dict | None = None
         with self._lock:
             paused_path = self._paused_path(task_id)
             if not paused_path.exists():
@@ -595,6 +637,7 @@ class FileBackend(TaskBackend):
                     if a["attempt_id"] == current_attempt_id:
                         a["status"] = AttemptStatus.SUPERSEDED.value
                         a["completed_at"] = now
+                        superseded_attempt = dict(a)
                         break
                 data["current_attempt"] = None
 
@@ -604,8 +647,12 @@ class FileBackend(TaskBackend):
             self._write_json(paused_path, data)
             os.rename(paused_path, self._ready_path(task_id))
 
+        # Close the superseded PR OUTSIDE the lock.
+        self._close_superseded_pr(superseded_attempt, "task resumed from paused")
+
     def reassign_task(self, task_id: str, worker_id: str) -> None:
         """Reassign an active task. Supersedes current attempt, returns to ready/."""
+        superseded_attempt: dict | None = None
         with self._lock:
             active_path = self._active_path(task_id)
             if not active_path.exists():
@@ -623,6 +670,7 @@ class FileBackend(TaskBackend):
                     if a["attempt_id"] == current_attempt_id:
                         a["status"] = AttemptStatus.SUPERSEDED.value
                         a["completed_at"] = now
+                        superseded_attempt = dict(a)
                         break
 
             trail_entry = TrailEntry(
@@ -640,6 +688,9 @@ class FileBackend(TaskBackend):
 
             self._write_json(active_path, data)
             os.rename(active_path, self._ready_path(task_id))
+
+        # Close the superseded PR OUTSIDE the lock.
+        self._close_superseded_pr(superseded_attempt, f"task reassigned to {worker_id}")
 
     def block_task(self, task_id: str, reason: str) -> None:
         """Block a ready task. Moves from ready/ to blocked/."""

--- a/antfarm/core/backends/github.py
+++ b/antfarm/core/backends/github.py
@@ -21,6 +21,7 @@ GitHub's Link header rel="next" pattern.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import threading
 import uuid
@@ -35,6 +36,7 @@ from antfarm.core.models import (
     TaskStatus,
     TrailEntry,
 )
+from antfarm.core.pr_ops import NullPROps, PROps
 
 from .base import TaskBackend
 
@@ -107,11 +109,13 @@ class GitHubBackend(TaskBackend):
         repo: str,
         token: str | None = None,
         label_prefix: str = "antfarm:",
+        pr_ops: PROps | None = None,
     ) -> None:
         self._repo = repo
         self._token = token
         self._prefix = label_prefix
         self._lock = threading.Lock()
+        self._pr_ops: PROps = pr_ops or NullPROps()
 
         # In-memory stores for ephemeral state
         self._workers: dict[str, dict] = {}
@@ -122,6 +126,17 @@ class GitHubBackend(TaskBackend):
             headers=self._default_headers(),
             timeout=30.0,
         )
+
+    def _close_superseded_pr(self, attempt: dict | None, reason: str) -> None:
+        """Close the PR on a superseded attempt. Never raises."""
+        if not attempt:
+            return
+        pr = attempt.get("pr")
+        if not pr:
+            return
+        # Never let PR close break a state transition — swallow any error.
+        with contextlib.suppress(Exception):
+            self._pr_ops.close_pr(pr, comment=f"Superseded by antfarm: {reason}")
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -541,11 +556,13 @@ class GitHubBackend(TaskBackend):
         now = _now_iso()
         current_attempt_id = task.get("current_attempt")
         worker_id = "system"
+        superseded_attempt: dict | None = None
         for a in task["attempts"]:
             if a["attempt_id"] == current_attempt_id:
                 a["status"] = AttemptStatus.SUPERSEDED.value
                 a["completed_at"] = now
                 worker_id = a.get("worker_id") or "system"
+                superseded_attempt = dict(a)
                 break
 
         trail_entry = TrailEntry(ts=now, worker_id=worker_id, message=reason)
@@ -559,6 +576,8 @@ class GitHubBackend(TaskBackend):
         self._ensure_label(ready_label)
         self._swap_labels(issue_number, ["done"], "ready")
         self._add_comment(issue_number, f"[kickback] {reason}")
+
+        self._close_superseded_pr(superseded_attempt, reason)
 
     def mark_harvest_pending(self, task_id: str, attempt_id: str) -> None:
         """Mark task as harvest_pending. Updates status in issue body."""
@@ -648,11 +667,13 @@ class GitHubBackend(TaskBackend):
 
         now = _now_iso()
         current_attempt_id = task.get("current_attempt")
+        superseded_attempt: dict | None = None
         if current_attempt_id:
             for a in task["attempts"]:
                 if a["attempt_id"] == current_attempt_id:
                     a["status"] = AttemptStatus.SUPERSEDED.value
                     a["completed_at"] = now
+                    superseded_attempt = dict(a)
                     break
             task["current_attempt"] = None
 
@@ -664,6 +685,8 @@ class GitHubBackend(TaskBackend):
         self._ensure_label(ready_label)
         self._swap_labels(issue_number, ["paused"], "ready")
 
+        self._close_superseded_pr(superseded_attempt, "task resumed from paused")
+
     def reassign_task(self, task_id: str, worker_id: str) -> None:
         """Reassign active task. Supersede attempt, return to READY."""
         task, issue_number = self._get_task_issue(task_id)
@@ -674,11 +697,13 @@ class GitHubBackend(TaskBackend):
 
         now = _now_iso()
         current_attempt_id = task.get("current_attempt")
+        superseded_attempt: dict | None = None
         if current_attempt_id:
             for a in task["attempts"]:
                 if a["attempt_id"] == current_attempt_id:
                     a["status"] = AttemptStatus.SUPERSEDED.value
                     a["completed_at"] = now
+                    superseded_attempt = dict(a)
                     break
 
         trail_entry = TrailEntry(ts=now, worker_id="system", message=f"Reassigned to {worker_id}")
@@ -691,6 +716,10 @@ class GitHubBackend(TaskBackend):
         ready_label = self._label_name("ready")
         self._ensure_label(ready_label)
         self._swap_labels(issue_number, ["active"], "ready")
+
+        self._close_superseded_pr(
+            superseded_attempt, f"task reassigned to {worker_id}"
+        )
 
     def block_task(self, task_id: str, reason: str) -> None:
         """Block a ready task. Swap label ready -> blocked."""

--- a/antfarm/core/pr_ops.py
+++ b/antfarm/core/pr_ops.py
@@ -1,0 +1,85 @@
+"""PR lifecycle operations (close/comment), abstracted so backends stay platform-agnostic.
+
+Backends call ``PROps.close_pr`` when transitioning an attempt to SUPERSEDED so
+stale PRs do not accumulate. Implementations must be safe to call outside any
+backend lock — subprocess calls inside a lock would stall all other workers.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from typing import Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class PROps(Protocol):
+    """Interface for PR lifecycle operations."""
+
+    def close_pr(self, pr: str, comment: str | None = None) -> bool:
+        """Close a PR, optionally with a comment. Returns True on success."""
+        ...
+
+
+class GhPROps:
+    """Close PRs via ``gh pr close <url|number> --comment <msg>``.
+
+    Treats "already closed" / "already merged" responses as success. Never
+    raises — returns False on any failure so callers (e.g. kickback) cannot be
+    blocked by cosmetic PR-close issues such as a missing ``gh`` binary,
+    network errors, or rate limits.
+    """
+
+    def __init__(self, cwd: str | None = None, timeout: float = 10.0) -> None:
+        self._cwd = cwd
+        self._timeout = timeout
+        self._gh_missing_logged = False
+
+    def close_pr(self, pr: str, comment: str | None = None) -> bool:
+        if not pr:
+            return True
+        args = ["gh", "pr", "close", pr]
+        if comment:
+            args.extend(["--comment", comment])
+        try:
+            result = subprocess.run(
+                args,
+                cwd=self._cwd,
+                capture_output=True,
+                text=True,
+                timeout=self._timeout,
+            )
+        except FileNotFoundError:
+            if not self._gh_missing_logged:
+                logger.warning("gh CLI not found; cannot close superseded PRs")
+                self._gh_missing_logged = True
+            return False
+        except subprocess.TimeoutExpired:
+            logger.warning("gh pr close timed out for %s", pr)
+            return False
+
+        if result.returncode == 0:
+            return True
+
+        stderr = (result.stderr or "").lower()
+        # gh wording varies: "already closed", "has already been closed",
+        # "already been merged", "has been merged" — all indicate terminal
+        # state we asked for, so treat as success.
+        if (
+            "already closed" in stderr
+            or "already been closed" in stderr
+            or "already been merged" in stderr
+            or "has been merged" in stderr
+        ):
+            return True
+
+        logger.warning("gh pr close failed for %s: %s", pr, (result.stderr or "").strip())
+        return False
+
+
+class NullPROps:
+    """No-op PROps implementation for tests and when ``gh`` is not configured."""
+
+    def close_pr(self, pr: str, comment: str | None = None) -> bool:
+        return True

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -355,15 +355,8 @@ def get_app(
     """
     global _backend, _max_attempts
 
-    if backend is not None:
-        _backend = backend
-    else:
-        from antfarm.core.backends.file import FileBackend
-
-        _backend = FileBackend(root=data_dir)
-
-    # Load max_attempts default from config
-    repo_path = "."
+    # Load config up front so backend construction can see repo_path.
+    repo_path: str | None = None
     integration_branch = "main"
     config_path = os.path.join(data_dir, "config.json")
     if os.path.exists(config_path):
@@ -371,10 +364,23 @@ def get_app(
             with open(config_path) as f:
                 cfg = json.load(f)
             _max_attempts = cfg.get("max_attempts", 3)
-            repo_path = cfg.get("repo_path", repo_path)
+            repo_path = cfg.get("repo_path") or None
             integration_branch = cfg.get("integration_branch", integration_branch)
         except (json.JSONDecodeError, OSError):
             pass
+
+    if backend is not None:
+        _backend = backend
+    else:
+        from antfarm.core.backends.file import FileBackend
+        from antfarm.core.pr_ops import GhPROps, NullPROps
+
+        pr_ops = GhPROps(cwd=repo_path) if repo_path else NullPROps()
+        _backend = FileBackend(root=data_dir, pr_ops=pr_ops)
+
+    # Fallback so downstream uses (Queen, etc.) still see a repo_path string.
+    if repo_path is None:
+        repo_path = "."
 
     app = FastAPI(title="Antfarm Colony")
 

--- a/tests/test_file_backend.py
+++ b/tests/test_file_backend.py
@@ -1126,3 +1126,163 @@ def test_register_worker_boundary_at_guard_ttl_rejects(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="already registered and live"):
         backend.register_worker(_make_worker("worker-1"))
 
+
+# ---------------------------------------------------------------------------
+# Superseded-PR closing (issue #222)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingPROps:
+    """PROps stub that records every close_pr invocation."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str | None]] = []
+
+    def close_pr(self, pr: str, comment: str | None = None) -> bool:
+        self.calls.append((pr, comment))
+        return True
+
+
+def _carry_pull_harvest(
+    backend: FileBackend,
+    task_id: str = "task-1",
+    pr: str = "https://gh/pr/99",
+) -> str:
+    backend.carry(_make_task(task_id))
+    pulled = backend.pull("worker-1")
+    assert pulled is not None
+    attempt_id = pulled["current_attempt"]
+    backend.mark_harvested(task_id, attempt_id, pr=pr, branch=f"feat/{task_id}")
+    return attempt_id
+
+
+def test_kickback_closes_superseded_pr(tmp_path: Path) -> None:
+    fake = _RecordingPROps()
+    backend = FileBackend(root=tmp_path / ".antfarm", pr_ops=fake)
+    _carry_pull_harvest(backend, pr="https://gh/pr/99")
+
+    backend.kickback("task-1", reason="tests failed")
+
+    assert len(fake.calls) == 1
+    pr, comment = fake.calls[0]
+    assert pr == "https://gh/pr/99"
+    assert comment is not None
+    assert "tests failed" in comment
+
+
+def test_kickback_skips_close_when_no_pr(tmp_path: Path) -> None:
+    """If the current attempt has no pr field, close_pr must not be invoked."""
+    fake = _RecordingPROps()
+    backend = FileBackend(root=tmp_path / ".antfarm", pr_ops=fake)
+
+    # Build a done task whose attempt has no PR (simulates direct move).
+    backend.carry(_make_task("task-1"))
+    pulled = backend.pull("worker-1")
+    assert pulled is not None
+    attempt_id = pulled["current_attempt"]
+    # Harvest with pr="" — attempt.pr ends up empty.
+    backend.mark_harvested("task-1", attempt_id, pr="", branch="feat/task-1")
+
+    backend.kickback("task-1", reason="bad")
+
+    assert fake.calls == []
+
+
+def test_rereview_closes_superseded_pr(tmp_path: Path) -> None:
+    fake = _RecordingPROps()
+    backend = FileBackend(root=tmp_path / ".antfarm", pr_ops=fake)
+
+    # Build a review task with a current attempt bearing a PR.
+    _carry_pull_harvest(backend, task_id="review-task-1", pr="https://gh/pr/77")
+
+    backend.rereview("review-task-1", new_spec="spec2", touches=["a"])
+
+    assert len(fake.calls) == 1
+    pr, comment = fake.calls[0]
+    assert pr == "https://gh/pr/77"
+    assert comment is not None
+    assert "re-review" in comment.lower()
+
+
+def test_resume_task_closes_superseded_pr(tmp_path: Path) -> None:
+    fake = _RecordingPROps()
+    backend = FileBackend(root=tmp_path / ".antfarm", pr_ops=fake)
+
+    # Task with a live attempt holding a PR: carry -> pull -> pause -> resume.
+    backend.carry(_make_task("task-1"))
+    pulled = backend.pull("worker-1")
+    assert pulled is not None
+    attempt_id = pulled["current_attempt"]
+    # Attach a PR on the active attempt (simulate worker writing it on the file).
+    active_path = backend._active_path("task-1")
+    data = json.loads(active_path.read_text())
+    for a in data["attempts"]:
+        if a["attempt_id"] == attempt_id:
+            a["pr"] = "https://gh/pr/55"
+    active_path.write_text(json.dumps(data))
+
+    backend.pause_task("task-1")
+    backend.resume_task("task-1")
+
+    assert len(fake.calls) == 1
+    pr, comment = fake.calls[0]
+    assert pr == "https://gh/pr/55"
+    assert comment is not None
+    assert "resumed" in comment.lower()
+
+
+def test_reassign_task_closes_superseded_pr(tmp_path: Path) -> None:
+    fake = _RecordingPROps()
+    backend = FileBackend(root=tmp_path / ".antfarm", pr_ops=fake)
+
+    backend.carry(_make_task("task-1"))
+    pulled = backend.pull("worker-1")
+    assert pulled is not None
+    attempt_id = pulled["current_attempt"]
+    active_path = backend._active_path("task-1")
+    data = json.loads(active_path.read_text())
+    for a in data["attempts"]:
+        if a["attempt_id"] == attempt_id:
+            a["pr"] = "https://gh/pr/42"
+    active_path.write_text(json.dumps(data))
+
+    backend.reassign_task("task-1", worker_id="worker-2")
+
+    assert len(fake.calls) == 1
+    pr, comment = fake.calls[0]
+    assert pr == "https://gh/pr/42"
+    assert comment is not None
+    assert "reassigned" in comment.lower()
+
+
+def test_kickback_does_not_hold_lock_during_pr_close(tmp_path: Path) -> None:
+    """Regression: PR close must run AFTER releasing self._lock.
+
+    If kickback held the lock during close_pr, the PROps implementation could
+    not acquire the backend's lock from within close_pr without deadlocking.
+    """
+
+    class _LockProbingPROps:
+        """Tries to (re-)acquire the backend's lock from inside close_pr."""
+
+        def __init__(self) -> None:
+            self.backend: FileBackend | None = None
+            self.acquired: bool = False
+
+        def close_pr(self, pr: str, comment: str | None = None) -> bool:
+            assert self.backend is not None
+            # Non-blocking acquire — succeeds only if lock has been released.
+            self.acquired = self.backend._lock.acquire(blocking=False)
+            if self.acquired:
+                self.backend._lock.release()
+            return True
+
+    probe = _LockProbingPROps()
+    backend = FileBackend(root=tmp_path / ".antfarm", pr_ops=probe)
+    probe.backend = backend
+
+    _carry_pull_harvest(backend, pr="https://gh/pr/1")
+    backend.kickback("task-1", reason="tests failed")
+
+    assert probe.acquired, "kickback held self._lock during PR close (deadlock risk)"
+

--- a/tests/test_pr_ops.py
+++ b/tests/test_pr_ops.py
@@ -1,0 +1,83 @@
+"""Tests for antfarm.core.pr_ops.
+
+Covers the GhPROps subprocess wrapper (success, already-closed, gh-missing,
+timeout) and the NullPROps no-op implementation.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from antfarm.core.pr_ops import GhPROps, NullPROps
+
+
+class _CompletedProcess:
+    def __init__(self, returncode: int, stderr: str = "", stdout: str = "") -> None:
+        self.returncode = returncode
+        self.stderr = stderr
+        self.stdout = stdout
+
+
+def test_ghprops_close_success() -> None:
+    ops = GhPROps()
+    with patch("antfarm.core.pr_ops.subprocess.run", return_value=_CompletedProcess(0)) as mock:
+        assert ops.close_pr("https://gh/pr/1", comment="hi") is True
+    args, kwargs = mock.call_args
+    assert args[0][:3] == ["gh", "pr", "close"]
+    assert args[0][3] == "https://gh/pr/1"
+    assert "--comment" in args[0]
+    assert "hi" in args[0]
+
+
+def test_ghprops_already_closed_is_ok() -> None:
+    ops = GhPROps()
+    resp = _CompletedProcess(1, stderr="Pull request has already been closed")
+    with patch("antfarm.core.pr_ops.subprocess.run", return_value=resp):
+        assert ops.close_pr("https://gh/pr/1") is True
+
+
+def test_ghprops_already_merged_is_ok() -> None:
+    ops = GhPROps()
+    resp = _CompletedProcess(1, stderr="This PR has been merged")
+    with patch("antfarm.core.pr_ops.subprocess.run", return_value=resp):
+        assert ops.close_pr("https://gh/pr/1") is True
+
+
+def test_ghprops_gh_missing_returns_false() -> None:
+    ops = GhPROps()
+    with patch("antfarm.core.pr_ops.subprocess.run", side_effect=FileNotFoundError()):
+        # Must not raise; returns False.
+        assert ops.close_pr("https://gh/pr/1") is False
+        # Second call with gh still missing also returns False.
+        assert ops.close_pr("https://gh/pr/2") is False
+
+
+def test_ghprops_timeout_returns_false() -> None:
+    ops = GhPROps(timeout=0.01)
+    with patch(
+        "antfarm.core.pr_ops.subprocess.run",
+        side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=0.01),
+    ):
+        assert ops.close_pr("https://gh/pr/1") is False
+
+
+def test_ghprops_empty_pr_is_noop() -> None:
+    ops = GhPROps()
+    with patch("antfarm.core.pr_ops.subprocess.run") as mock:
+        assert ops.close_pr("") is True
+    mock.assert_not_called()
+
+
+def test_ghprops_arbitrary_failure_returns_false() -> None:
+    ops = GhPROps()
+    resp = _CompletedProcess(1, stderr="network unreachable")
+    with patch("antfarm.core.pr_ops.subprocess.run", return_value=resp):
+        assert ops.close_pr("https://gh/pr/1") is False
+
+
+def test_nullprops_always_true() -> None:
+    ops = NullPROps()
+    assert ops.close_pr("") is True
+    assert ops.close_pr("https://gh/pr/1") is True
+    assert ops.close_pr("https://gh/pr/1", comment="hi") is True


### PR DESCRIPTION
## Summary

- Adds `antfarm/core/pr_ops.py` with a small `PROps` protocol, a `GhPROps` implementation that shells out to `gh pr close`, and a `NullPROps` no-op.
- `FileBackend` and `GitHubBackend` accept a `pr_ops` parameter and close the superseded attempt's PR whenever an attempt transitions to SUPERSEDED (`kickback`, `rereview`, `resume_task`, `reassign_task`).
- `serve.py` wires `GhPROps(cwd=repo_path)` when `repo_path` is present in `config.json`, otherwise `NullPROps`.
- PR close runs OUTSIDE the backend lock — subprocess inside `threading.Lock` would stall every other worker. Each method captures the superseded attempt inside the lock and calls `_close_superseded_pr` after release. Regression test `test_kickback_does_not_hold_lock_during_pr_close` verifies the invariant.

`GhPROps` is defensive: gh-missing, timeouts, and "already closed"/"already merged" stderr all resolve safely and never raise. The backend additionally wraps the call in `contextlib.suppress(Exception)` so a failed PR close cannot break a state transition.

## Test plan

- [x] `ruff check .` clean
- [x] `pytest tests/ -x -q` — 882 passed
- [x] New `tests/test_pr_ops.py` covers success, already-closed, already-merged, gh-missing, timeout, empty-pr, arbitrary failure, and NullPROps paths
- [x] New FileBackend tests cover kickback/rereview/resume/reassign close invocations, the no-PR skip path, and the critical deadlock test
- [x] Existing tests unaffected (pr_ops defaults to NullPROps)

## Related Issues

Closes #222