### PR TITLE
fix(doctor): harden check_orphan_tmux_sessions (#242)

### DIFF
--- a/antfarm/core/doctor.py
+++ b/antfarm/core/doctor.py
@@ -1102,6 +1102,7 @@ def check_orphan_tmux_sessions(config: dict, fix: bool = False) -> list[Finding]
         ["tmux", "list-sessions", "-F", "#{session_name}"],
         capture_output=True,
         text=True,
+        env={**os.environ, "LC_ALL": "C"},
     )
     if result.returncode != 0:
         # tmux server not running — no sessions to check
@@ -1141,10 +1142,14 @@ def check_orphan_tmux_sessions(config: dict, fix: bool = False) -> list[Finding]
         )
 
         if fix:
+            # Session name is already colony-hash-scoped (see #231), so we never
+            # kill a peer colony's session — this is what makes the race-tolerant
+            # behavior safe to default-on.
             kill = subprocess.run(
                 ["tmux", "kill-session", "-t", name],
                 capture_output=True,
                 text=True,
+                env={**os.environ, "LC_ALL": "C"},
             )
             if kill.returncode == 0:
                 finding.fixed = True
@@ -1152,6 +1157,9 @@ def check_orphan_tmux_sessions(config: dict, fix: bool = False) -> list[Finding]
                 # Race: session disappeared between list-sessions and kill-session.
                 # tmux emits these strings from cmd-kill-session.c / server.c when
                 # the target is gone or the server has exited. Treat as success.
+                # Note: "session not found" is defensive coverage — we've observed
+                # "can't find session" and "no server running" in tmux 3.x;
+                # "session not found" is added for other tmux versions/ports.
                 stderr_lower = (kill.stderr or "").strip().lower()
                 gone_markers = (
                     "can't find session",
@@ -1162,11 +1170,12 @@ def check_orphan_tmux_sessions(config: dict, fix: bool = False) -> list[Finding]
                     finding.fixed = True
                     finding.message += " (already gone)"
                 else:
-                    detail = (
+                    raw = (
                         kill.stderr.strip().splitlines()[0]
                         if kill.stderr and kill.stderr.strip()
                         else f"returncode={kill.returncode}"
                     )
+                    detail = raw if len(raw) <= 200 else raw[:199] + "…"
                     finding.message += f" — kill failed: {detail}"
                     finding.fixed = False
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1033,6 +1033,78 @@ def test_orphan_fix_success_regression(tmp_path):
     assert findings[0].message == f"orphan tmux session: {own_orphan} (no matching metadata)"
 
 
+def test_check_orphan_tmux_sessions_fix_mixed_batch(tmp_path):
+    """Three orphans: clean kill, benign race, genuine failure — all classified correctly."""
+    from unittest.mock import MagicMock, patch
+
+    from antfarm.core.doctor import check_orphan_tmux_sessions
+    from antfarm.core.process_manager import colony_hash
+
+    data_dir = tmp_path / ".antfarm"
+    (data_dir / "processes").mkdir(parents=True)
+
+    h = colony_hash(str(data_dir))
+    session_clean = f"auto-{h}-builder-1"
+    session_race = f"auto-{h}-builder-2"
+    session_fail = f"auto-{h}-builder-3"
+
+    list_result = MagicMock()
+    list_result.returncode = 0
+    list_result.stdout = f"{session_clean}\n{session_race}\n{session_fail}\n"
+
+    kill_clean = MagicMock()
+    kill_clean.returncode = 0
+    kill_clean.stderr = ""
+
+    kill_race = MagicMock()
+    kill_race.returncode = 1
+    kill_race.stderr = "can't find session: " + session_race + "\n"
+
+    kill_fail = MagicMock()
+    kill_fail.returncode = 1
+    kill_fail.stderr = "some other error\n"
+
+    kill_calls: list[str] = []
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["tmux", "list-sessions"]:
+            return list_result
+        if cmd[:2] == ["tmux", "kill-session"]:
+            target = cmd[cmd.index("-t") + 1]
+            kill_calls.append(target)
+            if target == session_clean:
+                return kill_clean
+            if target == session_race:
+                return kill_race
+            if target == session_fail:
+                return kill_fail
+            raise AssertionError(f"unexpected kill target: {target}")
+        raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+    with (
+        patch("antfarm.core.doctor.shutil.which", return_value="/usr/bin/tmux"),
+        patch("antfarm.core.doctor.subprocess.run", side_effect=fake_run),
+    ):
+        findings = check_orphan_tmux_sessions({"data_dir": str(data_dir)}, fix=True)
+
+    assert len(findings) == 3
+
+    by_name = {f.message.split(":")[1].split("(")[0].strip(): f for f in findings}
+
+    f_clean = by_name[session_clean]
+    assert f_clean.fixed is True
+    assert "already gone" not in f_clean.message
+    assert "kill failed" not in f_clean.message
+
+    f_race = by_name[session_race]
+    assert f_race.fixed is True
+    assert "already gone" in f_race.message
+
+    f_fail = by_name[session_fail]
+    assert f_fail.fixed is False
+    assert "kill failed" in f_fail.message
+
+
 def test_two_mock_colonies_dont_cross_see(tmp_path):
     """Two colonies with distinct data_dirs each see only their own orphans."""
     from unittest.mock import MagicMock, patch


### PR DESCRIPTION
## Summary

Five hardening items applied to `check_orphan_tmux_sessions` in `antfarm/core/doctor.py` (the function fixed by PR #241). Does not touch `sweep_legacy_tmux_sessions` (added by PR #248).

- **S1 (LC_ALL=C):** Added `env={**os.environ, "LC_ALL": "C"}` to both `tmux list-sessions` and `tmux kill-session` subprocess calls so stderr marker matching is locale-independent on any system locale.
- **S2 (stderr truncation):** Truncated the `detail` string to 200 chars with `…` suffix before composing the `kill failed:` finding message, preventing unbounded message growth from malformed tmux output.
- **S3 (mixed-batch test):** Added `test_check_orphan_tmux_sessions_fix_mixed_batch` — three orphans processed in one run covering clean kill, benign race (already gone), and genuine failure in a single call. Asserts `fixed=True`, `fixed=True + "already gone"`, and `fixed=False + "kill failed"` respectively.
- **N1 (defensive marker comment):** Added comment above `gone_markers` noting `"session not found"` is defensive coverage for tmux versions/ports beyond the tmux 3.x strings we've directly observed.
- **N2 (hash-scoping rationale comment):** Added comment above `kill-session` call noting session names are colony-hash-scoped (from #231), which is what makes race-tolerant `--fix` behavior safe to default-on.

## Test plan

- [x] `pytest tests/test_doctor.py -x -q` — 41 passed
- [x] `pytest tests/ -x -q` — 929 passed
- [x] `ruff check antfarm/ tests/` — all checks passed
- [x] New test `test_check_orphan_tmux_sessions_fix_mixed_batch` covers all three kill-session outcome branches in one call

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)