### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-04-16
+
 ### Added
 - Document deploy identity model in UPGRADE.md — how (realpath config + colony_url) hash determines session ownership, with examples of shared vs isolated namespaces and the localhost-tunnel edge case. (#244)
 - Per-worker current-action visibility: `POST /workers/{id}/activity`, TUI Activity column with elapsed time, and doctor `check_stuck_workers` warning for workers idle on an action > 5 min. (#239)
@@ -15,6 +17,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 - TUI now shows actionable guidance when the colony is unreachable, including the attempted URL and commands to start/redirect. (#246)
+- Doctor `check_orphan_tmux_sessions` hardened with `LC_ALL=C` (locale-independent stderr matching) and stderr truncation at 200 chars, so log output stays predictable and benign-race markers match reliably across locales. (#242)
+- Doctor `--fix` tolerates the `tmux kill-session` race when a session exits between list and kill; benign "can't find session" / "session not found" / "no server running" messages no longer produce spurious error findings. (#236)
 
 ### Changed
 - The `colony hash: ...` startup log now fires once per server startup (FastAPI startup event) instead of on every `get_app()` call, reducing noise in test suites. (#249)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antfarm"
-version = "0.6.3"
+version = "0.7.0"
 description = "Lightweight orchestration layer for distributing coding work across multiple AI coding agents"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Release v0.7.0 — bundles 8 PRs merged since v0.6.3 (2026-04-16).

Minor bump (not patch) because two `feat(...)` commits introduce new capabilities.

## What's in it

### Added
- `feat(worker)`: per-worker current-action visibility — `POST /workers/{id}/activity`, TUI Activity column, doctor `check_stuck_workers` warning (#239 via #245)
- `feat(doctor)`: `--sweep-legacy-tmux` flag + `UPGRADE.md` + startup colony-hash log (#237 via #248)
- `docs`: deploy identity model in UPGRADE.md (#244 via #252)

### Fixed
- `fix(tui)`: actionable guidance when colony unreachable (#246 via #247)
- `fix(doctor)`: `LC_ALL=C` + stderr truncation for orphan check (#242 via #250)
- `fix(doctor)`: harden `--fix` against tmux `kill-session` race (#236 via #241)

### Changed
- `fix(serve)`: colony-hash startup log in FastAPI lifespan instead of every `get_app()` call (#249 via #251)
- `fix(deploy)`: colony-scope tmux session names via `hash(realpath(config)|colony_url)` — **breaking** for pre-upgrade deploy sessions (#235 via #243)

## Test plan
- [x] `ruff check .` — clean
- [x] `pytest tests/ -x -q` — 950 passed
- [ ] CI green on this PR
- [ ] After merge: tag `v0.7.0` on main, create GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)