### PR TITLE
fix(doctor): scope tmux session names by colony data_dir hash (#231)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- Tmux session names now include an 8-char SHA-256 hash of the colony's resolved `data_dir` (format: `auto-{hash}-{role}-{N}` for autoscaler, `runner-{hash}-{role}-{N}` for Runner). This scopes orphan detection to the current colony so peer colonies on the same host are ignored. Doctor's `check_orphan_tmux_sessions` is restored to `warning` severity with `auto_fixable=True`, and `antfarm doctor --fix` now safely `tmux kill-session`s own orphans. Backwards-compat caveat: tmux sessions spawned by pre-upgrade builds lack the hash prefix and become unmanaged — operators should `tmux kill-session -t <name>` them after upgrading. (#231)
+
 ### Fixed
 - `register_worker` tolerates stale prior registrations — overwrites worker files whose heartbeat has expired instead of returning 409, preventing autoscaler crashes on colony restart (#194)
 

--- a/antfarm/core/autoscaler.py
+++ b/antfarm/core/autoscaler.py
@@ -23,7 +23,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from antfarm.core.backends.base import TaskBackend
-from antfarm.core.process_manager import ProcessManager, get_process_manager
+from antfarm.core.process_manager import ProcessManager, colony_hash, get_process_manager
 
 if TYPE_CHECKING:
     from antfarm.core.actuator import Actuator  # noqa: F401
@@ -189,8 +189,11 @@ class Autoscaler:
         self.managed: dict[str, ManagedWorker] = {}
         self._stopped = False
         self._counter = 0
-        self._pm = _pm if _pm is not None else get_process_manager(
-            prefix="auto-", state_dir=config.data_dir
+        self._prefix = f"auto-{colony_hash(config.data_dir)}-"
+        self._pm = (
+            _pm
+            if _pm is not None
+            else get_process_manager(prefix=self._prefix, state_dir=config.data_dir)
         )
 
     def run(self) -> None:
@@ -267,7 +270,7 @@ class Autoscaler:
         """Spawn a new worker via ProcessManager. Retries once on name collision."""
         for attempt in range(2):
             self._counter += 1
-            name = f"auto-{role}-{self._counter}"
+            name = f"{self._prefix}{role}-{self._counter}"
             worker_id = f"{self.config.node_id}/{name}"
 
             cmd = [

--- a/antfarm/core/doctor.py
+++ b/antfarm/core/doctor.py
@@ -58,7 +58,7 @@ def run_doctor(backend, config: dict, fix: bool = False) -> list[Finding]:
     findings.extend(check_dependency_cycles(backend))
     findings.extend(check_runner_health(backend, config))
     findings.extend(check_tmux_available(config))
-    findings.extend(check_orphan_tmux_sessions(config))
+    findings.extend(check_orphan_tmux_sessions(config, fix))
 
     return findings
 
@@ -980,29 +980,38 @@ def check_tmux_available(config: dict) -> list[Finding]:
 # Check 13: Orphan tmux sessions
 # ---------------------------------------------------------------------------
 
-_ANTFARM_PREFIXES = ("auto-", "runner-")
 
+def check_orphan_tmux_sessions(config: dict, fix: bool = False) -> list[Finding]:
+    """Detect tmux sessions owned by THIS colony that have no matching metadata.
 
-def check_orphan_tmux_sessions(config: dict) -> list[Finding]:
-    """Detect tmux sessions with antfarm prefixes that have no matching metadata file.
+    Session names carry an 8-char SHA-256 hash of the colony's resolved
+    ``data_dir`` (see :func:`antfarm.core.process_manager.colony_hash`), so
+    this check considers only sessions matching one of THIS colony's prefixes:
 
-    An orphan session is one whose name starts with a known antfarm prefix
-    (``auto-`` or ``runner-``) but whose ProcessMetadata file is absent from
-    ``{state_dir}/processes/{name}.json``.  This can happen when the colony
-    process crashed before writing metadata, or after a manual ``tmux kill-server``.
+    - ``auto-{hash}-`` — autoscaler-spawned workers
+    - ``runner-{hash}-`` — Runner-spawned workers
 
-    Severity is ``info``, not ``warning``, because we cannot reliably distinguish
-    our own orphan from a live session owned by a peer colony (different
-    ``data_dir`` on the same host) from tmux alone. Users running ``antfarm
-    doctor`` still see the finding, but automated gates (e.g. the Soldier merge
-    gate's "no errors/warnings" assertion) do not fire spuriously on hosts that
-    run multiple colonies or host long-lived dogfood sessions.
+    Sessions owned by peer colonies (different ``data_dir`` on the same host)
+    use a different hash and are ignored — they are not our problem.
+
+    An orphan is a session matching one of our prefixes but without a
+    corresponding ``ProcessMetadata`` file under
+    ``{data_dir}/processes/{name}.json``. This can happen when the colony
+    crashed before writing metadata, or after a manual ``tmux kill-server``
+    that left state files behind.
+
+    Severity is ``warning`` with ``auto_fixable=True``: prefix filtering
+    guarantees ownership, so ``--fix`` can safely ``tmux kill-session`` the
+    orphan without risking a peer colony's workers.
 
     Args:
-        config: Doctor config dict. Uses ``data_dir`` to locate process metadata.
+        config: Doctor config dict. Uses ``data_dir`` to derive the colony
+            hash and locate process metadata.
+        fix: If True, kill each orphan via ``tmux kill-session`` and mark
+            the finding as ``fixed=True``.
 
     Returns:
-        List of findings (report only, no fix).
+        List of findings for this colony's orphans.
     """
     if not shutil.which("tmux"):
         return []
@@ -1016,10 +1025,15 @@ def check_orphan_tmux_sessions(config: dict) -> list[Finding]:
         # tmux server not running — no sessions to check
         return []
 
-    from antfarm.core.process_manager import parse_session_name
+    from antfarm.core.process_manager import colony_hash, parse_session_name
 
     data_dir = config.get("data_dir", "")
-    processes_dir = Path(data_dir) / "processes" if data_dir else None
+    if not data_dir:
+        return []
+
+    h = colony_hash(data_dir)
+    own_prefixes = (f"auto-{h}-", f"runner-{h}-")
+    processes_dir = Path(data_dir) / "processes"
 
     findings: list[Finding] = []
     for name in result.stdout.strip().splitlines():
@@ -1027,26 +1041,31 @@ def check_orphan_tmux_sessions(config: dict) -> list[Finding]:
         if not name:
             continue
 
-        # Check if this is an antfarm session (matches any known prefix)
-        is_antfarm = any(
-            parse_session_name(name, prefix) is not None for prefix in _ANTFARM_PREFIXES
-        )
-        if not is_antfarm:
+        # Only consider sessions owned by THIS colony (hash match).
+        # Peer-colony sessions use a different hash and are skipped entirely.
+        is_ours = any(parse_session_name(name, prefix) is not None for prefix in own_prefixes)
+        if not is_ours:
             continue
 
-        # Check if matching metadata file exists
-        if processes_dir is not None:
-            metadata_file = processes_dir / f"{name}.json"
-            if metadata_file.exists():
-                continue
+        # Skip sessions with matching metadata — those are tracked, not orphans.
+        if (processes_dir / f"{name}.json").exists():
+            continue
 
-        findings.append(
-            Finding(
-                severity="info",
-                check="orphan_tmux_session",
-                message=f"orphan tmux session: {name} (no matching metadata)",
-                auto_fixable=False,
-            )
+        finding = Finding(
+            severity="warning",
+            check="orphan_tmux_session",
+            message=f"orphan tmux session: {name} (no matching metadata)",
+            auto_fixable=True,
         )
+
+        if fix:
+            kill = subprocess.run(
+                ["tmux", "kill-session", "-t", name],
+                capture_output=True,
+                text=True,
+            )
+            finding.fixed = kill.returncode == 0
+
+        findings.append(finding)
 
     return findings

--- a/antfarm/core/process_manager.py
+++ b/antfarm/core/process_manager.py
@@ -9,6 +9,7 @@ Use get_process_manager() to get the right implementation.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -22,9 +23,26 @@ from datetime import UTC, datetime
 logger = logging.getLogger(__name__)
 
 # Session name format: {prefix}{role}-{counter}
-# e.g., "auto-builder-3" or "runner-planner-1"
+# e.g., "auto-a1b2c3d4-builder-3" or "runner-a1b2c3d4-planner-1"
 # Shared constant so adoption parsing stays in sync with naming.
 SESSION_NAME_SEP = "-"
+
+
+def colony_hash(data_dir: str) -> str:
+    """Stable 8-char hex hash for this colony's tmux session prefix.
+
+    Resolves symlinks so ``data_dir``, ``./data_dir``, and the corresponding
+    absolute path collapse to the same hash. Operators who physically move
+    the directory get a new prefix — acceptable, since a move implies restart.
+
+    Args:
+        data_dir: Colony data directory (``.antfarm/`` path or Runner state dir).
+
+    Returns:
+        First 8 hex chars of SHA-256 over the resolved realpath.
+    """
+    real = os.path.realpath(data_dir)
+    return hashlib.sha256(real.encode("utf-8")).hexdigest()[:8]
 
 
 def parse_session_name(name: str, prefix: str) -> tuple[str, int] | None:

--- a/antfarm/core/runner.py
+++ b/antfarm/core/runner.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass, field
 from fastapi import FastAPI
 from pydantic import BaseModel, Field
 
-from antfarm.core.process_manager import get_process_manager
+from antfarm.core.process_manager import colony_hash, get_process_manager
 
 logger = logging.getLogger(__name__)
 
@@ -125,7 +125,8 @@ class Runner:
         self._lock = threading.Lock()
         self._colony = None  # ColonyClient, set in run()
 
-        self._pm = get_process_manager(prefix="runner-", state_dir=self.state_dir)
+        self._prefix = f"runner-{colony_hash(self.state_dir)}-"
+        self._pm = get_process_manager(prefix=self._prefix, state_dir=self.state_dir)
 
     def run(self) -> None:
         """Start the Runner daemon.
@@ -291,7 +292,7 @@ class Runner:
 
         for attempt in range(2):
             self._counter += 1
-            name = f"runner-{role}-{self._counter}"
+            name = f"{self._prefix}{role}-{self._counter}"
             log_path = os.path.join(log_dir, f"{name}.log")
 
             # Inject name into cmd (--name argument)

--- a/tests/test_autoscaler.py
+++ b/tests/test_autoscaler.py
@@ -73,6 +73,21 @@ def _mock_pm() -> MagicMock:
 
 
 # ---------------------------------------------------------------------------
+# Colony-hashed prefix (#231)
+# ---------------------------------------------------------------------------
+
+
+def test_autoscaler_uses_hashed_prefix(tmp_path):
+    """Autoscaler's ProcessManager prefix is ``auto-{colony_hash(data_dir)}-``."""
+    from antfarm.core.process_manager import colony_hash
+
+    data_dir = str(tmp_path / ".antfarm")
+    a = _make_autoscaler(data_dir=data_dir)
+    expected = f"auto-{colony_hash(data_dir)}-"
+    assert a._prefix == expected
+
+
+# ---------------------------------------------------------------------------
 # _compute_desired tests
 # ---------------------------------------------------------------------------
 
@@ -492,7 +507,8 @@ class TestStartWorker:
         cmd = start_call[0][1]
         role = start_call[1].get("role") or start_call[0][3]
 
-        assert name.startswith("auto-builder-")
+        assert name.startswith(a._prefix)
+        assert name.endswith("-builder-1")
         assert "antfarm" in cmd
         assert "--type" in cmd
         idx = cmd.index("--type")
@@ -532,7 +548,7 @@ class TestStartWorker:
         # The second name was registered
         names = list(a.managed.keys())
         assert len(names) == 1
-        assert names[0] == "auto-builder-2"
+        assert names[0] == f"{a._prefix}builder-2"
 
     @patch("antfarm.core.autoscaler.os.makedirs")
     def test_start_worker_both_attempts_fail_skips_gracefully(self, mock_makedirs):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -72,17 +72,13 @@ def test_healthy_colony_no_findings(setup):
     # Exclude tmux_available: it fires in CI/minimal environments where tmux
     # is not installed — this is expected and not a colony health issue.
     #
-    # orphan_tmux_session is also tolerated here (defense in depth): it is an
-    # ``info``-severity finding so the severity filter below already skips it,
-    # but we list it explicitly so the intent is code, not just comment. This
-    # matters when the test host has live tmux sessions owned by a peer colony
-    # (different data_dir on the same machine) — those are not failures of the
-    # colony under test.
+    # orphan_tmux_session is now scoped by colony hash — peer-colony sessions
+    # on the same host carry a different hash and are ignored, so it is no
+    # longer broadened into this exclusion tuple.
     errors_warnings = [
         f
         for f in findings
-        if f.severity in ("error", "warning")
-        and f.check not in ("tmux_available", "orphan_tmux_session")
+        if f.severity in ("error", "warning") and f.check not in ("tmux_available",)
     ]
     assert errors_warnings == [], f"Expected no errors/warnings, got: {errors_warnings}"
 
@@ -645,24 +641,29 @@ def test_check_orphan_tmux_sessions_no_tmux():
 
 
 def test_check_orphan_tmux_sessions_detects_orphans(tmp_path):
-    """Antfarm-prefixed session without metadata emits info finding; one WITH metadata does not."""
+    """Own-hash session without metadata emits warning finding; one WITH metadata does not."""
     from unittest.mock import MagicMock, patch
 
     from antfarm.core.doctor import check_orphan_tmux_sessions
+    from antfarm.core.process_manager import colony_hash
 
     data_dir = tmp_path / ".antfarm"
     processes_dir = data_dir / "processes"
     processes_dir.mkdir(parents=True)
 
+    h = colony_hash(str(data_dir))
+    known = f"auto-{h}-builder-1"
+    orphan = f"auto-{h}-planner-2"
+
     # Write metadata for the non-orphan session
-    (processes_dir / "auto-builder-1.json").write_text(
-        '{"name": "auto-builder-1", "role": "builder", "manager_type": "tmux"}'
+    (processes_dir / f"{known}.json").write_text(
+        f'{{"name": "{known}", "role": "builder", "manager_type": "tmux"}}'
     )
 
     config = {"data_dir": str(data_dir)}
 
-    # Two antfarm sessions: one with metadata, one orphan; plus one non-antfarm session
-    session_names = "auto-builder-1\nauto-planner-2\nsome-unrelated-session\n"
+    # Two own-hash sessions: one with metadata, one orphan; plus one non-antfarm session
+    session_names = f"{known}\n{orphan}\nsome-unrelated-session\n"
 
     mock_result = MagicMock()
     mock_result.returncode = 0
@@ -676,9 +677,9 @@ def test_check_orphan_tmux_sessions_detects_orphans(tmp_path):
 
     orphan_checks = [f for f in findings if f.check == "orphan_tmux_session"]
     assert len(orphan_checks) == 1
-    assert "auto-planner-2" in orphan_checks[0].message
-    assert orphan_checks[0].severity == "info"
-    assert orphan_checks[0].auto_fixable is False
+    assert orphan in orphan_checks[0].message
+    assert orphan_checks[0].severity == "warning"
+    assert orphan_checks[0].auto_fixable is True
 
 
 def test_check_orphan_tmux_sessions_no_server():
@@ -706,14 +707,13 @@ def test_check_orphan_tmux_sessions_no_server():
 
 
 def test_run_doctor_on_colony_with_peer_auto_tmux_sessions_produces_no_warnings(setup, monkeypatch):
-    """Peer-colony tmux sessions must not raise error/warning findings.
+    """Peer-colony tmux sessions must be ignored entirely (different hash prefix).
 
-    Scenario: another antfarm colony (different data_dir, same host) owns live
-    ``auto-*`` tmux sessions. From this colony's point of view those sessions
-    have no matching metadata in its own ``processes/`` directory, so
-    ``check_orphan_tmux_sessions`` will flag them. The finding must be
-    ``info`` severity so that the Soldier merge gate — which treats any
-    error/warning as blocking — does not kick back every PR during dogfooding.
+    Scenario: another antfarm colony (different ``data_dir``, same host) owns
+    live ``auto-*`` tmux sessions. Their session names carry that peer's
+    colony hash (derived from its ``data_dir`` realpath), which will not
+    match THIS colony's hash. ``check_orphan_tmux_sessions`` must therefore
+    produce zero findings for peer sessions — not even ``info``.
     """
     import subprocess as real_subprocess
     from unittest.mock import MagicMock
@@ -722,10 +722,11 @@ def test_run_doctor_on_colony_with_peer_auto_tmux_sessions_produces_no_warnings(
 
     backend, config = setup
 
-    # Simulate a peer colony's sessions appearing in `tmux ls` output.
+    # Simulate peer-colony sessions: `auto-{foreign_hash}-...`. Any hex digest
+    # other than this colony's own hash exercises the ownership filter.
     tmux_result = MagicMock()
     tmux_result.returncode = 0
-    tmux_result.stdout = "auto-reviewer-99\nauto-builder-42\n"
+    tmux_result.stdout = "auto-ffffffff-reviewer-99\nauto-deadbeef-builder-42\n"
 
     real_run = real_subprocess.run
 
@@ -743,11 +744,8 @@ def test_run_doctor_on_colony_with_peer_auto_tmux_sessions_produces_no_warnings(
     findings = run_doctor(backend, config, fix=False)
 
     orphan_findings = [f for f in findings if f.check == "orphan_tmux_session"]
-    assert len(orphan_findings) == 2, (
-        f"expected both peer sessions to be flagged, got: {orphan_findings}"
-    )
-    assert all(f.severity == "info" for f in orphan_findings), (
-        f"peer-session findings must be info-severity, got: {orphan_findings}"
+    assert orphan_findings == [], (
+        f"peer-colony sessions (foreign hash) must be ignored, got: {orphan_findings}"
     )
 
     # The real regression guard: Soldier's gate asserts no errors/warnings.
@@ -755,3 +753,144 @@ def test_run_doctor_on_colony_with_peer_auto_tmux_sessions_produces_no_warnings(
     assert blocking == [], (
         f"peer-colony tmux sessions must not produce error/warning findings: {blocking}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Colony-hashed orphan scoping (#231)
+# ---------------------------------------------------------------------------
+
+
+def test_orphan_own_prefix_detected_as_warning(tmp_path):
+    """Own-hash session without metadata is flagged warning + auto_fixable."""
+    from unittest.mock import MagicMock, patch
+
+    from antfarm.core.doctor import check_orphan_tmux_sessions
+    from antfarm.core.process_manager import colony_hash
+
+    data_dir = tmp_path / ".antfarm"
+    (data_dir / "processes").mkdir(parents=True)
+
+    h = colony_hash(str(data_dir))
+    orphan = f"runner-{h}-builder-7"
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = f"{orphan}\n"
+
+    with (
+        patch("antfarm.core.doctor.shutil.which", return_value="/usr/bin/tmux"),
+        patch("antfarm.core.doctor.subprocess.run", return_value=mock_result),
+    ):
+        findings = check_orphan_tmux_sessions({"data_dir": str(data_dir)}, fix=False)
+
+    assert len(findings) == 1
+    assert findings[0].severity == "warning"
+    assert findings[0].auto_fixable is True
+    assert findings[0].fixed is False
+    assert orphan in findings[0].message
+
+
+def test_orphan_peer_prefix_ignored(tmp_path):
+    """Foreign-hash session produces zero findings — not even info."""
+    from unittest.mock import MagicMock, patch
+
+    from antfarm.core.doctor import check_orphan_tmux_sessions
+
+    data_dir = tmp_path / ".antfarm"
+    (data_dir / "processes").mkdir(parents=True)
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    # Use 'ffffffff' which will not collide with the real hash of data_dir.
+    mock_result.stdout = "auto-ffffffff-reviewer-99\nrunner-deadbeef-planner-3\n"
+
+    with (
+        patch("antfarm.core.doctor.shutil.which", return_value="/usr/bin/tmux"),
+        patch("antfarm.core.doctor.subprocess.run", return_value=mock_result),
+    ):
+        findings = check_orphan_tmux_sessions({"data_dir": str(data_dir)}, fix=False)
+
+    assert findings == []
+
+
+def test_orphan_fix_kills_session(tmp_path):
+    """With fix=True, tmux kill-session is invoked for own orphans only."""
+    from unittest.mock import MagicMock, patch
+
+    from antfarm.core.doctor import check_orphan_tmux_sessions
+    from antfarm.core.process_manager import colony_hash
+
+    data_dir = tmp_path / ".antfarm"
+    (data_dir / "processes").mkdir(parents=True)
+
+    h = colony_hash(str(data_dir))
+    own_orphan = f"auto-{h}-builder-3"
+    peer = "auto-ffffffff-builder-3"
+
+    list_result = MagicMock()
+    list_result.returncode = 0
+    list_result.stdout = f"{own_orphan}\n{peer}\n"
+
+    kill_result = MagicMock()
+    kill_result.returncode = 0
+
+    calls: list = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:2] == ["tmux", "list-sessions"]:
+            return list_result
+        if cmd[:2] == ["tmux", "kill-session"]:
+            return kill_result
+        raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+    with (
+        patch("antfarm.core.doctor.shutil.which", return_value="/usr/bin/tmux"),
+        patch("antfarm.core.doctor.subprocess.run", side_effect=fake_run),
+    ):
+        findings = check_orphan_tmux_sessions({"data_dir": str(data_dir)}, fix=True)
+
+    # Exactly one finding (our orphan); peer session is ignored entirely.
+    assert len(findings) == 1
+    assert findings[0].fixed is True
+
+    # Exactly one kill invocation, targeting our orphan (NOT the peer).
+    kill_calls = [c for c in calls if c[:2] == ["tmux", "kill-session"]]
+    assert kill_calls == [["tmux", "kill-session", "-t", own_orphan]]
+
+
+def test_two_mock_colonies_dont_cross_see(tmp_path):
+    """Two colonies with distinct data_dirs each see only their own orphans."""
+    from unittest.mock import MagicMock, patch
+
+    from antfarm.core.doctor import check_orphan_tmux_sessions
+    from antfarm.core.process_manager import colony_hash
+
+    dir_a = tmp_path / "colony-a"
+    dir_b = tmp_path / "colony-b"
+    (dir_a / "processes").mkdir(parents=True)
+    (dir_b / "processes").mkdir(parents=True)
+
+    h_a = colony_hash(str(dir_a))
+    h_b = colony_hash(str(dir_b))
+    assert h_a != h_b
+
+    name_a = f"auto-{h_a}-builder-1"
+    name_b = f"auto-{h_b}-reviewer-2"
+
+    mock_result = MagicMock()
+    mock_result.returncode = 0
+    mock_result.stdout = f"{name_a}\n{name_b}\nnot-antfarm\n"
+
+    with (
+        patch("antfarm.core.doctor.shutil.which", return_value="/usr/bin/tmux"),
+        patch("antfarm.core.doctor.subprocess.run", return_value=mock_result),
+    ):
+        findings_a = check_orphan_tmux_sessions({"data_dir": str(dir_a)}, fix=False)
+        findings_b = check_orphan_tmux_sessions({"data_dir": str(dir_b)}, fix=False)
+
+    assert len(findings_a) == 1 and name_a in findings_a[0].message
+    assert name_b not in findings_a[0].message
+
+    assert len(findings_b) == 1 and name_b in findings_b[0].message
+    assert name_a not in findings_b[0].message

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -10,6 +10,7 @@ from antfarm.core.process_manager import (
     ProcessMetadata,
     SubprocessProcessManager,
     TmuxProcessManager,
+    colony_hash,
     get_process_manager,
     parse_session_name,
 )
@@ -30,6 +31,54 @@ def test_parse_session_name():
     assert parse_session_name("invalid", "auto-") is None
     # Empty role
     assert parse_session_name("auto--1", "auto-") is None
+
+
+def test_parse_session_name_with_hashed_prefix():
+    """Hashed prefixes (per #231) parse correctly for both adapters."""
+    assert parse_session_name("auto-a1b2c3d4-builder-3", "auto-a1b2c3d4-") == ("builder", 3)
+    assert parse_session_name("runner-a1b2c3d4-planner-1", "runner-a1b2c3d4-") == ("planner", 1)
+    # Multi-dash role under hashed prefix
+    assert parse_session_name("auto-a1b2c3d4-code-reviewer-5", "auto-a1b2c3d4-") == (
+        "code-reviewer",
+        5,
+    )
+    # Foreign hash is not matched by own-hash prefix
+    assert parse_session_name("auto-deadbeef-builder-3", "auto-a1b2c3d4-") is None
+
+
+# --- colony_hash tests (per #231) ---
+
+
+def test_colony_hash_stable_same_data_dir(tmp_path):
+    """Calling colony_hash twice on the same data_dir returns the same hash."""
+    path = str(tmp_path / "state")
+    os.makedirs(path, exist_ok=True)
+    assert colony_hash(path) == colony_hash(path)
+
+
+def test_colony_hash_differs_for_different_data_dir(tmp_path):
+    """Different data_dirs produce different hashes."""
+    a = str(tmp_path / "colony-a")
+    b = str(tmp_path / "colony-b")
+    os.makedirs(a, exist_ok=True)
+    os.makedirs(b, exist_ok=True)
+    assert colony_hash(a) != colony_hash(b)
+
+
+def test_colony_hash_resolves_symlinks(tmp_path):
+    """A symlink to a data_dir produces the same hash as the real path."""
+    real = tmp_path / "real"
+    real.mkdir()
+    link = tmp_path / "link"
+    os.symlink(str(real), str(link))
+    assert colony_hash(str(link)) == colony_hash(str(real))
+
+
+def test_colony_hash_length_is_8(tmp_path):
+    """Hash is exactly 8 hex chars — matches the session-name budget."""
+    h = colony_hash(str(tmp_path))
+    assert len(h) == 8
+    assert all(c in "0123456789abcdef" for c in h)
 
 
 def test_get_process_manager_no_tmux():

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -57,6 +57,14 @@ class TestRunnerDefaults:
         r = _make_runner(tmp_path)
         assert r._pm is not None
 
+    def test_runner_uses_hashed_prefix(self, tmp_path):
+        """Runner's ProcessManager prefix is ``runner-{colony_hash(state_dir)}-`` (#231)."""
+        from antfarm.core.process_manager import colony_hash
+
+        r = _make_runner(tmp_path)
+        expected = f"runner-{colony_hash(r.state_dir)}-"
+        assert r._prefix == expected
+
 
 class TestDesiredState:
     def test_apply_desired_state(self, tmp_path):
@@ -224,7 +232,8 @@ class TestStartWorker:
         log_path = call_args[0][2]
         role = call_args[1].get("role") or call_args[0][3]
 
-        assert name.startswith("runner-builder-")
+        assert name.startswith(r._prefix)
+        assert name.endswith("-builder-1")
         assert "antfarm" in cmd[0]
         assert "--type" in cmd
         assert "builder" in cmd


### PR DESCRIPTION
## Summary
- Tmux session names now embed an 8-char SHA-256 hash of the colony's resolved `data_dir`: `auto-{hash}-{role}-{N}` (autoscaler) and `runner-{hash}-{role}-{N}` (Runner). The hash is computed by a new `colony_hash(data_dir)` helper exported from `process_manager.py` (resolves symlinks via `os.path.realpath`).
- Doctor's `check_orphan_tmux_sessions` now filters by the colony's own hashed prefixes and ignores peer-colony sessions entirely (not even `info`-severity). Severity is restored to `warning` with `auto_fixable=True`, so `antfarm doctor --fix` safely invokes `tmux kill-session -t <name>` on own orphans — the structural fix blocked on scoping in #230.
- `deploy.py`'s `antfarm-*` remote sessions are deliberately left unhashed (out of scope per the approved plan; operator multi-colony deploy is narrow, and `node_id` already disambiguates).

## Test Plan
- [x] `ruff check .` clean
- [x] `pytest tests/ -x -q` — 893 passed
- [x] New coverage in `tests/test_process_manager.py`: `colony_hash` stability, difference, symlink resolution, length; plus hashed `parse_session_name` case.
- [x] New coverage in `tests/test_doctor.py`: own-hash orphan → warning + auto_fixable; foreign-hash session → zero findings; `fix=True` kills own orphan only (peer untouched); two mock colonies with distinct hashes do not cross-see each other's orphans.
- [x] New coverage in `tests/test_autoscaler.py` / `tests/test_runner.py`: PM prefix is `auto-{colony_hash(data_dir)}-` / `runner-{colony_hash(state_dir)}-`.
- [x] Updated `test_healthy_colony_no_findings` to drop the `orphan_tmux_session` exclusion added in #230; peer sessions are now ignored at the check level, not tolerated by filter.
- [x] Updated peer-session regression test (`test_run_doctor_on_colony_with_peer_auto_tmux_sessions_produces_no_warnings`) to inject foreign-hash prefixes and assert zero findings.

## Backwards-compat caveat
Tmux sessions spawned by pre-upgrade builds lack the hash prefix and become unmanaged after this change — they are neither adopted nor flagged as orphans. Operators should `tmux kill-session -t <name>` them manually once after upgrading.

Closes #231