### PR TITLE
docs: document deploy identity model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- Document deploy identity model in UPGRADE.md — how (realpath config + colony_url) hash determines session ownership, with examples of shared vs isolated namespaces and the localhost-tunnel edge case. (#244)
 - Per-worker current-action visibility: `POST /workers/{id}/activity`, TUI Activity column with elapsed time, and doctor `check_stuck_workers` warning for workers idle on an action > 5 min. (#239)
 - `antfarm doctor --sweep-legacy-tmux` flag (with `--yes`) to clean pre-#231/#235 tmux sessions host-wide. Requires interactive confirmation by default. (#237)
 - Colony startup now logs `colony hash: <8hex> (data_dir: <realpath>)` so operators can correlate tmux session names to a colony. (#237)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -86,3 +86,64 @@ antfarm doctor --sweep-legacy-tmux --yes
 This operates **host-wide** (not scoped to a single colony), so only run it
 when you're sure there's no peer colony on the box using the old format.
 Safe on any host that has been fully upgraded.
+
+---
+
+## Deploy Identity Model
+
+The 8-char hash embedded in deploy session names is computed as:
+
+```python
+colony_hash(f"{realpath(fleet_config)}|{colony_url}")
+```
+
+This means session ownership is determined by two things: **where the fleet config
+lives** (resolved absolute path) and **which colony the deploy targets**. The
+following scenarios explain the resulting behaviour.
+
+### Same colony, same fleet path → shared sessions (cooperative mode)
+
+Two operators running `antfarm deploy` with the same fleet file at the same
+absolute path against the same colony URL will produce identical hashes and
+therefore identical session names. The second `deploy` call attaches into the
+existing sessions via `tmux new-session -A` rather than spawning duplicates.
+
+This is the intended cooperative mode when a team shares a single deploy machine:
+one person deploys, another can check status or attach without creating extra
+workers.
+
+### Same colony, different fleet paths → isolated namespaces
+
+Operator A uses `~/team-a/fleet.json` and operator B uses `~/team-b/fleet.json`,
+both targeting the same colony. The differing `realpath` values produce different
+hashes, so each operator's sessions are fully isolated. Operator A killing "their"
+deploy sessions will not nuke Operator B's workers on the same node.
+
+### Different colony URLs → distinct namespaces
+
+Two deploys aimed at different colony URLs (e.g., `http://colony-dev:7433` vs
+`http://colony-prod:7433`) always produce different hashes — even with the same
+fleet file. Workers on the dev colony never collide with workers on the prod
+colony.
+
+This is the fix introduced in #235: previously, sessions were named only by
+`node_id + worker_index`, so workers from different colonies silently shared the
+same session name on the same host.
+
+### Known edge case: localhost + SSH tunnel
+
+If two operators both deploy using `colony_url=http://localhost:7433` (each with
+their own SSH tunnel to a different remote colony), the URL component of the hash
+is identical. If they also happen to use the same fleet config path (e.g., both
+checked out the repo to `~/antfarm/`), the hashes collide and the second deploy
+silently attaches into the first operator's sessions.
+
+**Recommendation:** When deploying to a remote colony via SSH tunnel, pass the
+colony's actual public or internal address rather than `localhost`:
+
+```bash
+antfarm deploy --colony-url http://colony-host:7433 --fleet-config fleet.json
+```
+
+This ensures each operator gets a unique hash even if their fleet config paths
+are identical.

--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -1064,7 +1064,11 @@ def deploy(
     integration_branch: str,
     colony_url: str,
 ):
-    """Deploy workers to remote nodes via SSH, or check deploy status."""
+    """Deploy workers to remote nodes via SSH, or check deploy status.
+
+    Session names are scoped by hash(realpath(config) | colony_url). See UPGRADE.md
+    for the full deploy identity model (shared vs isolated namespaces).
+    """
     from antfarm.core.deploy import deploy as run_deploy
     from antfarm.core.deploy import deploy_status
 

--- a/antfarm/core/deploy.py
+++ b/antfarm/core/deploy.py
@@ -2,6 +2,10 @@
 
 Reads a fleet configuration file and starts workers on remote machines via SSH.
 Each worker is launched inside a tmux session for persistence and easy monitoring.
+
+Session names are scoped by ``hash(realpath(fleet_config) | colony_url)``.
+See UPGRADE.md § "Deploy Identity Model" for the full explanation of shared vs
+isolated namespaces and the localhost-tunnel edge case.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- Adds a `## Deploy Identity Model` section to `UPGRADE.md` explaining how `colony_hash(realpath(fleet_config) | colony_url)` determines session ownership
- Covers four scenarios: shared/cooperative mode, isolated namespaces by fleet path, distinct namespaces by colony URL, and the localhost+SSH-tunnel edge case with mitigation advice
- Extends docstrings in `antfarm/core/deploy.py` (module-level) and `antfarm/core/cli.py` (`deploy` command) to reference the identity model and point to UPGRADE.md
- Updates CHANGELOG under `[Unreleased] ### Added`

## Test plan

- [x] Docs-only change — no behaviour modified
- [x] `ruff check antfarm/ tests/` — clean
- [x] `pytest tests/ -x -q` — 949 passed

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)