### PR TITLE
fix(deploy): colony-scope tmux session names (#235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- `deploy.py` tmux session names are now colony-scoped with an 8-char hash of `(realpath(fleet_config) | colony_url)`. **Breaking:** pre-upgrade deploy sessions won't be found by `deploy status` — kill them manually via `tmux kill-session` and redeploy. (#235)
+
 ## [0.6.3] - 2026-04-16
 
 ### Changed

--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -1017,7 +1017,7 @@ def deploy(
     from antfarm.core.deploy import deploy_status
 
     if show_status:
-        status = deploy_status(fleet_config)
+        status = deploy_status(fleet_config, colony_url)
         for node_id, sessions in status.items():
             if sessions:
                 click.echo(f"{node_id}: {len(sessions)} session(s) running")

--- a/antfarm/core/deploy.py
+++ b/antfarm/core/deploy.py
@@ -8,10 +8,13 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import shlex
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
+
+from antfarm.core.process_manager import colony_hash
 
 logger = logging.getLogger(__name__)
 
@@ -47,15 +50,29 @@ def load_fleet_config(config_path: str) -> list[NodeConfig]:
     nodes = data if isinstance(data, list) else data.get("nodes", [])
     configs = []
     for entry in nodes:
-        configs.append(NodeConfig(
-            node_id=entry["node_id"],
-            host=entry["host"],
-            ssh_user=entry["ssh_user"],
-            repo_path=entry["repo_path"],
-            agent_type=entry["agent_type"],
-            count=entry.get("count", 1),
-        ))
+        configs.append(
+            NodeConfig(
+                node_id=entry["node_id"],
+                host=entry["host"],
+                ssh_user=entry["ssh_user"],
+                repo_path=entry["repo_path"],
+                agent_type=entry["agent_type"],
+                count=entry.get("count", 1),
+            )
+        )
     return configs
+
+
+def _colony_prefix(config_path: str, colony_url: str) -> str:
+    """Return the colony-scoped tmux session prefix for this deploy target.
+
+    The hash is taken over ``realpath(config_path) | colony_url`` so two deploys
+    pointed at different colonies (or different fleet configs) cannot collide on
+    session names — each colony sees only its own remote workers in
+    ``deploy --status``.
+    """
+    key = f"{os.path.realpath(config_path)}|{colony_url}"
+    return f"antfarm-{colony_hash(key)}"
 
 
 def _build_worker_command(
@@ -82,10 +99,12 @@ def _build_ssh_command(
     worker_index: int,
     colony_url: str,
     integration_branch: str,
+    config_path: str,
 ) -> list[str]:
     """Build the full SSH command that launches a worker in a tmux session."""
     worker_cmd = _build_worker_command(node, worker_index, colony_url, integration_branch)
-    session_name = f"antfarm-{node.node_id}-{node.agent_type}-{worker_index}"
+    prefix = _colony_prefix(config_path, colony_url)
+    session_name = f"{prefix}-{node.node_id}-{node.agent_type}-{worker_index}"
     # -A: attach-or-create to avoid duplicate session errors
     tmux_cmd = f"tmux new-session -A -d -s {shlex.quote(session_name)} {shlex.quote(worker_cmd)}"
     return [
@@ -109,65 +128,75 @@ def deploy(
 
     for node in nodes:
         for i in range(node.count):
-            ssh_cmd = _build_ssh_command(node, i, colony_url, integration_branch)
+            ssh_cmd = _build_ssh_command(node, i, colony_url, integration_branch, config_path)
             logger.info("Deploying worker %d to %s@%s", i, node.ssh_user, node.host)
             try:
                 subprocess.run(ssh_cmd, check=True, capture_output=True, text=True, timeout=30)
-                results.append(DeployResult(
-                    node_id=node.node_id,
-                    host=node.host,
-                    worker_index=i,
-                    success=True,
-                    message="Worker launched successfully",
-                ))
+                results.append(
+                    DeployResult(
+                        node_id=node.node_id,
+                        host=node.host,
+                        worker_index=i,
+                        success=True,
+                        message="Worker launched successfully",
+                    )
+                )
             except subprocess.CalledProcessError as e:
-                results.append(DeployResult(
-                    node_id=node.node_id,
-                    host=node.host,
-                    worker_index=i,
-                    success=False,
-                    message=f"SSH failed: {e.stderr.strip() or e.stdout.strip() or str(e)}",
-                ))
+                results.append(
+                    DeployResult(
+                        node_id=node.node_id,
+                        host=node.host,
+                        worker_index=i,
+                        success=False,
+                        message=f"SSH failed: {e.stderr.strip() or e.stdout.strip() or str(e)}",
+                    )
+                )
             except subprocess.TimeoutExpired:
-                results.append(DeployResult(
-                    node_id=node.node_id,
-                    host=node.host,
-                    worker_index=i,
-                    success=False,
-                    message="SSH connection timed out",
-                ))
+                results.append(
+                    DeployResult(
+                        node_id=node.node_id,
+                        host=node.host,
+                        worker_index=i,
+                        success=False,
+                        message="SSH connection timed out",
+                    )
+                )
 
     return results
 
 
-def _build_status_ssh_command(node: NodeConfig) -> list[str]:
-    """Build SSH command to list antfarm tmux sessions on a remote node."""
+def _build_status_ssh_command(node: NodeConfig, prefix: str) -> list[str]:
+    """Build SSH command to list this colony's antfarm tmux sessions on a remote node."""
+    # Grep is scoped to the colony-specific prefix so sessions for peer colonies
+    # deployed to the same host are not reported.
+    grep_pattern = f"^{prefix}-"
     return [
         "ssh",
         f"{node.ssh_user}@{node.host}",
-        "tmux list-sessions -F '#{session_name}' 2>/dev/null | grep '^antfarm-' || true",
+        f"tmux list-sessions -F '#{{session_name}}' 2>/dev/null | "
+        f"grep {shlex.quote(grep_pattern)} || true",
     ]
 
 
-def deploy_status(config_path: str) -> dict[str, list[str]]:
-    """Check which antfarm tmux sessions are running on each node.
+def deploy_status(
+    config_path: str,
+    colony_url: str = "http://localhost:7433",
+) -> dict[str, list[str]]:
+    """Check which antfarm tmux sessions for this colony are running on each node.
 
     Returns a dict mapping node_id to a list of active tmux session names.
+    Only sessions matching this colony's prefix are returned; sessions belonging
+    to peer colonies on the same host are filtered out at the remote ``grep``.
     """
     nodes = load_fleet_config(config_path)
+    prefix = _colony_prefix(config_path, colony_url)
     status: dict[str, list[str]] = {}
 
     for node in nodes:
-        ssh_cmd = _build_status_ssh_command(node)
+        ssh_cmd = _build_status_ssh_command(node, prefix)
         try:
-            result = subprocess.run(
-                ssh_cmd, capture_output=True, text=True, timeout=10
-            )
-            sessions = [
-                line.strip()
-                for line in result.stdout.strip().splitlines()
-                if line.strip()
-            ]
+            result = subprocess.run(ssh_cmd, capture_output=True, text=True, timeout=10)
+            sessions = [line.strip() for line in result.stdout.strip().splitlines() if line.strip()]
             status[node.node_id] = sessions
         except subprocess.TimeoutExpired:
             status[node.node_id] = []

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
+import re
 import subprocess
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,7 +16,9 @@ from antfarm.core.cli import main
 from antfarm.core.deploy import (
     NodeConfig,
     _build_ssh_command,
+    _build_status_ssh_command,
     _build_worker_command,
+    _colony_prefix,
     deploy,
     deploy_status,
     load_fleet_config,
@@ -120,12 +125,121 @@ def test_build_worker_command():
     assert "--integration-branch dev" in cmd
 
 
-def test_build_ssh_command():
+def test_build_ssh_command(fleet_config_file):
     node = NodeConfig("node-1", "10.0.0.1", "deploy", "/opt/antfarm", "claude-code", 1)
-    cmd = _build_ssh_command(node, 0, "http://colony:7433", "dev")
+    cmd = _build_ssh_command(node, 0, "http://colony:7433", "dev", fleet_config_file)
     assert cmd[0] == "ssh"
     assert cmd[1] == "deploy@10.0.0.1"
-    assert "tmux new-session -A -d -s antfarm-node-1-claude-code-0" in cmd[2]
+    prefix = _colony_prefix(fleet_config_file, "http://colony:7433")
+    assert f"tmux new-session -A -d -s {prefix}-node-1-claude-code-0" in cmd[2]
+
+
+# ---------------------------------------------------------------------------
+# Colony-scoped session naming (issue #235)
+# ---------------------------------------------------------------------------
+
+
+def test_session_name_includes_colony_hash(fleet_config_file):
+    """Session name embeds an 8-hex colony hash prefix, not bare ``antfarm-``."""
+    node = NodeConfig("node-1", "10.0.0.1", "deploy", "/opt/antfarm", "claude-code", 1)
+    cmd = _build_ssh_command(node, 0, "http://colony:7433", "dev", fleet_config_file)
+    # Expect antfarm-<8hex>-node-1-claude-code-0 somewhere in the tmux invocation.
+    assert re.search(r"antfarm-[0-9a-f]{8}-node-1-claude-code-0", cmd[2])
+
+
+def test_distinct_colony_urls_distinct_prefixes(fleet_config_file):
+    p1 = _colony_prefix(fleet_config_file, "http://colony-a:7433")
+    p2 = _colony_prefix(fleet_config_file, "http://colony-b:7433")
+    assert p1 != p2
+    assert p1.startswith("antfarm-") and p2.startswith("antfarm-")
+
+
+def test_distinct_config_paths_distinct_prefixes(tmp_path):
+    cfg_a = tmp_path / "a.json"
+    cfg_b = tmp_path / "b.json"
+    payload = json.dumps(
+        [
+            {
+                "node_id": "n",
+                "host": "h",
+                "ssh_user": "u",
+                "repo_path": "/r",
+                "agent_type": "a",
+            }
+        ]
+    )
+    cfg_a.write_text(payload)
+    cfg_b.write_text(payload)
+
+    p_a = _colony_prefix(str(cfg_a), "http://colony:7433")
+    p_b = _colony_prefix(str(cfg_b), "http://colony:7433")
+    assert p_a != p_b
+
+
+def test_prefix_is_deterministic(fleet_config_file):
+    p1 = _colony_prefix(fleet_config_file, "http://colony:7433")
+    p2 = _colony_prefix(fleet_config_file, "http://colony:7433")
+    assert p1 == p2
+
+
+@pytest.mark.skipif(sys.platform.startswith("win"), reason="POSIX symlinks only")
+def test_prefix_stable_across_symlinks(tmp_path):
+    """A symlink to the real config resolves to the same prefix."""
+    real = tmp_path / "real.json"
+    real.write_text(
+        json.dumps(
+            [
+                {
+                    "node_id": "n",
+                    "host": "h",
+                    "ssh_user": "u",
+                    "repo_path": "/r",
+                    "agent_type": "a",
+                }
+            ]
+        )
+    )
+    link = tmp_path / "link.json"
+    os.symlink(real, link)
+
+    p_real = _colony_prefix(str(real), "http://colony:7433")
+    p_link = _colony_prefix(str(link), "http://colony:7433")
+    assert p_real == p_link
+
+
+def test_status_filter_scopes_to_this_colony(fleet_config_file):
+    """Status command's grep pattern must be colony-specific, not ``^antfarm-``."""
+    node = NodeConfig("node-1", "10.0.0.1", "deploy", "/opt/antfarm", "claude-code", 1)
+    prefix = _colony_prefix(fleet_config_file, "http://colony:7433")
+    cmd = _build_status_ssh_command(node, prefix)
+    # Bare antfarm- match would be an escape hatch that leaks peer colonies.
+    assert f"^{prefix}-" in cmd[2]
+    assert "'^antfarm-'" not in cmd[2]
+
+
+@patch("antfarm.core.deploy.subprocess.run")
+def test_deploy_status_ignores_foreign_sessions(mock_run, fleet_config_file):
+    """deploy_status only reports this colony's sessions, not peer-colony ones.
+
+    The real filtering happens inside the remote grep; here we verify both that
+    the correct pattern is emitted and that the returned dict reflects only what
+    grep would pass through (sessions already prefixed with this colony's hash).
+    """
+    prefix = _colony_prefix(fleet_config_file, "http://colony:7433")
+    mock_run.side_effect = [
+        MagicMock(stdout=f"{prefix}-node-1-claude-code-0\n{prefix}-node-1-claude-code-1\n"),
+        MagicMock(stdout=f"{prefix}-node-2-generic-0\n"),
+    ]
+    status = deploy_status(fleet_config_file, "http://colony:7433")
+
+    assert len(status["node-1"]) == 2
+    assert all(s.startswith(prefix) for s in status["node-1"])
+    assert all(s.startswith(prefix) for s in status["node-2"])
+
+    # Verify the ssh command issued contained the colony-specific grep.
+    for call in mock_run.call_args_list:
+        ssh_args = call.args[0]
+        assert f"^{prefix}-" in ssh_args[2]
 
 
 # ---------------------------------------------------------------------------
@@ -146,9 +260,7 @@ def test_deploy_success(mock_run, fleet_config_file):
 
 @patch("antfarm.core.deploy.subprocess.run")
 def test_deploy_ssh_failure(mock_run, fleet_config_file):
-    mock_run.side_effect = subprocess.CalledProcessError(
-        1, "ssh", stderr="Connection refused"
-    )
+    mock_run.side_effect = subprocess.CalledProcessError(1, "ssh", stderr="Connection refused")
     results = deploy(fleet_config_file, "http://colony:7433", "dev")
 
     assert len(results) == 3
@@ -188,15 +300,16 @@ def test_deploy_partial_failure(mock_run, fleet_config_file):
 
 @patch("antfarm.core.deploy.subprocess.run")
 def test_deploy_status(mock_run, fleet_config_file):
+    prefix = _colony_prefix(fleet_config_file, "http://colony:7433")
     mock_run.side_effect = [
-        MagicMock(stdout="antfarm-node-1-claude-code-0\nantfarm-node-1-claude-code-1\n"),
-        MagicMock(stdout="antfarm-node-2-generic-0\n"),
+        MagicMock(stdout=f"{prefix}-node-1-claude-code-0\n{prefix}-node-1-claude-code-1\n"),
+        MagicMock(stdout=f"{prefix}-node-2-generic-0\n"),
     ]
-    status = deploy_status(fleet_config_file)
+    status = deploy_status(fleet_config_file, "http://colony:7433")
 
     assert len(status["node-1"]) == 2
     assert len(status["node-2"]) == 1
-    assert "antfarm-node-1-claude-code-0" in status["node-1"]
+    assert f"{prefix}-node-1-claude-code-0" in status["node-1"]
 
 
 @patch("antfarm.core.deploy.subprocess.run")
@@ -233,7 +346,9 @@ def test_cli_deploy(mock_run, fleet_config_file):
 
 @patch("antfarm.core.deploy.subprocess.run")
 def test_cli_deploy_status(mock_run, fleet_config_file):
-    mock_run.return_value = MagicMock(stdout="antfarm-node-1-claude-code-0\n")
+    # CLI default colony-url is localhost:7433; reproduce the same prefix here.
+    prefix = _colony_prefix(fleet_config_file, "http://localhost:7433")
+    mock_run.return_value = MagicMock(stdout=f"{prefix}-node-1-claude-code-0\n")
     runner = CliRunner()
     result = runner.invoke(main, ["deploy", "--status", "--fleet-config", fleet_config_file])
     assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- `deploy.py` tmux session names now embed an 8-char SHA-256 hash of `(realpath(fleet_config) | colony_url)`, preventing name collisions and cross-colony leakage on shared hosts.
- `deploy --status` grep is scoped to this colony's prefix, so peer-colony sessions are filtered at the remote shell.
- `deploy_status()` takes a `colony_url` argument (default `http://localhost:7433`); CLI threads `--colony-url` through.

## Background
Before this change, every deploy produced sessions named `antfarm-<node>-<agent>-<N>` — a flat namespace shared across all colonies. Two colonies pointed at the same remote would collide on session names, and `deploy --status` for colony A would report colony B's sessions. Mirrors the v0.6.3 approach from #231 but keyed on `(fleet_config, colony_url)` instead of `data_dir`, since deploy has no `data_dir` handle.

## Breaking change
Pre-upgrade deploy sessions lack the hash prefix and become invisible to `deploy --status`. Operators should `tmux kill-session -t <name>` them manually on each remote and redeploy.

## Test plan
- [x] New unit tests for colony hash prefix: deterministic, distinct per colony_url, distinct per config_path, stable across symlinks
- [x] New test confirming status grep is colony-scoped (not bare `^antfarm-`)
- [x] New test confirming `deploy_status` filters out foreign sessions
- [x] Existing deploy tests updated for the new signature
- [x] `ruff check .` clean
- [x] Full suite: 905 passed

Closes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)