### PR TITLE
fix(doctor): harden --fix against tmux kill-session race (#236)

### DIFF
--- a/antfarm/core/doctor.py
+++ b/antfarm/core/doctor.py
@@ -1064,7 +1064,29 @@ def check_orphan_tmux_sessions(config: dict, fix: bool = False) -> list[Finding]
                 capture_output=True,
                 text=True,
             )
-            finding.fixed = kill.returncode == 0
+            if kill.returncode == 0:
+                finding.fixed = True
+            else:
+                # Race: session disappeared between list-sessions and kill-session.
+                # tmux emits these strings from cmd-kill-session.c / server.c when
+                # the target is gone or the server has exited. Treat as success.
+                stderr_lower = (kill.stderr or "").strip().lower()
+                gone_markers = (
+                    "can't find session",
+                    "session not found",
+                    "no server running",
+                )
+                if any(m in stderr_lower for m in gone_markers):
+                    finding.fixed = True
+                    finding.message += " (already gone)"
+                else:
+                    detail = (
+                        kill.stderr.strip().splitlines()[0]
+                        if kill.stderr and kill.stderr.strip()
+                        else f"returncode={kill.returncode}"
+                    )
+                    finding.message += f" — kill failed: {detail}"
+                    finding.fixed = False
 
         findings.append(finding)
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -859,6 +859,108 @@ def test_orphan_fix_kills_session(tmp_path):
     assert kill_calls == [["tmux", "kill-session", "-t", own_orphan]]
 
 
+def _run_orphan_fix_with_kill_result(tmp_path, kill_returncode: int, kill_stderr: str):
+    """Shared helper: run check_orphan_tmux_sessions(fix=True) with a canned kill result."""
+    from unittest.mock import MagicMock, patch
+
+    from antfarm.core.doctor import check_orphan_tmux_sessions
+    from antfarm.core.process_manager import colony_hash
+
+    data_dir = tmp_path / ".antfarm"
+    (data_dir / "processes").mkdir(parents=True)
+
+    h = colony_hash(str(data_dir))
+    own_orphan = f"auto-{h}-builder-3"
+
+    list_result = MagicMock()
+    list_result.returncode = 0
+    list_result.stdout = f"{own_orphan}\n"
+
+    kill_result = MagicMock()
+    kill_result.returncode = kill_returncode
+    kill_result.stderr = kill_stderr
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["tmux", "list-sessions"]:
+            return list_result
+        if cmd[:2] == ["tmux", "kill-session"]:
+            return kill_result
+        raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+    with (
+        patch("antfarm.core.doctor.shutil.which", return_value="/usr/bin/tmux"),
+        patch("antfarm.core.doctor.subprocess.run", side_effect=fake_run),
+    ):
+        findings = check_orphan_tmux_sessions({"data_dir": str(data_dir)}, fix=True)
+
+    return findings, own_orphan
+
+
+def test_orphan_fix_race_session_gone_marks_fixed(tmp_path):
+    """kill-session racing with tmux auto-cleanup ('can't find session') counts as fixed."""
+    findings, _ = _run_orphan_fix_with_kill_result(
+        tmp_path,
+        kill_returncode=1,
+        kill_stderr="can't find session: auto-abcdef-builder-3\n",
+    )
+    assert len(findings) == 1
+    assert findings[0].fixed is True
+    assert "already gone" in findings[0].message
+
+
+def test_orphan_fix_race_no_server_marks_fixed(tmp_path):
+    """kill-session when tmux server has exited ('no server running') counts as fixed."""
+    findings, _ = _run_orphan_fix_with_kill_result(
+        tmp_path,
+        kill_returncode=1,
+        kill_stderr="no server running on /tmp/tmux-501/default\n",
+    )
+    assert len(findings) == 1
+    assert findings[0].fixed is True
+    assert "already gone" in findings[0].message
+
+
+def test_orphan_fix_genuine_failure_surfaces_stderr(tmp_path):
+    """Genuine kill failure surfaces stderr's first line and leaves fixed=False."""
+    findings, _ = _run_orphan_fix_with_kill_result(
+        tmp_path,
+        kill_returncode=1,
+        kill_stderr="permission denied\nother line\n",
+    )
+    assert len(findings) == 1
+    assert findings[0].fixed is False
+    assert "kill failed" in findings[0].message
+    assert "permission denied" in findings[0].message
+    # Only first line surfaced.
+    assert "other line" not in findings[0].message
+
+
+def test_orphan_fix_empty_stderr_nonzero_returncode(tmp_path):
+    """Nonzero exit with empty stderr surfaces returncode instead."""
+    findings, _ = _run_orphan_fix_with_kill_result(
+        tmp_path,
+        kill_returncode=2,
+        kill_stderr="",
+    )
+    assert len(findings) == 1
+    assert findings[0].fixed is False
+    assert "kill failed" in findings[0].message
+    assert "returncode=2" in findings[0].message
+
+
+def test_orphan_fix_success_regression(tmp_path):
+    """Regression guard: successful kill still marks fixed and does not annotate message."""
+    findings, own_orphan = _run_orphan_fix_with_kill_result(
+        tmp_path,
+        kill_returncode=0,
+        kill_stderr="",
+    )
+    assert len(findings) == 1
+    assert findings[0].fixed is True
+    # Message must match the original format exactly — no "already gone" / "kill failed" suffixes.
+    assert findings[0].message == f"orphan tmux session: {own_orphan} (no matching metadata)"
+
+
 def test_two_mock_colonies_dont_cross_see(tmp_path):
     """Two colonies with distinct data_dirs each see only their own orphans."""
     from unittest.mock import MagicMock, patch


### PR DESCRIPTION
## Summary
- Hardens `doctor.check_orphan_tmux_sessions` `--fix` path against the benign race where a tmux session exits between `list-sessions` and `kill-session`.
- Case-insensitive stderr match on tmux's own 'gone' strings (`can't find session`, `session not found`, `no server running`) → treat as `fixed=True`, annotate message with ` (already gone)`.
- On genuine kill failure, surfaces stderr's first line (or `returncode=N` when stderr is empty) as ` — kill failed: <detail>` so operators have a diagnostic instead of a silent `fixed=False`.
- No `Finding` schema change. `auto_fixable=True` retained (it classifies the finding, not the outcome).

## Test plan
- [x] `ruff check .` clean
- [x] `ruff format .` on touched files (no changes)
- [x] `pytest tests/ -x -q` — 898 passed
- [x] New tests in `tests/test_doctor.py`:
  - `test_orphan_fix_race_session_gone_marks_fixed`
  - `test_orphan_fix_race_no_server_marks_fixed`
  - `test_orphan_fix_genuine_failure_surfaces_stderr` (also asserts only first stderr line leaks through)
  - `test_orphan_fix_empty_stderr_nonzero_returncode`
  - `test_orphan_fix_success_regression` (regression guard: rc=0 path keeps original message verbatim)

## Scope
Touches only `antfarm/core/doctor.py` and `tests/test_doctor.py`. No unrelated reformatting.

Closes #236