### PR TITLE
feat(doctor): sweep legacy tmux sessions + startup hash log (#237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Added
 - Per-worker current-action visibility: `POST /workers/{id}/activity`, TUI Activity column with elapsed time, and doctor `check_stuck_workers` warning for workers idle on an action > 5 min. (#239)
+- `antfarm doctor --sweep-legacy-tmux` flag (with `--yes`) to clean pre-#231/#235 tmux sessions host-wide. Requires interactive confirmation by default. (#237)
+- Colony startup now logs `colony hash: <8hex> (data_dir: <realpath>)` so operators can correlate tmux session names to a colony. (#237)
+- `UPGRADE.md` — migration notes for session-name format changes in #231 and #235. (#237)
 
 ### Fixed
 - TUI now shows actionable guidance when the colony is unreachable, including the attempted URL and commands to start/redirect. (#246)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -41,6 +41,18 @@ Or compute manually:
 python3 -c "from antfarm.core.process_manager import colony_hash; print(colony_hash('.antfarm'))"
 ```
 
+## Before you sweep: drain in-flight legacy workers
+
+Killing a tmux session kills whatever is running inside it. If a legacy worker is mid-task when you sweep, its attempt is lost and the task has to be kicked back for re-forage.
+
+**Safe order of operations:**
+
+1. Stop scheduling new work onto the legacy colony (pause your queen / stop submitting missions).
+2. Wait for in-flight attempts to harvest their PRs. Watch `antfarm scout --tui` until the Building and Review panels are empty, or run `tmux ls` and inspect the legacy sessions manually.
+3. Then run the sweep.
+
+Harvested-but-not-merged work survives (it's already a PR in git). Un-harvested attempts are lost and the task will need a kickback. If you can't drain safely, prefer manual `tmux kill-session -t <name>` targeted at specific idle sessions.
+
 ## Cleanup — manual (any version)
 
 List legacy sessions:

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,76 @@
+# Upgrade Guide
+
+This document describes breaking operational changes that require manual
+action between Antfarm versions.
+
+## Session-name format changes
+
+Antfarm now prefixes tmux session names with an 8-char hash of the colony's
+`data_dir` (or for deploys, the fleet config realpath + colony URL). This
+prevents silent collisions when two colonies run on the same host.
+
+### 0.6.3 — autoscaler / runner session names (#231)
+
+**Old:** `auto-builder-3`, `runner-planner-1`
+**New:** `auto-<hash>-builder-3`, `runner-<hash>-planner-1`
+
+### Unreleased — deploy session names (#235)
+
+**Old:** `antfarm-node1-claude-0`
+**New:** `antfarm-<hash>-node1-claude-0` (hash derived from
+`realpath(fleet_config) + colony_url`)
+
+## Why
+
+Two colonies on the same host (e.g., dev + staging, or two operators
+sharing a box) would previously collide on session names. The `-A` flag
+(attach-or-create) meant the second process would silently attach into the
+first's session — real data corruption potential.
+
+## Finding your colony's hash
+
+Run the colony and check logs for:
+
+```
+colony hash: a1b2c3d4 (data_dir: /Users/you/project/.antfarm)
+```
+
+Or compute manually:
+
+```bash
+python3 -c "from antfarm.core.process_manager import colony_hash; print(colony_hash('.antfarm'))"
+```
+
+## Cleanup — manual (any version)
+
+List legacy sessions:
+
+```bash
+tmux ls | awk -F: '/^(auto|runner)-[^-]+-[^-]+-[0-9]+:/ && !/^(auto|runner)-[0-9a-f]{8}-/ {print $1}'
+tmux ls | awk -F: '/^antfarm-/ && !/^antfarm-[0-9a-f]{8}-/ {print $1}'
+```
+
+Kill them:
+
+```bash
+tmux ls | awk -F: '/^(auto|runner)-[^-]+-[^-]+-[0-9]+:/ && !/^(auto|runner)-[0-9a-f]{8}-/ {print $1}' | xargs -r -n1 tmux kill-session -t
+tmux ls | awk -F: '/^antfarm-/ && !/^antfarm-[0-9a-f]{8}-/ {print $1}' | xargs -r -n1 tmux kill-session -t
+```
+
+## Cleanup — `antfarm doctor --sweep-legacy-tmux` (Unreleased / 0.7+)
+
+Preview matches:
+
+```bash
+antfarm doctor --sweep-legacy-tmux
+```
+
+Kill after confirmation:
+
+```bash
+antfarm doctor --sweep-legacy-tmux --yes
+```
+
+This operates **host-wide** (not scoped to a single colony), so only run it
+when you're sure there's no peer colony on the box using the old format.
+Safe on any host that has been fully upgraded.

--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -700,10 +700,43 @@ def scent(task_id: str, poll_interval: float, colony_url: str, token: str | None
 @main.command()
 @click.option("--fix", is_flag=True, default=False, help="Apply safe auto-fixes.")
 @click.option("--data-dir", default=".antfarm", show_default=True, help="Data directory.")
-def doctor(fix: bool, data_dir: str):
+@click.option(
+    "--sweep-legacy-tmux",
+    is_flag=True,
+    default=False,
+    help=(
+        "Kill pre-hash tmux sessions (auto-/runner-/antfarm- without colony hash). "
+        "Operates host-wide, not scoped to a colony."
+    ),
+)
+@click.option(
+    "--yes",
+    "-y",
+    is_flag=True,
+    default=False,
+    help="Skip confirmation prompt for --sweep-legacy-tmux.",
+)
+def doctor(fix: bool, data_dir: str, sweep_legacy_tmux: bool, yes: bool):
     """Run pre-flight diagnostics on the colony data directory."""
     from antfarm.core.backends.file import FileBackend
-    from antfarm.core.doctor import run_doctor
+    from antfarm.core.doctor import run_doctor, sweep_legacy_tmux_sessions
+
+    if sweep_legacy_tmux:
+        # Dry-run preview first so the operator sees exactly what will die.
+        preview = sweep_legacy_tmux_sessions({"data_dir": data_dir}, confirmed=False)
+        if not preview:
+            click.echo("No legacy sessions found.")
+            return
+        for f in preview:
+            click.echo(f"[{f.severity.upper()}] {f.check}: {f.message}")
+        if not yes and not click.confirm(f"Kill {len(preview)} legacy sessions?", default=False):
+            click.echo("Aborted.")
+            return
+        killed = sweep_legacy_tmux_sessions({"data_dir": data_dir}, confirmed=True)
+        for f in killed:
+            status = "[FIXED]" if f.fixed else "[FAILED]"
+            click.echo(f"[{f.severity.upper()}] {f.check}: {f.message} {status}".strip())
+        return
 
     backend = FileBackend(data_dir)
     config = {"data_dir": data_dir}

--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -10,6 +10,7 @@ Colony URL resolution: every command that talks to the colony accepts
 from __future__ import annotations
 
 import json
+import sys
 import time
 
 import click
@@ -718,10 +719,28 @@ def scent(task_id: str, poll_interval: float, colony_url: str, token: str | None
 )
 def doctor(fix: bool, data_dir: str, sweep_legacy_tmux: bool, yes: bool):
     """Run pre-flight diagnostics on the colony data directory."""
+    import os
+
     from antfarm.core.backends.file import FileBackend
     from antfarm.core.doctor import run_doctor, sweep_legacy_tmux_sessions
 
+    if sweep_legacy_tmux and fix:
+        click.echo(
+            "Error: --fix and --sweep-legacy-tmux have different safety profiles and "
+            "cannot be combined. Run them separately.",
+            err=True,
+        )
+        sys.exit(2)
+
     if sweep_legacy_tmux:
+        from antfarm.core.process_manager import colony_hash
+
+        h = colony_hash(data_dir)
+        real = os.path.realpath(data_dir)
+        click.echo(f"Colony hash: {h} (data_dir: {real})")
+        click.echo(
+            "Legacy sessions (no hash) will be killed; all hashed sessions will be untouched."
+        )
         # Dry-run preview first so the operator sees exactly what will die.
         preview = sweep_legacy_tmux_sessions({"data_dir": data_dir}, confirmed=False)
         if not preview:

--- a/antfarm/core/doctor.py
+++ b/antfarm/core/doctor.py
@@ -13,11 +13,25 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import shutil
 import subprocess
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
+
+# Matches legacy (pre-#231/#235) tmux session names. A hash slot is exactly
+# 8 lowercase hex chars followed by a dash; the negative lookahead ensures
+# the token after the prefix is NOT a hash. Regressions in PRs #234 (#231)
+# and #243 (#235) introduced colony-hash-prefixed names; pre-upgrade sessions
+# have no hash token and must be swept manually.
+LEGACY_TMUX_RE = re.compile(
+    r"^(?:"
+    r"auto-(?![0-9a-f]{8}-)[A-Za-z][A-Za-z0-9_-]*-\d+"
+    r"|runner-(?![0-9a-f]{8}-)[A-Za-z][A-Za-z0-9_-]*-\d+"
+    r"|antfarm-(?![0-9a-f]{8}-)[A-Za-z0-9_][A-Za-z0-9_-]*-[A-Za-z0-9_-]+-\d+"
+    r")$"
+)
 
 
 @dataclass
@@ -29,7 +43,12 @@ class Finding:
     fixed: bool = False
 
 
-def run_doctor(backend, config: dict, fix: bool = False) -> list[Finding]:
+def run_doctor(
+    backend,
+    config: dict,
+    fix: bool = False,
+    sweep_legacy_tmux: bool = False,
+) -> list[Finding]:
     """Run all diagnostic checks. If fix=True, apply safe repairs.
 
     Args:
@@ -40,6 +59,9 @@ def run_doctor(backend, config: dict, fix: bool = False) -> list[Finding]:
             - worker_ttl (int, default 300): seconds before worker is stale
             - guard_ttl (int, default 300): seconds before guard is stale
         fix: If True, apply safe auto-fixes.
+        sweep_legacy_tmux: If True, also kill pre-hash tmux sessions host-wide
+            (``auto-``/``runner-``/``antfarm-`` without a colony hash). Intended
+            to be driven from the CLI after explicit operator confirmation.
 
     Returns:
         List of Finding objects describing issues found.
@@ -60,6 +82,9 @@ def run_doctor(backend, config: dict, fix: bool = False) -> list[Finding]:
     findings.extend(check_runner_health(backend, config))
     findings.extend(check_tmux_available(config))
     findings.extend(check_orphan_tmux_sessions(config, fix))
+
+    if sweep_legacy_tmux:
+        findings.extend(sweep_legacy_tmux_sessions(config, confirmed=True))
 
     return findings
 
@@ -1159,6 +1184,104 @@ def check_orphan_tmux_sessions(config: dict, fix: bool = False) -> list[Finding]
                     "no server running",
                 )
                 if any(m in stderr_lower for m in gone_markers):
+                    finding.fixed = True
+                    finding.message += " (already gone)"
+                else:
+                    detail = (
+                        kill.stderr.strip().splitlines()[0]
+                        if kill.stderr and kill.stderr.strip()
+                        else f"returncode={kill.returncode}"
+                    )
+                    finding.message += f" — kill failed: {detail}"
+                    finding.fixed = False
+
+        findings.append(finding)
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Migration: sweep legacy (pre-hash) tmux sessions
+# ---------------------------------------------------------------------------
+
+
+_BENIGN_KILL_MARKERS = (
+    "can't find session",
+    "session not found",
+    "no server running",
+)
+
+
+def sweep_legacy_tmux_sessions(
+    config: dict,
+    confirmed: bool = False,
+) -> list[Finding]:
+    """List or kill pre-hash tmux session names host-wide.
+
+    Matches sessions whose names follow the pre-upgrade layout introduced
+    before #231 (autoscaler/runner) and #235 (deploy) — i.e., names lacking
+    an 8-char colony hash token:
+
+    - ``auto-<role>-<N>``
+    - ``runner-<role>-<N>``
+    - ``antfarm-<node>-<agent>-<idx>``
+
+    When ``confirmed=False``, returns one ``info`` finding per match so callers
+    can preview the sweep. When ``confirmed=True``, attempts ``tmux kill-session``
+    per match using the same benign-race stderr tolerance as
+    :func:`check_orphan_tmux_sessions`.
+
+    This is a **host-wide** operation; it is not scoped to a single colony.
+    Run it only after confirming there is no peer colony still using the
+    legacy format.
+
+    Args:
+        config: Doctor config dict (unused; signature mirrors other checks).
+        confirmed: When True, kill each match. Default False (dry-run preview).
+
+    Returns:
+        List of findings, one per matched legacy session.
+    """
+    del config  # unused — sweep is host-wide
+    if not shutil.which("tmux"):
+        return []
+
+    env = {**os.environ, "LC_ALL": "C"}
+    result = subprocess.run(
+        ["tmux", "list-sessions", "-F", "#{session_name}"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    if result.returncode != 0:
+        # tmux server not running — nothing to sweep
+        return []
+
+    findings: list[Finding] = []
+    for raw in result.stdout.splitlines():
+        name = raw.strip()
+        if not name or not LEGACY_TMUX_RE.match(name):
+            continue
+
+        finding = Finding(
+            severity="info",
+            check="legacy_tmux_session",
+            message=f"Legacy session: {name}",
+            auto_fixable=True,
+        )
+
+        if confirmed:
+            kill = subprocess.run(
+                ["tmux", "kill-session", "-t", name],
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            if kill.returncode == 0:
+                finding.fixed = True
+            else:
+                stderr_lower = (kill.stderr or "").strip().lower()
+                if any(m in stderr_lower for m in _BENIGN_KILL_MARKERS):
                     finding.fixed = True
                     finding.message += " (already gone)"
                 else:

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -382,6 +382,19 @@ def get_app(
         pr_ops = GhPROps(cwd=repo_path) if repo_path else NullPROps()
         _backend = FileBackend(root=data_dir, pr_ops=pr_ops)
 
+    # Log the colony hash so operators can correlate tmux session names
+    # (auto-<hash>-*, runner-<hash>-*) back to this colony's data_dir.
+    try:
+        from antfarm.core.process_manager import colony_hash
+
+        logger.info(
+            "colony hash: %s (data_dir: %s)",
+            colony_hash(data_dir),
+            os.path.realpath(data_dir),
+        )
+    except Exception:  # noqa: BLE001 — logging must never break startup
+        pass
+
     # Fallback so downstream uses (Queen, etc.) still see a repo_path string.
     if repo_path is None:
         repo_path = "."

--- a/tests/test_autoscaler.py
+++ b/tests/test_autoscaler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
@@ -204,8 +205,12 @@ class TestComputeDesired:
     def test_review_prefixed_tasks_not_counted_as_unreviewed(self):
         a = _make_autoscaler()
         tasks = [
-            _task("review-t1", status="done", current_attempt="att-1",
-                  attempts=[{"attempt_id": "att-1", "status": "done"}]),
+            _task(
+                "review-t1",
+                status="done",
+                current_attempt="att-1",
+                attempts=[{"attempt_id": "att-1", "status": "done"}],
+            ),
         ]
         result = a._compute_desired(tasks, [])
         assert result["reviewer"] == 0
@@ -268,8 +273,7 @@ class TestReconciliation:
 
         # Should have started 2 builders (2 scope groups, 2 tasks)
         builder_starts = [
-            c for c in pm.start.call_args_list
-            if "--type" in c[0][1] and "builder" in c[0][1]
+            c for c in pm.start.call_args_list if "--type" in c[0][1] and "builder" in c[0][1]
         ]
         assert len(builder_starts) == 2
 
@@ -613,3 +617,63 @@ class TestAdoptExisting:
         a._adopt_existing()
 
         assert a._counter == 7
+
+    def test_adopt_existing_ignores_legacy_unprefixed_sessions(self, tmp_path):
+        """Pre-#231 `auto-builder-3` sessions must NOT be adopted after upgrade.
+
+        Uses a real TmuxProcessManager whose prefix is the autoscaler's current
+        hashed prefix. The legacy name lacks the hash token, so list_managed()
+        filters it out and adopt_existing() returns {}.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from antfarm.core.process_manager import TmuxProcessManager, colony_hash
+
+        data_dir = str(tmp_path / ".antfarm")
+        os.makedirs(data_dir, exist_ok=True)
+        prefix = f"auto-{colony_hash(data_dir)}-"
+        pm = TmuxProcessManager(prefix=prefix, state_dir=data_dir)
+
+        list_result = MagicMock()
+        list_result.returncode = 0
+        list_result.stdout = "auto-builder-3\nauto-planner-1\n"
+
+        with (
+            patch("antfarm.core.process_manager.shutil.which", return_value="/usr/bin/tmux"),
+            patch("antfarm.core.process_manager.subprocess.run", return_value=list_result),
+        ):
+            a = _make_autoscaler(_pm=pm, data_dir=data_dir, node_id="node-x")
+            a._adopt_existing()
+
+        assert a.managed == {}
+        assert a._counter == 0
+
+    def test_adopt_existing_ignores_peer_colony_sessions(self, tmp_path):
+        """Sessions with a DIFFERENT colony hash must NOT be adopted.
+
+        Peer colonies on the same host use their own hash; the autoscaler's
+        prefix filter rejects them in list_managed().
+        """
+        from unittest.mock import MagicMock, patch
+
+        from antfarm.core.process_manager import TmuxProcessManager, colony_hash
+
+        data_dir = str(tmp_path / ".antfarm")
+        os.makedirs(data_dir, exist_ok=True)
+        prefix = f"auto-{colony_hash(data_dir)}-"
+        pm = TmuxProcessManager(prefix=prefix, state_dir=data_dir)
+
+        # Foreign hash that is very unlikely to collide with the real hash.
+        list_result = MagicMock()
+        list_result.returncode = 0
+        list_result.stdout = "auto-deadbeef-builder-1\nauto-ffffffff-reviewer-2\n"
+
+        with (
+            patch("antfarm.core.process_manager.shutil.which", return_value="/usr/bin/tmux"),
+            patch("antfarm.core.process_manager.subprocess.run", return_value=list_result),
+        ):
+            a = _make_autoscaler(_pm=pm, data_dir=data_dir, node_id="node-x")
+            a._adopt_existing()
+
+        assert a.managed == {}
+        assert a._counter == 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -83,9 +83,12 @@ def test_cli_carry_creates_task():
             main,
             [
                 "carry",
-                "--title", "Test Task",
-                "--spec", "Do the thing",
-                "--colony-url", "http://localhost:7433",
+                "--title",
+                "Test Task",
+                "--spec",
+                "Do the thing",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 
@@ -271,6 +274,100 @@ def test_cli_doctor_fix(tmp_path: Path):
     assert result.exit_code == 0, result.output
 
 
+def test_cli_doctor_sweep_no_legacy_sessions(tmp_path: Path):
+    """--sweep-legacy-tmux with no matches prints the no-op message and exits."""
+    runner = CliRunner()
+
+    with patch("antfarm.core.doctor.sweep_legacy_tmux_sessions") as mock_sweep:
+        mock_sweep.return_value = []
+        result = runner.invoke(
+            main,
+            ["doctor", "--sweep-legacy-tmux", "--data-dir", str(tmp_path)],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "No legacy sessions found" in result.output
+    # Only the dry-run call should have happened; no confirmation prompt either.
+    mock_sweep.assert_called_once()
+    assert mock_sweep.call_args.kwargs["confirmed"] is False
+
+
+def test_cli_doctor_sweep_prompts_without_yes(tmp_path: Path):
+    """Without --yes, --sweep-legacy-tmux requires interactive confirmation and aborts on 'n'."""
+    from antfarm.core.doctor import Finding
+
+    runner = CliRunner()
+
+    preview = [
+        Finding(
+            severity="info",
+            check="legacy_tmux_session",
+            message="Legacy session: auto-builder-3",
+            auto_fixable=True,
+        ),
+    ]
+
+    with patch("antfarm.core.doctor.sweep_legacy_tmux_sessions") as mock_sweep:
+        mock_sweep.return_value = preview
+        result = runner.invoke(
+            main,
+            ["doctor", "--sweep-legacy-tmux", "--data-dir", str(tmp_path)],
+            input="n\n",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "auto-builder-3" in result.output
+    assert "Aborted" in result.output
+    # Dry-run only — no confirmed=True call.
+    assert mock_sweep.call_count == 1
+    assert mock_sweep.call_args.kwargs["confirmed"] is False
+
+
+def test_cli_doctor_sweep_yes_bypasses_prompt(tmp_path: Path):
+    """--yes skips the prompt and invokes the sweep with confirmed=True."""
+    from antfarm.core.doctor import Finding
+
+    runner = CliRunner()
+
+    preview = [
+        Finding(
+            severity="info",
+            check="legacy_tmux_session",
+            message="Legacy session: auto-builder-3",
+            auto_fixable=True,
+        ),
+    ]
+    killed = [
+        Finding(
+            severity="info",
+            check="legacy_tmux_session",
+            message="Legacy session: auto-builder-3",
+            auto_fixable=True,
+            fixed=True,
+        ),
+    ]
+
+    with patch("antfarm.core.doctor.sweep_legacy_tmux_sessions") as mock_sweep:
+        mock_sweep.side_effect = [preview, killed]
+        result = runner.invoke(
+            main,
+            [
+                "doctor",
+                "--sweep-legacy-tmux",
+                "--yes",
+                "--data-dir",
+                str(tmp_path),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "auto-builder-3" in result.output
+    assert "[FIXED]" in result.output
+    assert mock_sweep.call_count == 2
+    assert mock_sweep.call_args_list[0].kwargs["confirmed"] is False
+    assert mock_sweep.call_args_list[1].kwargs["confirmed"] is True
+
+
 # ---------------------------------------------------------------------------
 # join
 # ---------------------------------------------------------------------------
@@ -315,10 +412,14 @@ def test_cli_hatch_registers_worker():
             main,
             [
                 "hatch",
-                "--node", "node-1",
-                "--agent", "claude-code",
-                "--name", "claude-1",
-                "--colony-url", "http://localhost:7433",
+                "--node",
+                "node-1",
+                "--agent",
+                "claude-code",
+                "--name",
+                "claude-1",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 
@@ -381,9 +482,13 @@ def test_cli_trail_appends_entry():
         result = runner.invoke(
             main,
             [
-                "trail", "task-001", "completed routes",
-                "--worker-id", "node-1/w1",
-                "--colony-url", "http://localhost:7433",
+                "trail",
+                "task-001",
+                "completed routes",
+                "--worker-id",
+                "node-1/w1",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 
@@ -405,9 +510,12 @@ def test_cli_harvest_posts_pr():
         result = runner.invoke(
             main,
             [
-                "harvest", "task-001",
-                "--pr", "https://github.com/org/repo/pull/42",
-                "--colony-url", "http://localhost:7433",
+                "harvest",
+                "task-001",
+                "--pr",
+                "https://github.com/org/repo/pull/42",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 
@@ -468,9 +576,13 @@ def test_cli_signal_posts():
         result = runner.invoke(
             main,
             [
-                "signal", "task-001", "needs re-scoping",
-                "--worker-id", "node-1/w1",
-                "--colony-url", "http://localhost:7433",
+                "signal",
+                "task-001",
+                "needs re-scoping",
+                "--worker-id",
+                "node-1/w1",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 
@@ -497,11 +609,16 @@ def test_worker_start_reviewer_adds_review_capability():
         result = runner.invoke(
             main,
             [
-                "worker", "start",
-                "--agent", "claude-code",
-                "--type", "reviewer",
-                "--node", "n1",
-                "--colony-url", "http://localhost:7433",
+                "worker",
+                "start",
+                "--agent",
+                "claude-code",
+                "--type",
+                "reviewer",
+                "--node",
+                "n1",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 
@@ -523,10 +640,14 @@ def test_worker_start_builder_no_review_capability():
         result = runner.invoke(
             main,
             [
-                "worker", "start",
-                "--agent", "claude-code",
-                "--node", "n1",
-                "--colony-url", "http://localhost:7433",
+                "worker",
+                "start",
+                "--agent",
+                "claude-code",
+                "--node",
+                "n1",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 
@@ -548,11 +669,16 @@ def test_worker_start_name_defaults_to_type():
         result = runner.invoke(
             main,
             [
-                "worker", "start",
-                "--agent", "claude-code",
-                "--type", "reviewer",
-                "--node", "n1",
-                "--colony-url", "http://localhost:7433",
+                "worker",
+                "start",
+                "--agent",
+                "claude-code",
+                "--type",
+                "reviewer",
+                "--node",
+                "n1",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 
@@ -574,12 +700,18 @@ def test_worker_start_explicit_name_overrides():
         result = runner.invoke(
             main,
             [
-                "worker", "start",
-                "--agent", "claude-code",
-                "--type", "reviewer",
-                "--name", "my-worker",
-                "--node", "n1",
-                "--colony-url", "http://localhost:7433",
+                "worker",
+                "start",
+                "--agent",
+                "claude-code",
+                "--type",
+                "reviewer",
+                "--name",
+                "my-worker",
+                "--node",
+                "n1",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 
@@ -633,8 +765,10 @@ def test_cli_colony_multi_node_flag():
                 "colony",
                 "--autoscaler",
                 "--multi-node",
-                "--port", "9001",
-                "--host", "127.0.0.1",
+                "--port",
+                "9001",
+                "--host",
+                "127.0.0.1",
             ],
         )
 
@@ -652,10 +786,12 @@ def test_plan_carry_resolves_index_deps():
     """plan --carry resolves 1-based index deps to generated task IDs."""
     runner = CliRunner()
 
-    plan_json = json.dumps([
-        {"title": "Task A", "spec": "Do A"},
-        {"title": "Task B", "spec": "Do B", "depends_on": [1]},
-    ])
+    plan_json = json.dumps(
+        [
+            {"title": "Task A", "spec": "Do A"},
+            {"title": "Task B", "spec": "Do B", "depends_on": [1]},
+        ]
+    )
 
     carried_payloads = []
 
@@ -672,9 +808,11 @@ def test_plan_carry_resolves_index_deps():
             main,
             [
                 "plan",
-                "--spec", plan_json,
+                "--spec",
+                plan_json,
                 "--carry",
-                "--colony-url", "http://localhost:7433",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -368,6 +368,41 @@ def test_cli_doctor_sweep_yes_bypasses_prompt(tmp_path: Path):
     assert mock_sweep.call_args_list[1].kwargs["confirmed"] is True
 
 
+def test_cli_doctor_sweep_and_fix_are_mutually_exclusive():
+    """--fix + --sweep-legacy-tmux is rejected because they have different safety profiles."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["doctor", "--fix", "--sweep-legacy-tmux", "--yes"])
+    assert result.exit_code == 2
+    assert "cannot be combined" in result.output
+
+
+def test_cli_doctor_sweep_prints_colony_hash_before_preview(tmp_path: Path):
+    """--sweep-legacy-tmux prints the colony hash before the session preview."""
+    from antfarm.core.doctor import Finding
+
+    runner = CliRunner()
+
+    preview = [
+        Finding(
+            severity="info",
+            check="legacy_tmux_session",
+            message="Legacy session: auto-builder-3",
+            auto_fixable=True,
+        ),
+    ]
+
+    with patch("antfarm.core.doctor.sweep_legacy_tmux_sessions") as mock_sweep:
+        mock_sweep.return_value = preview
+        result = runner.invoke(
+            main,
+            ["doctor", "--sweep-legacy-tmux", "--data-dir", str(tmp_path)],
+            input="n\n",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Colony hash:" in result.output
+
+
 # ---------------------------------------------------------------------------
 # join
 # ---------------------------------------------------------------------------

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1068,3 +1068,248 @@ def test_two_mock_colonies_dont_cross_see(tmp_path):
 
     assert len(findings_b) == 1 and name_b in findings_b[0].message
     assert name_a not in findings_b[0].message
+
+
+# ---------------------------------------------------------------------------
+# Legacy tmux sweep (#237)
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_regex_matches_auto_role_n():
+    """Pre-#231 ``auto-<role>-<N>`` sessions match, including multi-word roles."""
+    from antfarm.core.doctor import LEGACY_TMUX_RE
+
+    assert LEGACY_TMUX_RE.match("auto-builder-3")
+    assert LEGACY_TMUX_RE.match("auto-code-reviewer-12")
+    assert LEGACY_TMUX_RE.match("auto-planner-1")
+
+
+def test_legacy_regex_matches_runner_role_n():
+    """Pre-#231 ``runner-<role>-<N>`` sessions match, including multi-word roles."""
+    from antfarm.core.doctor import LEGACY_TMUX_RE
+
+    assert LEGACY_TMUX_RE.match("runner-planner-1")
+    assert LEGACY_TMUX_RE.match("runner-code-reviewer-7")
+
+
+def test_legacy_regex_matches_antfarm_deploy():
+    """Pre-#235 deploy sessions (``antfarm-<node>-<agent>-<idx>``) match."""
+    from antfarm.core.doctor import LEGACY_TMUX_RE
+
+    assert LEGACY_TMUX_RE.match("antfarm-node1-claude-0")
+    assert LEGACY_TMUX_RE.match("antfarm-node-2-codex-11")
+
+
+def test_legacy_regex_rejects_hashed_names():
+    """New-format hash-prefixed names for all three prefixes do NOT match."""
+    from antfarm.core.doctor import LEGACY_TMUX_RE
+
+    assert not LEGACY_TMUX_RE.match("auto-a1b2c3d4-builder-3")
+    assert not LEGACY_TMUX_RE.match("runner-deadbeef-planner-1")
+    assert not LEGACY_TMUX_RE.match("antfarm-ffffffff-node1-claude-0")
+    # Also don't trip on unrelated session names
+    assert not LEGACY_TMUX_RE.match("some-unrelated-session")
+    assert not LEGACY_TMUX_RE.match("auto-builder")  # missing -N
+    assert not LEGACY_TMUX_RE.match("runner-3")  # missing role
+
+
+def test_sweep_legacy_tmux_dry_run_reports_only():
+    """confirmed=False emits info findings only; no kill-session invoked."""
+    from unittest.mock import MagicMock, patch
+
+    from antfarm.core.doctor import sweep_legacy_tmux_sessions
+
+    list_result = MagicMock()
+    list_result.returncode = 0
+    list_result.stdout = "auto-builder-3\nrunner-planner-1\nantfarm-a1b2c3d4-node-x-0\n"
+
+    calls: list = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+        return list_result
+
+    with (
+        patch("antfarm.core.doctor.shutil.which", return_value="/usr/bin/tmux"),
+        patch("antfarm.core.doctor.subprocess.run", side_effect=fake_run),
+    ):
+        findings = sweep_legacy_tmux_sessions({"data_dir": "/x"}, confirmed=False)
+
+    assert len(findings) == 2
+    names = sorted(f.message for f in findings)
+    assert any("auto-builder-3" in n for n in names)
+    assert any("runner-planner-1" in n for n in names)
+    for f in findings:
+        assert f.severity == "info"
+        assert f.check == "legacy_tmux_session"
+        assert f.auto_fixable is True
+        assert f.fixed is False
+    # Only list-sessions was called — no kill-session
+    assert all(c[:2] == ["tmux", "list-sessions"] for c in calls)
+
+
+def test_sweep_legacy_tmux_confirmed_kills():
+    """confirmed=True runs tmux kill-session per match and marks fixed=True."""
+    from unittest.mock import MagicMock, patch
+
+    from antfarm.core.doctor import sweep_legacy_tmux_sessions
+
+    list_result = MagicMock()
+    list_result.returncode = 0
+    list_result.stdout = "auto-builder-3\nrunner-planner-1\n"
+
+    kill_result = MagicMock()
+    kill_result.returncode = 0
+    kill_result.stderr = ""
+
+    calls: list = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:2] == ["tmux", "list-sessions"]:
+            return list_result
+        return kill_result
+
+    with (
+        patch("antfarm.core.doctor.shutil.which", return_value="/usr/bin/tmux"),
+        patch("antfarm.core.doctor.subprocess.run", side_effect=fake_run),
+    ):
+        findings = sweep_legacy_tmux_sessions({"data_dir": "/x"}, confirmed=True)
+
+    assert len(findings) == 2
+    assert all(f.fixed for f in findings)
+    kill_cmds = [c for c in calls if c[:2] == ["tmux", "kill-session"]]
+    targets = sorted(c[3] for c in kill_cmds)
+    assert targets == ["auto-builder-3", "runner-planner-1"]
+
+
+def test_sweep_legacy_tmux_handles_already_gone():
+    """Benign-race stderr from kill-session → fixed=True with "(already gone)"."""
+    from unittest.mock import MagicMock, patch
+
+    from antfarm.core.doctor import sweep_legacy_tmux_sessions
+
+    list_result = MagicMock()
+    list_result.returncode = 0
+    list_result.stdout = "auto-builder-3\n"
+
+    kill_result = MagicMock()
+    kill_result.returncode = 1
+    kill_result.stderr = "can't find session: auto-builder-3"
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["tmux", "list-sessions"]:
+            return list_result
+        return kill_result
+
+    with (
+        patch("antfarm.core.doctor.shutil.which", return_value="/usr/bin/tmux"),
+        patch("antfarm.core.doctor.subprocess.run", side_effect=fake_run),
+    ):
+        findings = sweep_legacy_tmux_sessions({"data_dir": "/x"}, confirmed=True)
+
+    assert len(findings) == 1
+    assert findings[0].fixed is True
+    assert "(already gone)" in findings[0].message
+
+
+def test_sweep_legacy_tmux_handles_kill_failure():
+    """Real kill-session failure → fixed=False with "kill failed:" detail."""
+    from unittest.mock import MagicMock, patch
+
+    from antfarm.core.doctor import sweep_legacy_tmux_sessions
+
+    list_result = MagicMock()
+    list_result.returncode = 0
+    list_result.stdout = "runner-planner-1\n"
+
+    kill_result = MagicMock()
+    kill_result.returncode = 2
+    kill_result.stderr = "permission denied: something real and bad"
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["tmux", "list-sessions"]:
+            return list_result
+        return kill_result
+
+    with (
+        patch("antfarm.core.doctor.shutil.which", return_value="/usr/bin/tmux"),
+        patch("antfarm.core.doctor.subprocess.run", side_effect=fake_run),
+    ):
+        findings = sweep_legacy_tmux_sessions({"data_dir": "/x"}, confirmed=True)
+
+    assert len(findings) == 1
+    assert findings[0].fixed is False
+    assert "kill failed:" in findings[0].message
+    assert "permission denied" in findings[0].message
+
+
+def test_sweep_legacy_tmux_no_tmux_returns_empty():
+    """tmux binary missing → sweep returns [] without raising."""
+    from unittest.mock import patch
+
+    from antfarm.core.doctor import sweep_legacy_tmux_sessions
+
+    with patch("antfarm.core.doctor.shutil.which", return_value=None):
+        assert sweep_legacy_tmux_sessions({"data_dir": "/x"}, confirmed=False) == []
+        assert sweep_legacy_tmux_sessions({"data_dir": "/x"}, confirmed=True) == []
+
+
+def test_sweep_legacy_tmux_no_server_returns_empty():
+    """tmux server not running (list-sessions returncode != 0) → []."""
+    from unittest.mock import MagicMock, patch
+
+    from antfarm.core.doctor import sweep_legacy_tmux_sessions
+
+    list_result = MagicMock()
+    list_result.returncode = 1
+    list_result.stdout = ""
+
+    with (
+        patch("antfarm.core.doctor.shutil.which", return_value="/usr/bin/tmux"),
+        patch("antfarm.core.doctor.subprocess.run", return_value=list_result),
+    ):
+        assert sweep_legacy_tmux_sessions({"data_dir": "/x"}, confirmed=True) == []
+
+
+def test_run_doctor_sweep_legacy_tmux_flag_invokes_sweep():
+    """run_doctor(sweep_legacy_tmux=True) appends legacy_tmux_session findings."""
+    from unittest.mock import MagicMock, patch
+
+    import antfarm.core.doctor as doctor_mod
+
+    list_result = MagicMock()
+    list_result.returncode = 0
+    list_result.stdout = "auto-builder-3\n"
+
+    kill_result = MagicMock()
+    kill_result.returncode = 0
+    kill_result.stderr = ""
+
+    import subprocess as real_subprocess
+
+    real_run = real_subprocess.run
+
+    def fake_run(cmd, *args, **kwargs):
+        if isinstance(cmd, (list, tuple)) and cmd and cmd[0] == "tmux":
+            if cmd[:2] == ["tmux", "list-sessions"]:
+                return list_result
+            return kill_result
+        return real_run(cmd, *args, **kwargs)
+
+    backend = MagicMock()
+    backend.list_tasks.return_value = []
+    backend.list_nodes.return_value = []
+
+    config = {"data_dir": "/tmp/antfarm-test-doctor-sweep"}
+    os.makedirs(config["data_dir"], exist_ok=True)
+
+    with (
+        patch.object(doctor_mod.shutil, "which", return_value="/usr/bin/tmux"),
+        patch.object(doctor_mod.subprocess, "run", side_effect=fake_run),
+    ):
+        findings = doctor_mod.run_doctor(backend, config, fix=False, sweep_legacy_tmux=True)
+
+    legacy = [f for f in findings if f.check == "legacy_tmux_session"]
+    assert len(legacy) == 1
+    assert legacy[0].fixed is True

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -301,6 +301,33 @@ class TestAdoptExistingWorkers:
         assert len(r.managed) == 0
         assert r._counter == 0
 
+    def test_runner_adopt_ignores_legacy_sessions(self, tmp_path):
+        """Pre-#231 `runner-builder-1` sessions must NOT be adopted after upgrade.
+
+        Uses a real TmuxProcessManager with the Runner's current hashed prefix;
+        the legacy name lacks the hash token so ``list_managed()`` filters it
+        out before it reaches ``_adopt_existing_workers``.
+        """
+        from antfarm.core.process_manager import TmuxProcessManager, colony_hash
+
+        r = _make_runner(tmp_path)
+        prefix = f"runner-{colony_hash(r.state_dir)}-"
+        r._pm = TmuxProcessManager(prefix=prefix, state_dir=r.state_dir)
+        r._prefix = prefix
+
+        list_result = MagicMock()
+        list_result.returncode = 0
+        list_result.stdout = "runner-builder-1\nrunner-planner-2\nrunner-deadbeef-reviewer-3\n"
+
+        with (
+            patch("antfarm.core.process_manager.shutil.which", return_value="/usr/bin/tmux"),
+            patch("antfarm.core.process_manager.subprocess.run", return_value=list_result),
+        ):
+            r._adopt_existing_workers()
+
+        assert r.managed == {}
+        assert r._counter == 0
+
 
 class TestStalePidsDirSweep:
     def test_stale_pids_dir_swept_on_run(self, tmp_path):

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -910,3 +910,26 @@ def test_carry_accepts_mission_id(client):
 
     mission = client.get("/missions/m-1").json()
     assert "task-linked" in mission["task_ids"]
+
+
+def test_startup_logs_colony_hash(tmp_path, caplog):
+    """Colony startup logs the 8-char data_dir hash so operators can correlate sessions."""
+    import logging
+
+    from antfarm.core.backends.file import FileBackend
+    from antfarm.core.process_manager import colony_hash
+
+    data_dir = str(tmp_path / ".antfarm")
+    backend = FileBackend(root=data_dir)
+
+    with caplog.at_level(logging.INFO, logger="antfarm.core.serve"):
+        get_app(backend=backend, data_dir=data_dir)
+
+    expected_hash = colony_hash(data_dir)
+    matching = [
+        r
+        for r in caplog.records
+        if "colony hash:" in r.getMessage() and expected_hash in r.getMessage()
+    ]
+    assert matching, f"expected colony hash log, got: {[r.getMessage() for r in caplog.records]}"
+    assert os.path.realpath(data_dir) in matching[0].getMessage()


### PR DESCRIPTION
## Summary
- Adds ``antfarm doctor --sweep-legacy-tmux`` (with ``--yes``) to find and kill pre-#231/#235 tmux sessions host-wide. Interactive confirmation by default.
- Logs ``colony hash: <8hex> (data_dir: <realpath>)`` at colony startup so operators can correlate tmux session names back to a colony.
- Adds ``UPGRADE.md`` explaining the session-name format changes in #231 and #235, plus manual awk one-liners and the new doctor flag for cleanup.
- Regression tests assert that the autoscaler/runner adoption path will NOT adopt legacy (``auto-builder-3``) or peer-colony-hash (``auto-deadbeef-builder-1``) sessions after upgrade.

## Test plan
- [x] ``ruff check antfarm/ tests/`` clean
- [x] ``pytest tests/ -x -q`` — 946 passed (+18 new tests)
- [x] Dry-run preview emits info findings only; no kill-session is invoked
- [x] ``--yes`` skips the confirmation prompt and kills matches
- [x] Benign-race stderr (``can't find session`` / ``session not found`` / ``no server running``) is treated as success with ``(already gone)`` suffix
- [x] Real kill failures surface ``kill failed: <detail>`` and ``fixed=False``
- [x] ``LEGACY_TMUX_RE`` matches the three legacy prefixes and rejects hashed names
- [x] ``TmuxProcessManager`` with the current colony prefix filters legacy / peer-hash names out of ``list_managed`` so adoption returns ``{}``
- [x] ``get_app`` emits the colony-hash INFO log line on startup

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)