### PR TITLE
fix(tui): actionable message when colony is unreachable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Added
 - Per-worker current-action visibility: `POST /workers/{id}/activity`, TUI Activity column with elapsed time, and doctor `check_stuck_workers` warning for workers idle on an action > 5 min. (#239)
 
+### Fixed
+- TUI now shows actionable guidance when the colony is unreachable, including the attempted URL and commands to start/redirect. (#246)
+
 ### Changed
 - `deploy.py` tmux session names are now colony-scoped with an 8-char hash of `(realpath(fleet_config) | colony_url)`. **Breaking:** pre-upgrade deploy sessions won't be found by `deploy status` — kill them manually via `tmux kill-session` and redeploy. (#235)
 

--- a/antfarm/core/tui.py
+++ b/antfarm/core/tui.py
@@ -73,6 +73,17 @@ class AntfarmTUI:
             tasks = full.get("tasks", [])
             workers = full.get("workers", [])
             soldier_status = full.get("soldier", "unknown")
+        except httpx.ConnectError:
+            layout = Layout()
+            msg = (
+                f"[red]Can't reach colony at {self.colony_url} — is it running?[/red]\n\n"
+                f"[bold]Start the colony on this host:[/bold]\n"
+                f"    antfarm colony\n\n"
+                f"[bold]Or point the TUI elsewhere:[/bold]\n"
+                f"    antfarm scout --tui --colony-url http://<host>:<port>"
+            )
+            layout.update(Panel(msg, title="Antfarm TUI"))
+            return layout
         except Exception as exc:
             layout = Layout()
             layout.update(Panel(f"[red]Connection error: {exc}[/red]", title="Antfarm TUI"))

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -4,6 +4,7 @@ Tests classification, helpers, render methods, and pipeline bar
 without any live terminal or network I/O.
 """
 
+import httpx
 from rich.table import Table
 from rich.text import Text
 
@@ -817,3 +818,41 @@ def test_tui_mission_panel_overflow():
     assert isinstance(result, Table)
     # 5 shown + 1 overflow hint
     assert result.row_count == 6
+
+
+# ---------------------------------------------------------------------------
+# Connection error handling
+# ---------------------------------------------------------------------------
+
+
+def test_tui_shows_hint_on_connect_error(monkeypatch):
+    """ConnectError shows actionable guidance with URL and commands."""
+    tui = _make_tui()
+
+    def _fail(*args, **kwargs):
+        raise httpx.ConnectError("boom")
+
+    monkeypatch.setattr(tui, "_fetch", _fail)
+    layout = tui._build_display()
+
+    # Walk the layout to extract the Panel renderable text
+    panel = layout.renderable
+    text = str(panel.renderable)
+    assert "Can't reach colony at http://localhost:7433" in text
+    assert "antfarm colony" in text
+    assert "--colony-url" in text
+
+
+def test_tui_shows_generic_error_on_other_exceptions(monkeypatch):
+    """Non-ConnectError exceptions fall through to the generic error message."""
+    tui = _make_tui()
+
+    def _fail(*args, **kwargs):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(tui, "_fetch", _fail)
+    layout = tui._build_display()
+
+    panel = layout.renderable
+    text = str(panel.renderable)
+    assert "Connection error: kaboom" in text


### PR DESCRIPTION
## Summary
- Distinguish `httpx.ConnectError` from other exceptions in `_build_display()` so users see the attempted URL plus start/redirect commands instead of a raw exception string
- Generic non-connection exceptions still show the existing `Connection error: <exc>` message (preserved behavior)
- CHANGELOG updated under `[Unreleased] → Fixed`

## Test plan
- [x] `test_tui_shows_hint_on_connect_error` — monkeypatches `_fetch` to raise `httpx.ConnectError`, asserts Panel text contains colony URL, `antfarm colony`, and `--colony-url`
- [x] `test_tui_shows_generic_error_on_other_exceptions` — monkeypatches `_fetch` to raise `RuntimeError`, asserts existing generic message is preserved
- [x] All 928 tests pass (`pytest tests/ -x -q`)
- [x] `ruff check antfarm/ tests/` — no issues

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)