### PR TITLE
fix(serve): log colony hash on startup event, not every get_app call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - TUI now shows actionable guidance when the colony is unreachable, including the attempted URL and commands to start/redirect. (#246)
 
 ### Changed
+- The `colony hash: ...` startup log now fires once per server startup (FastAPI startup event) instead of on every `get_app()` call, reducing noise in test suites. (#249)
 - `deploy.py` tmux session names are now colony-scoped with an 8-char hash of `(realpath(fleet_config) | colony_url)`. **Breaking:** pre-upgrade deploy sessions won't be found by `deploy status` — kill them manually via `tmux kill-session` and redeploy. (#235)
 
 ## [0.6.3] - 2026-04-16

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -382,24 +382,28 @@ def get_app(
         pr_ops = GhPROps(cwd=repo_path) if repo_path else NullPROps()
         _backend = FileBackend(root=data_dir, pr_ops=pr_ops)
 
-    # Log the colony hash so operators can correlate tmux session names
-    # (auto-<hash>-*, runner-<hash>-*) back to this colony's data_dir.
-    try:
-        from antfarm.core.process_manager import colony_hash
-
-        logger.info(
-            "colony hash: %s (data_dir: %s)",
-            colony_hash(data_dir),
-            os.path.realpath(data_dir),
-        )
-    except Exception:  # noqa: BLE001 — logging must never break startup
-        pass
-
     # Fallback so downstream uses (Queen, etc.) still see a repo_path string.
     if repo_path is None:
         repo_path = "."
 
-    app = FastAPI(title="Antfarm Colony")
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _lifespan(application: FastAPI):  # noqa: ARG001
+        # Log colony hash once per server startup so operators can correlate
+        # tmux session names (auto-<hash>-*, runner-<hash>-*) to this data_dir.
+        # Fires only when uvicorn actually starts — not on every get_app() call,
+        # which would spam test suite logs.
+        try:
+            from antfarm.core.process_manager import colony_hash
+
+            resolved = os.path.realpath(data_dir)
+            logger.info("colony hash: %s (data_dir: %s)", colony_hash(data_dir), resolved)
+        except ImportError:
+            pass
+        yield
+
+    app = FastAPI(title="Antfarm Colony", lifespan=_lifespan)
 
     if auth_secret:
         from antfarm.core.auth import create_auth_middleware

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -913,7 +913,7 @@ def test_carry_accepts_mission_id(client):
 
 
 def test_startup_logs_colony_hash(tmp_path, caplog):
-    """Colony startup logs the 8-char data_dir hash so operators can correlate sessions."""
+    """Colony hash log fires once when the server actually starts (lifespan startup)."""
     import logging
 
     from antfarm.core.backends.file import FileBackend
@@ -922,8 +922,16 @@ def test_startup_logs_colony_hash(tmp_path, caplog):
     data_dir = str(tmp_path / ".antfarm")
     backend = FileBackend(root=data_dir)
 
+    app = get_app(backend=backend, data_dir=data_dir)
+
+    # Log must NOT appear from get_app() alone — only on server startup.
+    pre_start_matching = [r for r in caplog.records if "colony hash:" in r.getMessage()]
+    assert not pre_start_matching, "colony hash log must not fire on get_app(), only on startup"
+
+    # Startup fires when TestClient enters its context manager.
     with caplog.at_level(logging.INFO, logger="antfarm.core.serve"):
-        get_app(backend=backend, data_dir=data_dir)
+        with TestClient(app):
+            pass
 
     expected_hash = colony_hash(data_dir)
     matching = [
@@ -931,5 +939,21 @@ def test_startup_logs_colony_hash(tmp_path, caplog):
         for r in caplog.records
         if "colony hash:" in r.getMessage() and expected_hash in r.getMessage()
     ]
-    assert matching, f"expected colony hash log, got: {[r.getMessage() for r in caplog.records]}"
+    assert matching, f"expected colony hash log on startup, got: {[r.getMessage() for r in caplog.records]}"
     assert os.path.realpath(data_dir) in matching[0].getMessage()
+
+
+def test_get_app_does_not_log_colony_hash(tmp_path, caplog):
+    """get_app() must not emit colony hash log — it only fires on server startup."""
+    import logging
+
+    from antfarm.core.backends.file import FileBackend
+
+    data_dir = str(tmp_path / ".antfarm")
+    backend = FileBackend(root=data_dir)
+
+    with caplog.at_level(logging.INFO, logger="antfarm.core.serve"):
+        get_app(backend=backend, data_dir=data_dir)
+
+    noisy = [r for r in caplog.records if "colony hash:" in r.getMessage()]
+    assert not noisy, f"get_app() must not log colony hash, but got: {[r.getMessage() for r in noisy]}"

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -929,9 +929,8 @@ def test_startup_logs_colony_hash(tmp_path, caplog):
     assert not pre_start_matching, "colony hash log must not fire on get_app(), only on startup"
 
     # Startup fires when TestClient enters its context manager.
-    with caplog.at_level(logging.INFO, logger="antfarm.core.serve"):
-        with TestClient(app):
-            pass
+    with caplog.at_level(logging.INFO, logger="antfarm.core.serve"), TestClient(app):
+        pass
 
     expected_hash = colony_hash(data_dir)
     matching = [
@@ -939,7 +938,9 @@ def test_startup_logs_colony_hash(tmp_path, caplog):
         for r in caplog.records
         if "colony hash:" in r.getMessage() and expected_hash in r.getMessage()
     ]
-    assert matching, f"expected colony hash log on startup, got: {[r.getMessage() for r in caplog.records]}"
+    assert matching, (
+        f"expected colony hash log on startup, got: {[r.getMessage() for r in caplog.records]}"
+    )
     assert os.path.realpath(data_dir) in matching[0].getMessage()
 
 
@@ -956,4 +957,6 @@ def test_get_app_does_not_log_colony_hash(tmp_path, caplog):
         get_app(backend=backend, data_dir=data_dir)
 
     noisy = [r for r in caplog.records if "colony hash:" in r.getMessage()]
-    assert not noisy, f"get_app() must not log colony hash, but got: {[r.getMessage() for r in noisy]}"
+    assert not noisy, (
+        f"get_app() must not log colony hash, but got: {[r.getMessage() for r in noisy]}"
+    )


### PR DESCRIPTION
## Summary
- Move the `colony hash: ...` INFO log from `get_app()` into a FastAPI lifespan startup handler — fires once per server start, not on every app construction
- Fixes 25+ noisy log lines in `pytest -v --log-cli-level=INFO` runs with many test fixtures that call `get_app()`
- Narrows exception guard from `except Exception` to `except ImportError` (the only failure mode; `realpath` and `colony_hash` are safe once imported)

## Test plan
- [x] `test_startup_logs_colony_hash` updated to use `TestClient` context (triggers lifespan startup event) and verifies log appears
- [x] `test_startup_logs_colony_hash` also verifies log does NOT appear from `get_app()` alone (pre-start assertion)
- [x] `test_get_app_does_not_log_colony_hash` added — confirms construction-time silence
- [x] All 950 tests pass
- [x] `ruff check` passes

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)