### PR TITLE
feat(worker): per-worker current-action visibility (#239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- Per-worker current-action visibility: `POST /workers/{id}/activity`, TUI Activity column with elapsed time, and doctor `check_stuck_workers` warning for workers idle on an action > 5 min. (#239)
+
 ### Changed
 - `deploy.py` tmux session names are now colony-scoped with an 8-char hash of `(realpath(fleet_config) | colony_url)`. **Breaking:** pre-upgrade deploy sessions won't be found by `deploy status` — kill them manually via `tmux kill-session` and redeploy. (#235)
 

--- a/antfarm/adapters/claude_code/hooks/post_tool.sh
+++ b/antfarm/adapters/claude_code/hooks/post_tool.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
-# PostToolUse hook: clear the worker's current action once the tool returns.
-curl -s -m 1 "$ANTFARM_URL/workers/$WORKER_ID/activity" -X POST \
-  -H "Content-Type: application/json" \
-  -d '{"action": null}' || true
+# PostToolUse hook: clear worker activity.
+# Claude Code fires pre/post hooks per top-level tool use, serially.
+# Nested operations happen inside the tool process and do not re-fire hooks,
+# so we don't need to worry about clearing too early.
+set -u
+: "${ANTFARM_URL:?}"
+: "${WORKER_ID:?}"
+
+curl -s -m 1 "$ANTFARM_URL/workers/$WORKER_ID/activity" \
+  -X POST -H "Content-Type: application/json" -d '{"action": null}' || true

--- a/antfarm/adapters/claude_code/hooks/post_tool.sh
+++ b/antfarm/adapters/claude_code/hooks/post_tool.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# PostToolUse hook: clear the worker's current action once the tool returns.
+curl -s -m 1 "$ANTFARM_URL/workers/$WORKER_ID/activity" -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"action": null}' || true

--- a/antfarm/adapters/claude_code/hooks/pre_tool.sh
+++ b/antfarm/adapters/claude_code/hooks/pre_tool.sh
@@ -1,11 +1,27 @@
 #!/usr/bin/env bash
-# PreToolUse hook: post the worker's current action before each tool call.
-#
-# TODO: CLAUDE_TOOL_NAME is the presumed env var exposed by Claude Code's
-# PreToolUse hook — verify against the Claude Code hook contract when
-# integrating. The fallback value "tool" keeps the hook harmless if the
-# variable name differs.
-ACTION="Running: ${CLAUDE_TOOL_NAME:-tool}"
-curl -s -m 1 "$ANTFARM_URL/workers/$WORKER_ID/activity" -X POST \
-  -H "Content-Type: application/json" \
-  -d "{\"action\": \"$ACTION\"}" || true
+# PreToolUse hook: post worker activity before each tool call.
+# Claude Code delivers hook context as JSON on stdin.
+# See: https://docs.claude.ai/en/docs/claude-code/hooks (PreToolUse)
+set -u
+: "${ANTFARM_URL:?}"
+: "${WORKER_ID:?}"
+
+# Read stdin (may be empty if invoked outside a hook context — fallback to "tool")
+INPUT=$(cat 2>/dev/null || echo "")
+if command -v jq >/dev/null 2>&1 && [ -n "$INPUT" ]; then
+  TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // "tool"' 2>/dev/null || echo "tool")
+else
+  TOOL_NAME="tool"
+fi
+ACTION="Running: $TOOL_NAME"
+
+# Use jq to build a safely-quoted JSON payload.
+if command -v jq >/dev/null 2>&1; then
+  PAYLOAD=$(jq -nc --arg a "$ACTION" '{action:$a}')
+else
+  # Fallback: best-effort shell-quoted JSON (tool names are alphanumeric in practice).
+  PAYLOAD="{\"action\": \"$ACTION\"}"
+fi
+
+curl -s -m 1 "$ANTFARM_URL/workers/$WORKER_ID/activity" \
+  -X POST -H "Content-Type: application/json" -d "$PAYLOAD" || true

--- a/antfarm/adapters/claude_code/hooks/pre_tool.sh
+++ b/antfarm/adapters/claude_code/hooks/pre_tool.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# PreToolUse hook: post the worker's current action before each tool call.
+#
+# TODO: CLAUDE_TOOL_NAME is the presumed env var exposed by Claude Code's
+# PreToolUse hook — verify against the Claude Code hook contract when
+# integrating. The fallback value "tool" keeps the hook harmless if the
+# variable name differs.
+ACTION="Running: ${CLAUDE_TOOL_NAME:-tool}"
+curl -s -m 1 "$ANTFARM_URL/workers/$WORKER_ID/activity" -X POST \
+  -H "Content-Type: application/json" \
+  -d "{\"action\": \"$ACTION\"}" || true

--- a/antfarm/adapters/claude_code/setup.sh
+++ b/antfarm/adapters/claude_code/setup.sh
@@ -41,14 +41,27 @@ for agent_md in "${ADAPTER_DIR}/agents/"*.md; do
   fi
 done
 
-# 3. Add heartbeat PostToolUse hook to .claude/settings.json
+# 3. Add heartbeat + activity hooks to .claude/settings.json
 HEARTBEAT_CMD="${ADAPTER_DIR}/hooks/heartbeat.sh"
+PRE_TOOL_CMD="${ADAPTER_DIR}/hooks/pre_tool.sh"
+POST_TOOL_CMD="${ADAPTER_DIR}/hooks/post_tool.sh"
 
 if [ ! -f "${SETTINGS_FILE}" ]; then
-  # Create a minimal settings.json with the heartbeat hook
+  # Create a minimal settings.json with heartbeat + activity hooks
   cat > "${SETTINGS_FILE}" <<EOF
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${PRE_TOOL_CMD}"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "",
@@ -56,6 +69,10 @@ if [ ! -f "${SETTINGS_FILE}" ]; then
           {
             "type": "command",
             "command": "${HEARTBEAT_CMD}"
+          },
+          {
+            "type": "command",
+            "command": "${POST_TOOL_CMD}"
           }
         ]
       }
@@ -63,9 +80,9 @@ if [ ! -f "${SETTINGS_FILE}" ]; then
   }
 }
 EOF
-  echo "[created] ${SETTINGS_FILE} with heartbeat hook"
+  echo "[created] ${SETTINGS_FILE} with heartbeat + activity hooks"
 else
-  # Check if heartbeat is already present
+  # Heartbeat already present?
   if grep -q "heartbeat.sh" "${SETTINGS_FILE}" 2>/dev/null; then
     echo "[exists]  heartbeat hook already in ${SETTINGS_FILE}"
   else
@@ -79,6 +96,17 @@ else
     echo '          }'
     echo ""
   fi
+
+  # Activity hooks already present?
+  if grep -q "pre_tool.sh" "${SETTINGS_FILE}" 2>/dev/null; then
+    echo "[exists]  activity hooks already in ${SETTINGS_FILE}"
+  else
+    echo ""
+    echo "[manual]  activity hooks NOT added automatically — settings.json already exists."
+    echo "          Add a PreToolUse entry pointing to ${PRE_TOOL_CMD}"
+    echo "          and an additional PostToolUse entry pointing to ${POST_TOOL_CMD}."
+    echo ""
+  fi
 fi
 
 echo ""
@@ -87,6 +115,7 @@ echo "  .claude/agents/worker.md   — worker agent (forage → implement → ha
 echo "  .claude/agents/soldier.md  — v0.2 placeholder (conflict resolution)"
 echo "  .claude/agents/queen.md    — example: AI-driven task decomposition"
 echo "  PostToolUse heartbeat hook — keeps worker slot alive automatically"
+echo "  PreToolUse/PostToolUse activity hooks — surface current worker action in TUI"
 echo ""
 echo "Set environment variables before starting a worker session:"
 echo "  export ANTFARM_URL=http://localhost:8000"

--- a/antfarm/core/backends/base.py
+++ b/antfarm/core/backends/base.py
@@ -96,9 +96,7 @@ class TaskBackend(ABC):
         ...
 
     @abstractmethod
-    def kickback(
-        self, task_id: str, reason: str, max_attempts: int = 3
-    ) -> None:
+    def kickback(self, task_id: str, reason: str, max_attempts: int = 3) -> None:
         """Transition task to READY (or BLOCKED if attempts exhausted).
 
         Sets current_attempt to None. Next pull() creates a fresh attempt.
@@ -134,9 +132,7 @@ class TaskBackend(ABC):
         ...
 
     @abstractmethod
-    def store_review_verdict(
-        self, task_id: str, attempt_id: str, verdict: dict
-    ) -> None:
+    def store_review_verdict(self, task_id: str, attempt_id: str, verdict: dict) -> None:
         """Store a ReviewVerdict on the task's current attempt.
 
         Args:
@@ -421,6 +417,21 @@ class TaskBackend(ABC):
         Args:
             worker_id: ID of the worker sending the heartbeat.
             status: Status dict to persist (e.g. current task, state).
+        """
+        ...
+
+    @abstractmethod
+    def update_worker_activity(self, worker_id: str, action: str | None) -> None:
+        """Set current_action / current_action_at on the worker file.
+
+        action=None or empty string clears the activity. Server stamps timestamp.
+        Long actions are trimmed to a bounded length. This does not touch
+        ``last_heartbeat``. Unknown workers are a silent no-op so pre-tool-use
+        hooks firing before registration cannot disrupt the control plane.
+
+        Args:
+            worker_id: ID of the worker whose activity is being updated.
+            action: Short description of what the worker is doing, or None to clear.
         """
         ...
 

--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -370,9 +370,7 @@ class FileBackend(TaskBackend):
             self._write_json(active_path, data)
             os.rename(active_path, done_path)
 
-    def kickback(
-        self, task_id: str, reason: str, max_attempts: int = 3
-    ) -> None:
+    def kickback(self, task_id: str, reason: str, max_attempts: int = 3) -> None:
         """Move task from done/ to ready/ or blocked/ if max attempts exhausted.
 
         Soldier calls kickback after a failed integration merge. The task
@@ -419,21 +417,16 @@ class FileBackend(TaskBackend):
             finished = sum(
                 1
                 for a in data["attempts"]
-                if a["status"]
-                in (AttemptStatus.DONE.value, AttemptStatus.SUPERSEDED.value)
+                if a["status"] in (AttemptStatus.DONE.value, AttemptStatus.SUPERSEDED.value)
             )
 
             if finished >= effective_max:
-                assert_task_transition(
-                    data["status"], TaskStatus.BLOCKED.value
-                )
+                assert_task_transition(data["status"], TaskStatus.BLOCKED.value)
                 data["status"] = TaskStatus.BLOCKED.value
                 self._write_json(done_path, data)
                 os.rename(done_path, self._blocked_path(task_id))
             else:
-                assert_task_transition(
-                    data["status"], TaskStatus.READY.value
-                )
+                assert_task_transition(data["status"], TaskStatus.READY.value)
                 data["status"] = TaskStatus.READY.value
                 self._write_json(done_path, data)
                 os.rename(done_path, self._ready_path(task_id))
@@ -464,9 +457,7 @@ class FileBackend(TaskBackend):
             data["updated_at"] = _now_iso()
             self._write_json(active_path, data)
 
-    def store_review_verdict(
-        self, task_id: str, attempt_id: str, verdict: dict
-    ) -> None:
+    def store_review_verdict(self, task_id: str, attempt_id: str, verdict: dict) -> None:
         """Store a ReviewVerdict on the task's current attempt in done/."""
         with self._lock:
             done_path = self._done_path(task_id)
@@ -526,9 +517,7 @@ class FileBackend(TaskBackend):
         with self._lock:
             path = self._find_task_path(review_task_id)
             if path is None:
-                raise FileNotFoundError(
-                    f"Review task '{review_task_id}' not found"
-                )
+                raise FileNotFoundError(f"Review task '{review_task_id}' not found")
 
             data = self._read_json(path)
             now = _now_iso()
@@ -545,9 +534,7 @@ class FileBackend(TaskBackend):
                 data["current_attempt"] = None
 
             # Normalize touches: trim + dedupe (preserve case)
-            data["touches"] = list(
-                dict.fromkeys(t.strip() for t in (touches or []))
-            )
+            data["touches"] = list(dict.fromkeys(t.strip() for t in (touches or [])))
             data["spec"] = new_spec
 
             trail_entry = TrailEntry(
@@ -937,6 +924,27 @@ class FileBackend(TaskBackend):
         data["last_heartbeat"] = _now_iso()
         self._write_json(worker_path, data)
         # Touch to ensure mtime reflects now (write_json via replace does this)
+
+    def update_worker_activity(self, worker_id: str, action: str | None) -> None:
+        """Set current_action / current_action_at on the worker file.
+
+        Does not update ``last_heartbeat`` — activity is a separate signal so a
+        worker stuck on a tool call can be flagged even while heartbeating.
+        Silently no-ops if the worker file does not exist so early hook firings
+        cannot interfere with registration flow.
+        """
+        worker_path = self._worker_path(worker_id)
+        with self._lock:
+            if not worker_path.exists():
+                return
+            data = self._read_json(worker_path)
+            if action is None or action == "":
+                data["current_action"] = None
+                data["current_action_at"] = None
+            else:
+                data["current_action"] = action[:200]
+                data["current_action_at"] = _now_iso()
+            self._write_json(worker_path, data)
 
     # ------------------------------------------------------------------
     # Workers (list)

--- a/antfarm/core/backends/github.py
+++ b/antfarm/core/backends/github.py
@@ -42,8 +42,7 @@ from .base import TaskBackend
 
 _GITHUB_API = "https://api.github.com"
 _GITHUB_BACKEND_MSG = (
-    "Mission mode requires FileBackend in v0.6.0. "
-    "Use --backend file or wait for v0.6.1."
+    "Mission mode requires FileBackend in v0.6.0. Use --backend file or wait for v0.6.1."
 )
 _SPEC_FENCE_OPEN = "<!-- antfarm-spec\n"
 _SPEC_FENCE_CLOSE = "\n-->"
@@ -189,11 +188,15 @@ class GitHubBackend(TaskBackend):
             self._api("GET", f"/labels/{name}")
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code == 404:
-                self._api("POST", "/labels", json={
-                    "name": name,
-                    "color": "0075ca",
-                    "description": f"Antfarm managed label: {name}",
-                })
+                self._api(
+                    "POST",
+                    "/labels",
+                    json={
+                        "name": name,
+                        "color": "0075ca",
+                        "description": f"Antfarm managed label: {name}",
+                    },
+                )
             else:
                 raise
 
@@ -228,11 +231,14 @@ class GitHubBackend(TaskBackend):
 
     def _find_issues_by_label(self, label: str, state: str = "open") -> list[dict]:
         """List issues with a specific label."""
-        return self._paginated_get("/issues", {
-            "labels": label,
-            "state": state,
-            "per_page": 100,
-        })
+        return self._paginated_get(
+            "/issues",
+            {
+                "labels": label,
+                "state": state,
+                "per_page": 100,
+            },
+        )
 
     def _issue_to_task(self, issue: dict) -> dict:
         """Parse a GitHub Issue dict into an Antfarm task dict.
@@ -353,11 +359,15 @@ class GitHubBackend(TaskBackend):
         self._ensure_label(ready_label)
 
         body = _render_body(task)
-        self._api("POST", "/issues", json={
-            "title": task.get("title", task_id),
-            "body": body,
-            "labels": [ready_label],
-        })
+        self._api(
+            "POST",
+            "/issues",
+            json={
+                "title": task.get("title", task_id),
+                "body": body,
+                "labels": [ready_label],
+            },
+        )
         return task_id
 
     def pull(self, worker_id: str) -> dict | None:
@@ -623,17 +633,13 @@ class GitHubBackend(TaskBackend):
         self._api("PATCH", f"/issues/{issue_number}", json={"state": "closed"})
         self._add_comment(issue_number, "[merged] Task merged successfully.")
 
-    def store_review_verdict(
-        self, task_id: str, attempt_id: str, verdict: dict
-    ) -> None:
+    def store_review_verdict(self, task_id: str, attempt_id: str, verdict: dict) -> None:
         """Store a ReviewVerdict on the task's current attempt."""
         task, issue_number = self._get_task_issue(task_id)
         if issue_number is None:
             raise FileNotFoundError(f"Task '{task_id}' not found")
         if task.get("current_attempt") != attempt_id:
-            raise ValueError(
-                f"attempt_id '{attempt_id}' is not the current attempt"
-            )
+            raise ValueError(f"attempt_id '{attempt_id}' is not the current attempt")
         for a in task["attempts"]:
             if a["attempt_id"] == attempt_id:
                 a["review_verdict"] = verdict
@@ -717,9 +723,7 @@ class GitHubBackend(TaskBackend):
         self._ensure_label(ready_label)
         self._swap_labels(issue_number, ["active"], "ready")
 
-        self._close_superseded_pr(
-            superseded_attempt, f"task reassigned to {worker_id}"
-        )
+        self._close_superseded_pr(superseded_attempt, f"task reassigned to {worker_id}")
 
     def block_task(self, task_id: str, reason: str) -> None:
         """Block a ready task. Swap label ready -> blocked."""
@@ -924,6 +928,20 @@ class GitHubBackend(TaskBackend):
             self._workers[worker_id] = {"worker_id": worker_id}
         self._workers[worker_id].update(status)
         self._workers[worker_id]["last_heartbeat"] = _now_iso()
+
+    def update_worker_activity(self, worker_id: str, action: str | None) -> None:
+        """Set current_action / current_action_at on the worker record.
+
+        Silently no-ops for unknown worker IDs. Does not touch last_heartbeat.
+        """
+        if worker_id not in self._workers:
+            return
+        if action is None or action == "":
+            self._workers[worker_id]["current_action"] = None
+            self._workers[worker_id]["current_action_at"] = None
+        else:
+            self._workers[worker_id]["current_action"] = action[:200]
+            self._workers[worker_id]["current_action_at"] = _now_iso()
 
     def list_workers(self) -> list[dict]:
         """Return all registered workers."""

--- a/antfarm/core/doctor.py
+++ b/antfarm/core/doctor.py
@@ -50,6 +50,7 @@ def run_doctor(backend, config: dict, fix: bool = False) -> list[Finding]:
     findings.extend(check_colony_reachable(config))
     findings.extend(check_git_config())
     findings.extend(check_stale_workers(backend, config, fix))
+    findings.extend(check_stuck_workers(backend, config, fix))
     findings.extend(check_stale_tasks(backend, config, fix))
     findings.extend(check_stale_guards(backend, config, fix))
     findings.extend(check_workspace_conflicts(backend))
@@ -295,6 +296,87 @@ def check_stale_workers(backend, config: dict, fix: bool = False) -> list[Findin
         except FileNotFoundError:
             # File disappeared between glob and stat
             continue
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Check 4b: Stuck workers (fresh heartbeat, stale current_action_at)
+# ---------------------------------------------------------------------------
+
+
+def check_stuck_workers(backend, config: dict, fix: bool = False) -> list[Finding]:
+    """Flag workers whose current_action has been in flight longer than stuck_ttl.
+
+    A worker is "stuck" when its heartbeat is fresh (so it is not a stale
+    worker) but its ``current_action_at`` is older than ``stuck_ttl`` seconds.
+    This means the worker is still alive but has been executing a single tool
+    call (or other activity) for too long — usually a symptom of a hung
+    subprocess, a network-pegged tool, or an agent spinning on a stuck loop.
+
+    This check never auto-fixes. It emits a warning so operators can
+    investigate or kill the worker manually.
+
+    Args:
+        backend: TaskBackend instance.
+        config: Doctor config dict; ``stuck_ttl`` (default 300) controls the
+            threshold in seconds. ``worker_ttl`` (default 300) determines
+            whether heartbeat is considered fresh.
+        fix: Unused — stuck workers are not auto-fixable.
+
+    Returns:
+        List of findings, one per stuck worker.
+    """
+    del fix  # unused; stuck workers are reported, not auto-fixed
+    findings: list[Finding] = []
+    data_dir = Path(config["data_dir"])
+    stuck_ttl = config.get("stuck_ttl", 300)
+    worker_ttl = config.get("worker_ttl", 300)
+    workers_dir = data_dir / "workers"
+
+    if not workers_dir.exists():
+        return findings
+
+    now = datetime.now(UTC)
+    now_ts = now.timestamp()
+    for worker_file in workers_dir.glob("*.json"):
+        try:
+            stat = os.stat(str(worker_file))
+            heartbeat_age = now_ts - stat.st_mtime
+            if heartbeat_age > worker_ttl:
+                # Already caught by check_stale_workers — don't double-report
+                continue
+            with open(str(worker_file)) as fh:
+                data = json.load(fh)
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            continue
+
+        action = data.get("current_action")
+        action_at = data.get("current_action_at")
+        if not action or not action_at:
+            continue
+
+        try:
+            start = datetime.fromisoformat(action_at)
+            if start.tzinfo is None:
+                start = start.replace(tzinfo=UTC)
+            elapsed = int((now - start).total_seconds())
+        except (ValueError, TypeError):
+            continue
+
+        if elapsed > stuck_ttl:
+            worker_id = data.get("worker_id", worker_file.stem)
+            findings.append(
+                Finding(
+                    severity="warning",
+                    check="stuck_worker",
+                    message=(
+                        f"Worker {worker_id!r} stuck on '{action}' for {elapsed}s "
+                        f"(threshold={stuck_ttl}s)"
+                    ),
+                    auto_fixable=False,
+                )
+            )
 
     return findings
 

--- a/antfarm/core/models.py
+++ b/antfarm/core/models.py
@@ -489,6 +489,8 @@ class Worker:
     status: WorkerStatus = WorkerStatus.IDLE
     capabilities: list[str] = field(default_factory=list)
     cooldown_until: str | None = None
+    current_action: str | None = None
+    current_action_at: str | None = None
 
     def to_dict(self) -> dict:
         return {
@@ -501,6 +503,8 @@ class Worker:
             "registered_at": self.registered_at,
             "last_heartbeat": self.last_heartbeat,
             "cooldown_until": self.cooldown_until,
+            "current_action": self.current_action,
+            "current_action_at": self.current_action_at,
         }
 
     @classmethod
@@ -515,6 +519,8 @@ class Worker:
             registered_at=data["registered_at"],
             last_heartbeat=data["last_heartbeat"],
             cooldown_until=data.get("cooldown_until"),
+            current_action=data.get("current_action"),
+            current_action_at=data.get("current_action_at"),
         )
 
 

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -245,6 +245,10 @@ class HeartbeatRequest(BaseModel):
     cooldown_until: str | None = None
 
 
+class ActivityRequest(BaseModel):
+    action: str | None = None
+
+
 class PullRequest(BaseModel):
     worker_id: str
 
@@ -479,6 +483,16 @@ def get_app(
         if req.cooldown_until is not None or "cooldown_until" not in (req.status or {}):
             update["cooldown_until"] = req.cooldown_until
         _backend.heartbeat(worker_id, update)
+        return {"ok": True}
+
+    @app.post("/workers/{worker_id:path}/activity", status_code=200)
+    def worker_activity(worker_id: str, req: ActivityRequest):
+        """Set or clear the worker's current action.
+
+        Does not update last_heartbeat — activity is a separate signal. Unknown
+        workers are a silent no-op at the backend layer.
+        """
+        _backend.update_worker_activity(worker_id, req.action)
         return {"ok": True}
 
     @app.get("/workers", status_code=200)

--- a/antfarm/core/tui.py
+++ b/antfarm/core/tui.py
@@ -116,6 +116,7 @@ class AntfarmTUI:
         banner.append("      ", style="dim")
         banner.append(line2, style="bold dark_orange")
         from antfarm.core import __version__
+
         banner.append(f"\n v{__version__}", style="bold bright_white")
         layout["header"]["banner"].update(Panel(banner))
 
@@ -180,8 +181,7 @@ class AntfarmTUI:
             Panel(
                 self._render_awaiting_review(snap.awaiting_review),
                 title=(
-                    f"[bold magenta]Awaiting Review"
-                    f" ({len(snap.awaiting_review)})[/bold magenta]"
+                    f"[bold magenta]Awaiting Review ({len(snap.awaiting_review)})[/bold magenta]"
                 ),
             )
         )
@@ -202,10 +202,7 @@ class AntfarmTUI:
         layout["merged"].update(
             Panel(
                 self._render_recently_merged(snap.recently_merged),
-                title=(
-                    f"[bold green]Recently Merged"
-                    f" ({len(snap.recently_merged)})[/bold green]"
-                ),
+                title=(f"[bold green]Recently Merged ({len(snap.recently_merged)})[/bold green]"),
             )
         )
 
@@ -267,9 +264,7 @@ class AntfarmTUI:
 
     def _is_kicked_back(self, task: dict) -> bool:
         """Check if task has a superseded attempt (was kicked back)."""
-        return any(
-            attempt.get("status") == "superseded" for attempt in task.get("attempts", [])
-        )
+        return any(attempt.get("status") == "superseded" for attempt in task.get("attempts", []))
 
     def _get_verdict(self, task: dict) -> dict | None:
         """Get review verdict from current attempt."""
@@ -283,9 +278,7 @@ class AntfarmTUI:
 
     def _has_merged_attempt(self, task: dict) -> bool:
         """Check if any attempt has status=merged."""
-        return any(
-            attempt.get("status") == "merged" for attempt in task.get("attempts", [])
-        )
+        return any(attempt.get("status") == "merged" for attempt in task.get("attempts", []))
 
     def _get_worker_for_task(self, task: dict) -> str:
         """Get worker_id from current attempt."""
@@ -688,9 +681,7 @@ class AntfarmTUI:
         self._add_overflow_hint(table, len(tasks), max_shown)
         return table
 
-    def _render_awaiting_review(
-        self, tasks: list[dict], max_shown: int = 8
-    ) -> Table:
+    def _render_awaiting_review(self, tasks: list[dict], max_shown: int = 8) -> Table:
         """Render tasks awaiting review."""
         table = Table(show_header=True, header_style="bold", box=None, padding=(0, 1))
         table.add_column("ID", max_width=20, no_wrap=True)
@@ -803,6 +794,31 @@ class AntfarmTUI:
             return "reviewer"
         return "builder"
 
+    def _format_activity_cell(self, worker: dict, stuck_ttl: int = 300) -> Text:
+        """Format the Activity column cell for a worker row.
+
+        Returns a Rich Text object rendering '<action[:40]> (<N>s)' when the
+        worker has a current_action, dim em-dash when it does not, and red
+        when the elapsed time exceeds stuck_ttl.
+        """
+        action = worker.get("current_action")
+        action_at = worker.get("current_action_at")
+        if not action or not action_at:
+            return Text("—", style="dim")
+
+        try:
+            start = datetime.fromisoformat(action_at)
+            if start.tzinfo is None:
+                start = start.replace(tzinfo=UTC)
+            elapsed = int((datetime.now(UTC) - start).total_seconds())
+        except (ValueError, TypeError):
+            return Text(str(action)[:40], style="dim")
+
+        truncated = action[:40]
+        label = f"{truncated} ({elapsed}s)"
+        style = "red" if elapsed > stuck_ttl else ""
+        return Text(label, style=style)
+
     def _render_workers(self, workers: list, soldier_status: str = "unknown") -> Table:
         """Render worker list with type column, including Soldier."""
         table = Table(show_header=True, header_style="bold", box=None, padding=(0, 1))
@@ -810,6 +826,7 @@ class AntfarmTUI:
         table.add_column("Node", max_width=15, no_wrap=True)
         table.add_column("Status", max_width=10, no_wrap=True)
         table.add_column("Type", max_width=10, no_wrap=True)
+        table.add_column("Activity", max_width=50, no_wrap=True)
         table.add_column("Rate Limit", max_width=20, no_wrap=True)
 
         # Soldier row (virtual — it's a thread, not a registered worker)
@@ -821,10 +838,11 @@ class AntfarmTUI:
                 Text(soldier_status, style=s_style),
                 Text("soldier", style="bold"),
                 Text("—", style="dim"),
+                Text("—", style="dim"),
             )
 
         if not workers and soldier_status == "disabled":
-            table.add_row("[dim]\u2014[/dim]", "[dim]no workers[/dim]", "", "", "")
+            table.add_row("[dim]\u2014[/dim]", "[dim]no workers[/dim]", "", "", "", "")
             return table
 
         for worker in workers:
@@ -857,11 +875,14 @@ class AntfarmTUI:
             else:
                 type_text = Text("builder", style="yellow")
 
+            activity_text = self._format_activity_cell(worker)
+
             table.add_row(
                 Text(worker_id[:20], style="cyan"),
                 Text(node_id[:13], style="dim"),
                 status_text,
                 type_text,
+                activity_text,
                 rate_text,
             )
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -128,6 +128,78 @@ def test_stale_worker_fixed(setup):
 
 
 # ---------------------------------------------------------------------------
+# Stuck worker checks (#239)
+# ---------------------------------------------------------------------------
+
+
+def test_stuck_worker_detected(setup):
+    """Fresh heartbeat + stale current_action_at emits a stuck_worker warning."""
+    backend, config = setup
+    backend.register_worker(_make_worker("worker-stuck"))
+
+    # Simulate an activity set in the past by writing directly into the worker file.
+    worker_file = Path(config["data_dir"]) / "workers" / "worker-stuck.json"
+    data = json.loads(worker_file.read_text())
+    stale_ts = datetime.now(UTC).timestamp() - 600
+    data["current_action"] = "Running: Bash"
+    data["current_action_at"] = datetime.fromtimestamp(stale_ts, tz=UTC).isoformat()
+    worker_file.write_text(json.dumps(data))
+    # Keep heartbeat fresh: touch mtime to now so check_stale_workers doesn't fire.
+    now = time.time()
+    os.utime(str(worker_file), (now, now))
+
+    findings = run_doctor(backend, config, fix=False)
+    stuck = [f for f in findings if f.check == "stuck_worker"]
+    assert len(stuck) == 1
+    assert "worker-stuck" in stuck[0].message
+    assert "Running: Bash" in stuck[0].message
+    assert stuck[0].severity == "warning"
+    assert stuck[0].auto_fixable is False
+    assert stuck[0].fixed is False
+
+
+def test_stuck_worker_not_detected_when_recent(setup):
+    """Action set recently does not trigger the stuck_worker check."""
+    backend, config = setup
+    backend.register_worker(_make_worker("worker-ok"))
+    backend.update_worker_activity("worker-ok", "Running: Bash")
+
+    findings = run_doctor(backend, config, fix=False)
+    stuck = [f for f in findings if f.check == "stuck_worker"]
+    assert stuck == []
+
+
+def test_stuck_worker_not_detected_without_action(setup):
+    """Worker without current_action is never stuck."""
+    backend, config = setup
+    backend.register_worker(_make_worker("worker-idle"))
+
+    findings = run_doctor(backend, config, fix=False)
+    stuck = [f for f in findings if f.check == "stuck_worker"]
+    assert stuck == []
+
+
+def test_stuck_worker_not_double_reported_when_heartbeat_also_stale(setup):
+    """A worker with stale heartbeat is only reported as stale, not also stuck."""
+    backend, config = setup
+    backend.register_worker(_make_worker("worker-dead"))
+
+    worker_file = Path(config["data_dir"]) / "workers" / "worker-dead.json"
+    data = json.loads(worker_file.read_text())
+    data["current_action"] = "Running: Bash"
+    data["current_action_at"] = datetime.fromtimestamp(time.time() - 600, tz=UTC).isoformat()
+    worker_file.write_text(json.dumps(data))
+    # Backdate heartbeat mtime — stale worker
+    _backdate(worker_file, seconds=1200)
+
+    findings = run_doctor(backend, config, fix=False)
+    stale = [f for f in findings if f.check == "stale_worker"]
+    stuck = [f for f in findings if f.check == "stuck_worker"]
+    assert len(stale) == 1
+    assert stuck == []
+
+
+# ---------------------------------------------------------------------------
 # 4. test_stale_task_detected
 # ---------------------------------------------------------------------------
 

--- a/tests/test_file_backend.py
+++ b/tests/test_file_backend.py
@@ -382,6 +382,77 @@ def test_heartbeat_updates(backend: FileBackend) -> None:
 
 
 # ---------------------------------------------------------------------------
+# update_worker_activity (#239)
+# ---------------------------------------------------------------------------
+
+
+def _register_test_worker(backend: FileBackend, worker_id: str = "worker-1") -> None:
+    now = datetime.now(UTC).isoformat()
+    backend.register_worker(
+        {
+            "worker_id": worker_id,
+            "node_id": "node-1",
+            "agent_type": "engineer",
+            "workspace_root": "/tmp/ws",
+            "registered_at": now,
+            "last_heartbeat": now,
+        }
+    )
+
+
+def test_update_worker_activity_sets_fields(backend: FileBackend) -> None:
+    _register_test_worker(backend)
+    backend.update_worker_activity("worker-1", "Running: Bash")
+    data = json.loads(backend._worker_path("worker-1").read_text())
+    assert data["current_action"] == "Running: Bash"
+    assert data["current_action_at"] is not None
+
+
+def test_update_worker_activity_clear_with_none(backend: FileBackend) -> None:
+    _register_test_worker(backend)
+    backend.update_worker_activity("worker-1", "Running: Bash")
+    backend.update_worker_activity("worker-1", None)
+    data = json.loads(backend._worker_path("worker-1").read_text())
+    assert data["current_action"] is None
+    assert data["current_action_at"] is None
+
+
+def test_update_worker_activity_clear_with_empty_string(backend: FileBackend) -> None:
+    _register_test_worker(backend)
+    backend.update_worker_activity("worker-1", "Running: Bash")
+    backend.update_worker_activity("worker-1", "")
+    data = json.loads(backend._worker_path("worker-1").read_text())
+    assert data["current_action"] is None
+    assert data["current_action_at"] is None
+
+
+def test_update_worker_activity_trims_long(backend: FileBackend) -> None:
+    _register_test_worker(backend)
+    long_action = "x" * 500
+    backend.update_worker_activity("worker-1", long_action)
+    data = json.loads(backend._worker_path("worker-1").read_text())
+    assert len(data["current_action"]) == 200
+    assert data["current_action"] == "x" * 200
+
+
+def test_update_worker_activity_missing_worker_noop(backend: FileBackend) -> None:
+    # No worker registered — must not raise, must not create file.
+    backend.update_worker_activity("ghost-worker", "Running: Bash")
+    assert not backend._worker_path("ghost-worker").exists()
+
+
+def test_update_worker_activity_does_not_bump_heartbeat(backend: FileBackend) -> None:
+    _register_test_worker(backend)
+    original = json.loads(backend._worker_path("worker-1").read_text())
+    original_hb = original["last_heartbeat"]
+    # Give the clock room so timestamps would differ if heartbeat were bumped.
+    time.sleep(0.01)
+    backend.update_worker_activity("worker-1", "Running: Bash")
+    after = json.loads(backend._worker_path("worker-1").read_text())
+    assert after["last_heartbeat"] == original_hb
+
+
+# ---------------------------------------------------------------------------
 # Bug fix regression tests
 # ---------------------------------------------------------------------------
 
@@ -629,17 +700,19 @@ def test_pull_returns_none_for_rate_limited_worker(backend: FileBackend) -> None
 
     # Register the worker with a future cooldown
     future = (datetime.now(UTC) + timedelta(hours=1)).isoformat()
-    backend.register_worker({
-        "worker_id": "worker-rl",
-        "node_id": "node-1",
-        "agent_type": "claude-code",
-        "workspace_root": "/tmp/ws",
-        "capabilities": [],
-        "status": "idle",
-        "registered_at": datetime.now(UTC).isoformat(),
-        "last_heartbeat": datetime.now(UTC).isoformat(),
-        "cooldown_until": future,
-    })
+    backend.register_worker(
+        {
+            "worker_id": "worker-rl",
+            "node_id": "node-1",
+            "agent_type": "claude-code",
+            "workspace_root": "/tmp/ws",
+            "capabilities": [],
+            "status": "idle",
+            "registered_at": datetime.now(UTC).isoformat(),
+            "last_heartbeat": datetime.now(UTC).isoformat(),
+            "cooldown_until": future,
+        }
+    )
 
     result = backend.pull("worker-rl")
     assert result is None
@@ -652,17 +725,19 @@ def test_pull_succeeds_after_cooldown_expires(backend: FileBackend) -> None:
     backend.carry(_make_task("task-1"))
 
     past = (datetime.now(UTC) - timedelta(hours=1)).isoformat()
-    backend.register_worker({
-        "worker_id": "worker-past",
-        "node_id": "node-1",
-        "agent_type": "claude-code",
-        "workspace_root": "/tmp/ws",
-        "capabilities": [],
-        "status": "idle",
-        "registered_at": datetime.now(UTC).isoformat(),
-        "last_heartbeat": datetime.now(UTC).isoformat(),
-        "cooldown_until": past,
-    })
+    backend.register_worker(
+        {
+            "worker_id": "worker-past",
+            "node_id": "node-1",
+            "agent_type": "claude-code",
+            "workspace_root": "/tmp/ws",
+            "capabilities": [],
+            "status": "idle",
+            "registered_at": datetime.now(UTC).isoformat(),
+            "last_heartbeat": datetime.now(UTC).isoformat(),
+            "cooldown_until": past,
+        }
+    )
 
     result = backend.pull("worker-past")
     assert result is not None
@@ -685,16 +760,18 @@ def test_list_workers_returns_all(backend: FileBackend) -> None:
 
     now = datetime.now(UTC).isoformat()
     for i in range(3):
-        backend.register_worker({
-            "worker_id": f"worker-{i}",
-            "node_id": "node-1",
-            "agent_type": "claude-code",
-            "workspace_root": f"/tmp/ws-{i}",
-            "capabilities": [],
-            "status": "idle",
-            "registered_at": now,
-            "last_heartbeat": now,
-        })
+        backend.register_worker(
+            {
+                "worker_id": f"worker-{i}",
+                "node_id": "node-1",
+                "agent_type": "claude-code",
+                "workspace_root": f"/tmp/ws-{i}",
+                "capabilities": [],
+                "status": "idle",
+                "registered_at": now,
+                "last_heartbeat": now,
+            }
+        )
 
     workers = backend.list_workers()
     assert len(workers) == 3
@@ -765,8 +842,15 @@ def test_old_state_loads_with_new_lifecycle(tmp_path: Path) -> None:
     ready_dir = data_dir / "tasks" / "ready"
     ready_dir.mkdir(parents=True)
     # Create minimal required dirs
-    for d in ["tasks/active", "tasks/done", "tasks/paused", "tasks/blocked",
-              "workers", "nodes", "guards"]:
+    for d in [
+        "tasks/active",
+        "tasks/done",
+        "tasks/paused",
+        "tasks/blocked",
+        "workers",
+        "nodes",
+        "guards",
+    ]:
         (data_dir / d).mkdir(parents=True, exist_ok=True)
 
     old_task = {
@@ -798,16 +882,18 @@ def test_old_state_loads_with_new_lifecycle(tmp_path: Path) -> None:
     assert tasks[0]["id"] == "task-old"
 
     # Should be pullable
-    backend.register_worker({
-        "worker_id": "w1",
-        "node_id": "n1",
-        "agent_type": "generic",
-        "workspace_root": "/tmp",
-        "capabilities": [],
-        "status": "idle",
-        "registered_at": "2026-01-01T00:00:00Z",
-        "last_heartbeat": "2026-01-01T00:00:00Z",
-    })
+    backend.register_worker(
+        {
+            "worker_id": "w1",
+            "node_id": "n1",
+            "agent_type": "generic",
+            "workspace_root": "/tmp",
+            "capabilities": [],
+            "status": "idle",
+            "registered_at": "2026-01-01T00:00:00Z",
+            "last_heartbeat": "2026-01-01T00:00:00Z",
+        }
+    )
     result = backend.pull("w1")
     assert result is not None
     assert result["id"] == "task-old"
@@ -879,9 +965,7 @@ def _kickback_cycle(backend: FileBackend, task_id: str) -> None:
     backend.kickback(task_id, reason="tests failed", max_attempts=3)
 
 
-def test_kickback_blocks_after_max_attempts(
-    backend: FileBackend, tmp_path: Path
-) -> None:
+def test_kickback_blocks_after_max_attempts(backend: FileBackend, tmp_path: Path) -> None:
     """After max_attempts kickbacks, task transitions to blocked/."""
     backend.carry(_make_task("task-1"))
 
@@ -896,17 +980,13 @@ def test_kickback_blocks_after_max_attempts(
     pulled = backend.pull("worker-1")
     assert pulled is not None
     attempt_id = pulled["current_attempt"]
-    backend.mark_harvested(
-        "task-1", attempt_id, pr="pr", branch="branch"
-    )
+    backend.mark_harvested("task-1", attempt_id, pr="pr", branch="branch")
     backend.kickback("task-1", reason="tests failed again", max_attempts=3)
 
     task = backend.get_task("task-1")
     assert task is not None
     assert task["status"] == TaskStatus.BLOCKED.value
-    blocked_file = (
-        tmp_path / ".antfarm" / "tasks" / "blocked" / "task-1.json"
-    )
+    blocked_file = tmp_path / ".antfarm" / "tasks" / "blocked" / "task-1.json"
     assert blocked_file.exists()
 
 
@@ -974,15 +1054,11 @@ def test_unblock_does_not_reset_attempt_counter(
     attempt_id = pulled["current_attempt"]
     backend.mark_harvested("task-1", attempt_id, pr="pr", branch="branch")
     backend.kickback("task-1", reason="fail", max_attempts=1)
-    assert (
-        backend.get_task("task-1")["status"] == TaskStatus.BLOCKED.value
-    )
+    assert backend.get_task("task-1")["status"] == TaskStatus.BLOCKED.value
 
     # Unblock it
     backend.unblock_task("task-1")
-    assert (
-        backend.get_task("task-1")["status"] == TaskStatus.READY.value
-    )
+    assert backend.get_task("task-1")["status"] == TaskStatus.READY.value
 
     # Another cycle should block again since attempts still counted
     pulled = backend.pull("worker-1")
@@ -990,9 +1066,7 @@ def test_unblock_does_not_reset_attempt_counter(
     attempt_id = pulled["current_attempt"]
     backend.mark_harvested("task-1", attempt_id, pr="pr", branch="branch")
     backend.kickback("task-1", reason="fail again", max_attempts=1)
-    assert (
-        backend.get_task("task-1")["status"] == TaskStatus.BLOCKED.value
-    )
+    assert backend.get_task("task-1")["status"] == TaskStatus.BLOCKED.value
 
 
 # ---------------------------------------------------------------------------
@@ -1285,4 +1359,3 @@ def test_kickback_does_not_hold_lock_during_pr_close(tmp_path: Path) -> None:
     backend.kickback("task-1", reason="tests failed")
 
     assert probe.acquired, "kickback held self._lock during PR close (deadlock risk)"
-

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -125,6 +125,34 @@ def test_worker_roundtrip():
     assert Worker.from_dict(worker.to_dict()) == worker
 
 
+def test_worker_roundtrip_with_activity_fields():
+    worker = _make_worker()
+    worker.current_action = "Running: Bash"
+    worker.current_action_at = "2026-04-16T10:05:00+00:00"
+    d = worker.to_dict()
+    assert d["current_action"] == "Running: Bash"
+    assert d["current_action_at"] == "2026-04-16T10:05:00+00:00"
+    assert Worker.from_dict(d) == worker
+
+
+def test_worker_roundtrip_missing_activity_fields():
+    """Pre-upgrade worker JSON without current_action* still loads with None defaults."""
+    data = {
+        "worker_id": "w-1",
+        "node_id": "node-1",
+        "agent_type": "engineer",
+        "workspace_root": "/tmp/ws",
+        "status": "active",
+        "capabilities": [],
+        "registered_at": "2026-04-04T08:00:00Z",
+        "last_heartbeat": "2026-04-04T10:00:00Z",
+        "cooldown_until": None,
+    }
+    worker = Worker.from_dict(data)
+    assert worker.current_action is None
+    assert worker.current_action_at is None
+
+
 def test_node_roundtrip():
     node = _make_node()
     assert Node.from_dict(node.to_dict()) == node

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -378,12 +378,11 @@ def test_scent_new_entries(tmp_path):
         assert r.status_code == 200
         for line in r.iter_lines():
             if line.startswith("data: "):
-                entry = json.loads(line[len("data: "):])
+                entry = json.loads(line[len("data: ") :])
                 messages.append(entry.get("message", ""))
 
     t.join(timeout=5)
     assert "late entry" in messages
-
 
 
 def test_carry_with_capabilities_and_pull_with_capable_worker(tmp_path):
@@ -594,6 +593,62 @@ def test_heartbeat_without_rate_limit_fields(client):
 
 
 # ---------------------------------------------------------------------------
+# Worker activity endpoint (#239)
+# ---------------------------------------------------------------------------
+
+
+def test_activity_endpoint_stamps_timestamp(client):
+    """POST /workers/{id}/activity sets current_action and current_action_at."""
+    _register_worker(client, "worker-act")
+    r = client.post(
+        "/workers/worker-act/activity",
+        json={"action": "Running: Bash"},
+    )
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+
+    workers = client.get("/workers").json()
+    worker = next(w for w in workers if w["worker_id"] == "worker-act")
+    assert worker["current_action"] == "Running: Bash"
+    assert worker["current_action_at"] is not None
+
+
+def test_activity_endpoint_clears_with_null(client):
+    """POST /workers/{id}/activity with null action clears both fields."""
+    _register_worker(client, "worker-act")
+    client.post("/workers/worker-act/activity", json={"action": "Running: Bash"})
+    client.post("/workers/worker-act/activity", json={"action": None})
+
+    worker = next(w for w in client.get("/workers").json() if w["worker_id"] == "worker-act")
+    assert worker["current_action"] is None
+    assert worker["current_action_at"] is None
+
+
+def test_activity_independent_from_heartbeat(client):
+    """Activity endpoint must not touch last_heartbeat."""
+    _register_worker(client, "worker-act")
+    before = next(w for w in client.get("/workers").json() if w["worker_id"] == "worker-act")
+    original_hb = before["last_heartbeat"]
+
+    import time as _time
+
+    _time.sleep(0.01)
+    r = client.post("/workers/worker-act/activity", json={"action": "Running: Bash"})
+    assert r.status_code == 200
+
+    after = next(w for w in client.get("/workers").json() if w["worker_id"] == "worker-act")
+    assert after["last_heartbeat"] == original_hb
+
+
+def test_activity_endpoint_unknown_worker_noop(client):
+    """Unknown worker is a silent 200 no-op (never creates a worker record)."""
+    r = client.post("/workers/ghost-worker/activity", json={"action": "Running: Bash"})
+    assert r.status_code == 200
+    # No worker record should have been created
+    assert client.get("/workers").json() == []
+
+
+# ---------------------------------------------------------------------------
 # Rate limit: GET /workers endpoint
 # ---------------------------------------------------------------------------
 
@@ -711,37 +766,35 @@ def test_from_backend_idempotent_review_creation(tmp_path):
     from antfarm.core.soldier import Soldier
 
     backend = FileBackend(root=str(tmp_path / ".antfarm"))
-    soldier = Soldier.from_backend(
-        backend, repo_path=str(tmp_path), require_review=True
-    )
+    soldier = Soldier.from_backend(backend, repo_path=str(tmp_path), require_review=True)
 
     # Carry a task, forage, and harvest it manually
     from datetime import UTC, datetime
 
     now = datetime.now(UTC).isoformat()
-    backend.carry({
-        "id": "task-001",
-        "title": "Test",
-        "spec": "spec",
-        "complexity": "M",
-        "priority": 10,
-        "depends_on": [],
-        "touches": [],
-        "capabilities_required": [],
-        "created_by": "test",
-        "status": "ready",
-        "current_attempt": None,
-        "attempts": [],
-        "trail": [],
-        "signals": [],
-        "created_at": now,
-        "updated_at": now,
-    })
+    backend.carry(
+        {
+            "id": "task-001",
+            "title": "Test",
+            "spec": "spec",
+            "complexity": "M",
+            "priority": 10,
+            "depends_on": [],
+            "touches": [],
+            "capabilities_required": [],
+            "created_by": "test",
+            "status": "ready",
+            "current_attempt": None,
+            "attempts": [],
+            "trail": [],
+            "signals": [],
+            "created_at": now,
+            "updated_at": now,
+        }
+    )
     task = backend.pull("worker-1")
     assert task is not None
-    backend.mark_harvested(
-        "task-001", task["current_attempt"], "pr-url", "feat/branch"
-    )
+    backend.mark_harvested("task-001", task["current_attempt"], "pr-url", "feat/branch")
 
     # Create review task
     done_task = backend.get_task("task-001")
@@ -789,7 +842,7 @@ def test_sse_events_on_harvest(tmp_path):
         events = []
         for line in r.iter_lines():
             if line.startswith("data: "):
-                events.append(json_mod.loads(line[len("data: "):]))
+                events.append(json_mod.loads(line[len("data: ") :]))
 
     assert len(events) >= 1
     assert events[0]["type"] == "harvested"

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -70,8 +70,7 @@ def _task(
 
 def test_classify_building():
     tui = _make_tui()
-    tasks = [_task(status="active", current_attempt="att-001",
-                   attempts=[_attempt()])]
+    tasks = [_task(status="active", current_attempt="att-001", attempts=[_attempt()])]
     snap = tui._classify_tasks(tasks)
     assert len(snap.building) == 1
     assert len(snap.under_review) == 0
@@ -94,9 +93,11 @@ def test_classify_awaiting_review():
 
 def test_classify_under_review():
     tui = _make_tui()
-    tasks = [_task(task_id="review-001", status="active",
-                   current_attempt="att-001",
-                   attempts=[_attempt()])]
+    tasks = [
+        _task(
+            task_id="review-001", status="active", current_attempt="att-001", attempts=[_attempt()]
+        )
+    ]
     snap = tui._classify_tasks(tasks)
     assert len(snap.under_review) == 1
     assert len(snap.building) == 0
@@ -112,8 +113,7 @@ def test_classify_merge_ready():
 
 def test_classify_planning():
     tui = _make_tui()
-    t = _task(status="active", current_attempt="att-001",
-              attempts=[_attempt()])
+    t = _task(status="active", current_attempt="att-001", attempts=[_attempt()])
     t["capabilities_required"] = ["plan"]
     tasks = [t]
     snap = tui._classify_tasks(tasks)
@@ -123,8 +123,9 @@ def test_classify_planning():
 
 def test_classify_waiting_rework():
     tui = _make_tui()
-    att = _attempt(attempt_id="att-001", status="superseded",
-                   completed_at="2026-04-05T01:00:00+00:00")
+    att = _attempt(
+        attempt_id="att-001", status="superseded", completed_at="2026-04-05T01:00:00+00:00"
+    )
     tasks = [_task(status="ready", attempts=[att])]
     snap = tui._classify_tasks(tasks)
     assert len(snap.waiting_rework) == 1
@@ -143,12 +144,18 @@ def test_classify_review_task_not_in_building():
     """A review task that is active should be in under_review, not building."""
     tui = _make_tui()
     tasks = [
-        _task(task_id="review-task", status="active",
-              current_attempt="att-r",
-              attempts=[_attempt(attempt_id="att-r")]),
-        _task(task_id="build-task", status="active",
-              current_attempt="att-b",
-              attempts=[_attempt(attempt_id="att-b")]),
+        _task(
+            task_id="review-task",
+            status="active",
+            current_attempt="att-r",
+            attempts=[_attempt(attempt_id="att-r")],
+        ),
+        _task(
+            task_id="build-task",
+            status="active",
+            current_attempt="att-b",
+            attempts=[_attempt(attempt_id="att-b")],
+        ),
     ]
     snap = tui._classify_tasks(tasks)
     assert len(snap.building) == 1
@@ -269,9 +276,15 @@ def test_get_time_since_harvested_no_completed():
 
 def test_pipeline_bar_renders():
     tui = _make_tui()
-    counts = {"plan": 0, "building": 3, "waiting": 2, "merged": 5,
-              "awaiting_review": 0, "under_review": 0,
-              "merge_ready": 1}
+    counts = {
+        "plan": 0,
+        "building": 3,
+        "waiting": 2,
+        "merged": 5,
+        "awaiting_review": 0,
+        "under_review": 0,
+        "merge_ready": 1,
+    }
     result = tui._render_pipeline_bar(counts)
     assert isinstance(result, Text)
     assert len(str(result)) > 0
@@ -279,18 +292,30 @@ def test_pipeline_bar_renders():
 
 def test_pipeline_bar_empty():
     tui = _make_tui()
-    counts = {"plan": 0, "building": 0, "waiting": 0, "merged": 0,
-              "awaiting_review": 0, "under_review": 0,
-              "merge_ready": 0}
+    counts = {
+        "plan": 0,
+        "building": 0,
+        "waiting": 0,
+        "merged": 0,
+        "awaiting_review": 0,
+        "under_review": 0,
+        "merge_ready": 0,
+    }
     result = tui._render_pipeline_bar(counts)
     assert "no tasks" in str(result)
 
 
 def test_pipeline_bar_uses_wt_abbreviation():
     tui = _make_tui()
-    counts = {"plan": 0, "building": 1, "waiting": 3, "merged": 0,
-              "awaiting_review": 0, "under_review": 0,
-              "merge_ready": 0}
+    counts = {
+        "plan": 0,
+        "building": 1,
+        "waiting": 3,
+        "merged": 0,
+        "awaiting_review": 0,
+        "under_review": 0,
+        "merge_ready": 0,
+    }
     result = tui._render_pipeline_bar(counts)
     text_str = str(result)
     assert "wt:3" in text_str
@@ -352,9 +377,12 @@ def test_render_building_empty():
 
 def test_render_building_populated():
     tui = _make_tui()
-    t = _task(status="active", current_attempt="att-001",
-              attempts=[_attempt()],
-              trail=[{"ts": "2026-01-01T00:00:00", "worker_id": "w1", "message": "working"}])
+    t = _task(
+        status="active",
+        current_attempt="att-001",
+        attempts=[_attempt()],
+        trail=[{"ts": "2026-01-01T00:00:00", "worker_id": "w1", "message": "working"}],
+    )
     result = tui._render_building([t])
     assert isinstance(result, Table)
     assert result.row_count == 1
@@ -441,8 +469,11 @@ def test_render_merge_ready_empty():
 
 def test_render_merge_ready_populated():
     tui = _make_tui()
-    att = _attempt(review_verdict={"result": "pass", "freshness": "fresh"},
-                   status="done", completed_at="2026-04-05T01:00:00+00:00")
+    att = _attempt(
+        review_verdict={"result": "pass", "freshness": "fresh"},
+        status="done",
+        completed_at="2026-04-05T01:00:00+00:00",
+    )
     t = _task(status="done", current_attempt="att-001", attempts=[att])
     result = tui._render_merge_ready([t])
     assert isinstance(result, Table)
@@ -458,9 +489,12 @@ def test_render_planning_empty():
 
 def test_render_planning_populated():
     tui = _make_tui()
-    t = _task(status="active", current_attempt="att-001",
-              attempts=[_attempt()],
-              trail=[{"ts": "2026-01-01T00:00:00", "worker_id": "w1", "message": "planning"}])
+    t = _task(
+        status="active",
+        current_attempt="att-001",
+        attempts=[_attempt()],
+        trail=[{"ts": "2026-01-01T00:00:00", "worker_id": "w1", "message": "planning"}],
+    )
     t["capabilities_required"] = ["plan"]
     result = tui._render_planning([t])
     assert isinstance(result, Table)
@@ -487,10 +521,12 @@ def test_render_recently_merged_limits_to_5():
     tui = _make_tui()
     tasks = []
     for i in range(8):
-        att = _attempt(attempt_id=f"att-{i}", status="merged",
-                       completed_at="2026-04-05T01:00:00+00:00")
-        tasks.append(_task(task_id=f"task-{i}", status="done",
-                           current_attempt=f"att-{i}", attempts=[att]))
+        att = _attempt(
+            attempt_id=f"att-{i}", status="merged", completed_at="2026-04-05T01:00:00+00:00"
+        )
+        tasks.append(
+            _task(task_id=f"task-{i}", status="done", current_attempt=f"att-{i}", attempts=[att])
+        )
     result = tui._render_recently_merged(tasks)
     assert isinstance(result, Table)
     # 5 shown + 1 overflow hint row
@@ -506,8 +542,12 @@ def test_overflow_hint_building():
     """Building panel should show overflow hint when more than max_shown tasks."""
     tui = _make_tui()
     tasks = [
-        _task(task_id=f"task-{i}", status="active", current_attempt=f"att-{i}",
-              attempts=[_attempt(attempt_id=f"att-{i}")])
+        _task(
+            task_id=f"task-{i}",
+            status="active",
+            current_attempt=f"att-{i}",
+            attempts=[_attempt(attempt_id=f"att-{i}")],
+        )
         for i in range(7)
     ]
     result = tui._render_building(tasks, max_shown=5)
@@ -520,9 +560,15 @@ def test_overflow_hint_awaiting_review():
     """Awaiting review uses max_shown=8 by default."""
     tui = _make_tui()
     tasks = [
-        _task(task_id=f"task-{i}", current_attempt=f"att-{i}",
-              attempts=[_attempt(attempt_id=f"att-{i}", status="done",
-                                 completed_at="2026-04-05T01:00:00+00:00")])
+        _task(
+            task_id=f"task-{i}",
+            current_attempt=f"att-{i}",
+            attempts=[
+                _attempt(
+                    attempt_id=f"att-{i}", status="done", completed_at="2026-04-05T01:00:00+00:00"
+                )
+            ],
+        )
         for i in range(10)
     ]
     result = tui._render_awaiting_review(tasks)
@@ -552,10 +598,69 @@ def test_render_workers_empty():
     assert result.row_count == 1
 
 
+def test_format_activity_cell_no_action_shows_dash():
+    tui = _make_tui()
+    cell = tui._format_activity_cell({})
+    assert cell.plain == "—"
+    assert cell.style == "dim"
+
+
+def test_format_activity_cell_fresh_action_includes_elapsed():
+    from datetime import UTC, datetime
+
+    tui = _make_tui()
+    now_iso = datetime.now(UTC).isoformat()
+    cell = tui._format_activity_cell(
+        {"current_action": "Running: Bash", "current_action_at": now_iso}
+    )
+    assert cell.plain.startswith("Running: Bash (")
+    assert cell.plain.endswith("s)")
+    # Fresh elapsed time should not be rendered red
+    assert cell.style != "red"
+
+
+def test_format_activity_cell_stale_action_is_red():
+    from datetime import UTC, datetime, timedelta
+
+    tui = _make_tui()
+    old_iso = (datetime.now(UTC) - timedelta(seconds=600)).isoformat()
+    cell = tui._format_activity_cell(
+        {"current_action": "Running: Bash", "current_action_at": old_iso},
+        stuck_ttl=300,
+    )
+    assert "Running: Bash" in cell.plain
+    assert cell.style == "red"
+
+
+def test_format_activity_cell_truncates_long_action():
+    from datetime import UTC, datetime
+
+    tui = _make_tui()
+    now_iso = datetime.now(UTC).isoformat()
+    long_action = "X" * 100
+    cell = tui._format_activity_cell({"current_action": long_action, "current_action_at": now_iso})
+    # Activity is truncated to 40 chars in the UI before the "(Ns)" suffix
+    assert cell.plain.startswith("X" * 40 + " (")
+
+
+def test_render_workers_table_has_activity_column():
+    tui = _make_tui()
+    result = tui._render_workers([], soldier_status="disabled")
+    headers = [c.header for c in result.columns]
+    assert "Activity" in headers
+
+
 def test_render_workers_type_column_builder():
     tui = _make_tui()
-    workers = [{"worker_id": "n1/w1", "status": "idle", "node_id": "n1",
-                "agent_type": "claude-code", "rate_limited": False}]
+    workers = [
+        {
+            "worker_id": "n1/w1",
+            "status": "idle",
+            "node_id": "n1",
+            "agent_type": "claude-code",
+            "rate_limited": False,
+        }
+    ]
     result = tui._render_workers(workers, soldier_status="disabled")
     assert isinstance(result, Table)
     assert result.row_count == 1
@@ -563,8 +668,15 @@ def test_render_workers_type_column_builder():
 
 def test_render_workers_type_column_reviewer():
     tui = _make_tui()
-    workers = [{"worker_id": "n1/r1", "status": "busy", "node_id": "n1",
-                "agent_type": "claude-code-review", "rate_limited": False}]
+    workers = [
+        {
+            "worker_id": "n1/r1",
+            "status": "busy",
+            "node_id": "n1",
+            "agent_type": "claude-code-review",
+            "rate_limited": False,
+        }
+    ]
     result = tui._render_workers(workers, soldier_status="disabled")
     assert isinstance(result, Table)
     assert result.row_count == 1
@@ -589,8 +701,10 @@ def test_get_worker_type_reviewer_by_agent_type():
 
 def test_get_worker_type_reviewer_by_capability():
     tui = _make_tui()
-    assert tui._get_worker_type({"agent_type": "claude-code",
-                                  "capabilities": ["review"]}) == "reviewer"
+    assert (
+        tui._get_worker_type({"agent_type": "claude-code", "capabilities": ["review"]})
+        == "reviewer"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -628,15 +742,24 @@ def test_tui_mission_panel_renders_multi():
     """Multiple missions render with correct row count."""
     tui = _make_tui()
     missions = [
-        _mission(mission_id="mission-auth", status="building",
-                 task_ids=["t1", "t2", "t3", "t4", "t5", "t6"],
-                 report={"merged_tasks": 4}),
-        _mission(mission_id="mission-api-v2", status="complete",
-                 task_ids=["t1", "t2", "t3", "t4"],
-                 report={"merged_tasks": 4}),
-        _mission(mission_id="mission-migrate", status="blocked",
-                 task_ids=["t1", "t2", "t3", "t4", "t5"],
-                 blocked_task_ids=["t3"]),
+        _mission(
+            mission_id="mission-auth",
+            status="building",
+            task_ids=["t1", "t2", "t3", "t4", "t5", "t6"],
+            report={"merged_tasks": 4},
+        ),
+        _mission(
+            mission_id="mission-api-v2",
+            status="complete",
+            task_ids=["t1", "t2", "t3", "t4"],
+            report={"merged_tasks": 4},
+        ),
+        _mission(
+            mission_id="mission-migrate",
+            status="blocked",
+            task_ids=["t1", "t2", "t3", "t4", "t5"],
+            blocked_task_ids=["t3"],
+        ),
     ]
     result = tui._render_missions(missions)
     assert isinstance(result, Table)
@@ -648,19 +771,13 @@ def test_tui_mission_panel_formats_progress_time():
     tui = _make_tui()
 
     # Complete mission -> "done"
-    assert tui._format_mission_progress(
-        _mission(status="complete")
-    ) == "done"
+    assert tui._format_mission_progress(_mission(status="complete")) == "done"
 
     # Failed mission -> "done"
-    assert tui._format_mission_progress(
-        _mission(status="failed")
-    ) == "done"
+    assert tui._format_mission_progress(_mission(status="failed")) == "done"
 
     # Cancelled mission -> "done"
-    assert tui._format_mission_progress(
-        _mission(status="cancelled")
-    ) == "done"
+    assert tui._format_mission_progress(_mission(status="cancelled")) == "done"
 
     # Blocked mission -> "stalled <time>"
     result = tui._format_mission_progress(
@@ -675,9 +792,7 @@ def test_tui_mission_panel_formats_progress_time():
     assert result.endswith(" ago")
 
     # No last_progress_at -> "--"
-    assert tui._format_mission_progress(
-        _mission(status="building", last_progress_at="")
-    ) == "--"
+    assert tui._format_mission_progress(_mission(status="building", last_progress_at="")) == "--"
 
 
 def test_tui_mission_panel_shows_blocked_count():


### PR DESCRIPTION
## Summary

- Adds `current_action` / `current_action_at` to `Worker` and a new `POST /workers/{id}/activity` endpoint so workers can publish a short, best-effort description of what they're doing right now.
- TUI workers table gets an "Activity" column showing `<action[:40]> (<N>s)`, dim when empty, red when elapsed exceeds 300s.
- Doctor gains `check_stuck_workers` — a warning-severity check (not auto-fixable) that flags workers idle on the same action longer than `config["stuck_ttl"]` (default 300s), while carefully avoiding double-reporting with `check_stale_workers`.
- Claude Code adapter gets `pre_tool.sh` / `post_tool.sh` hooks wired into `setup.sh` so activity is published before each tool call and cleared after.

Design notes:
- `update_worker_activity` is under the backend lock and does NOT bump `last_heartbeat` — activity and liveness are independent.
- Unknown worker IDs are a silent no-op (endpoint still returns 200) to keep hooks robust during worker lifecycle edges.
- `current_action` is trimmed to 200 chars on the backend; the TUI further trims the displayed prefix to 40 chars.
- `None` or empty string clears the action (both fields go to `null`).

## Test plan

- [x] `ruff check .` — clean
- [x] `pytest tests/ -x -q` — 926 passed (+21 new tests across models, file_backend, serve, doctor, tui)
- [ ] Manual: `antfarm tui` against a colony with a worker posting activity — verify column renders, elapsed increments, and turns red past threshold
- [ ] Manual: `antfarm doctor` after a worker hangs on an action — verify `stuck_worker` warning (and that a worker whose heartbeat is also stale is only reported once, by `check_stale_workers`)

### Open question

The Claude Code `pre_tool.sh` hook currently uses `${CLAUDE_TOOL_NAME:-tool}`. The env var name is a best-guess placeholder — a `TODO` comment in the hook flags this. Worth verifying against the Claude Code hooks docs before we rely on the tool name being meaningful; falls back to `"Running: tool"` if unset.

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)