### PR TITLE
fix(worker): detect silent agent failures (#193)

### DIFF
--- a/antfarm/core/models.py
+++ b/antfarm/core/models.py
@@ -91,6 +91,7 @@ class FailureType(StrEnum):
     BUILD_FAILURE = "build_failure"
     INFRA_FAILURE = "infra_failure"
     INVALID_TASK = "invalid_task"
+    SILENT_FAILURE = "silent_failure"
 
 
 # ---------------------------------------------------------------------------

--- a/antfarm/core/worker.py
+++ b/antfarm/core/worker.py
@@ -42,6 +42,7 @@ RETRY_POLICIES: dict[FailureType, dict] = {
     FailureType.BUILD_FAILURE: {"retryable": True, "max_retries": 1, "action": "retry"},
     FailureType.MERGE_CONFLICT: {"retryable": True, "max_retries": 1, "action": "retry"},
     FailureType.INVALID_TASK: {"retryable": False, "max_retries": 0, "action": "escalate"},
+    FailureType.SILENT_FAILURE: {"retryable": False, "max_retries": 0, "action": "escalate"},
 }
 
 
@@ -52,6 +53,12 @@ def classify_failure(returncode: int, stderr: str, stdout: str) -> FailureType:
     come before test checks to prevent generic markers like 'error' or
     'failed' from triggering false test-failure classifications.
     """
+    # 0. Silent failure — returncode 0 but no output at all. Indicates a
+    # misconfigured agent (e.g., missing agent definition, adapter misconfig)
+    # that exits cleanly without doing any work.
+    if returncode == 0 and not stdout.strip() and not stderr.strip():
+        return FailureType.SILENT_FAILURE
+
     combined = (stderr + stdout).lower()
 
     # 1. Timeout (highest priority — clear signal)
@@ -347,13 +354,35 @@ class WorkerRuntime:
         finally:
             self._stop_heartbeat_loop()
 
-        if result.returncode != 0:
-            with contextlib.suppress(Exception):
-                self.colony.trail(
+        is_silent = (
+            result.returncode == 0
+            and not result.stdout.strip()
+            and not result.stderr.strip()
+        )
+
+        if result.returncode != 0 or is_silent:
+            if is_silent:
+                logger.warning(
+                    "silent agent failure detected task_id=%s attempt_id=%s "
+                    "worker_id=%s — returncode=0 with empty stdout+stderr",
                     task_id,
+                    attempt_id,
                     self.worker_id,
-                    f"agent failed (exit {result.returncode})",
                 )
+                with contextlib.suppress(Exception):
+                    self.colony.trail(
+                        task_id,
+                        self.worker_id,
+                        "silent_failure: agent exited 0 with empty stdout+stderr "
+                        "— likely missing agent definition or adapter misconfiguration",
+                    )
+            else:
+                with contextlib.suppress(Exception):
+                    self.colony.trail(
+                        task_id,
+                        self.worker_id,
+                        f"agent failed (exit {result.returncode})",
+                    )
             # Agent failed — classify, record, and trail the failure.
             failure = build_failure_record(
                 task_id=task_id,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1341,3 +1341,100 @@ def test_reviewer_polls_unchanged(tmp_path, http_client):
 
     # max_idle_polls=10 → one initial attempt + 10 retries = 11 forage calls
     assert call_count[0] == 11
+
+
+# ---------------------------------------------------------------------------
+# #193: Silent agent failure detection (returncode=0 + empty stdout + empty stderr)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_failure_silent_on_empty_output():
+    """returncode 0 with empty stdout AND stderr is classified as SILENT_FAILURE."""
+    from antfarm.core.worker import classify_failure
+
+    assert classify_failure(returncode=0, stderr="", stdout="") == FailureType.SILENT_FAILURE
+    # Whitespace-only counts as empty
+    assert classify_failure(returncode=0, stderr="\n", stdout="  ") == FailureType.SILENT_FAILURE
+    # Regression: returncode 0 with real stdout is NOT silent
+    assert classify_failure(returncode=0, stderr="", stdout="done") != FailureType.SILENT_FAILURE
+
+
+def test_build_failure_record_silent():
+    """Silent classification is non-retryable and escalates."""
+    from antfarm.core.worker import build_failure_record, get_retry_policy
+
+    rec = build_failure_record(
+        task_id="t1", attempt_id="a1", worker_id="w1",
+        returncode=0, stderr="", stdout="",
+    )
+    assert rec.failure_type == FailureType.SILENT_FAILURE
+    assert rec.retryable is False
+    assert rec.recommended_action == "escalate"
+
+    policy = get_retry_policy(FailureType.SILENT_FAILURE)
+    assert policy["retryable"] is False
+    assert policy["action"] == "escalate"
+
+
+def _silent_agent(task, workspace) -> AgentResult:
+    """Monkeypatch: simulates a silently-failing agent (exit 0, no output)."""
+    branch = f"feat/{task['id']}-{task['current_attempt']}"
+    return AgentResult(returncode=0, stdout="", stderr="", branch=branch)
+
+
+def test_process_one_task_silent_failure_trails_warning(tc, runtime):
+    """Silent agent failure emits a human-readable trail warning and FAILURE_RECORD,
+    and does NOT harvest the task."""
+    _carry(tc, task_id="task-silent-001")
+
+    runtime._launch_agent = _silent_agent
+    # Sentinel to confirm harvest is never called on silent failure
+    harvest_called = []
+    original_harvest = runtime.colony.harvest
+
+    def tracking_harvest(*args, **kwargs):
+        harvest_called.append((args, kwargs))
+        return original_harvest(*args, **kwargs)
+
+    runtime.colony.harvest = tracking_harvest
+    runtime.run()
+
+    r = tc.get("/tasks/task-silent-001")
+    task = r.json()
+    messages = [e["message"] for e in task["trail"]]
+
+    # Human-readable warning present
+    assert any(
+        "silent_failure" in m or "empty stdout" in m
+        for m in messages
+    ), f"expected silent_failure trail entry, got: {messages}"
+    # Structured FAILURE_RECORD emitted
+    assert any("[FAILURE_RECORD]" in m for m in messages)
+    # Harvest was NOT called — silent failure takes the failure branch
+    assert harvest_called == []
+
+
+def test_process_one_task_empty_stdout_with_stderr_not_silent(tc, runtime):
+    """Regression: returncode=0 with empty stdout but non-empty stderr is NOT silent —
+    it takes the normal success path."""
+    _carry(tc, task_id="task-warn-001")
+
+    def warning_agent(task, workspace) -> AgentResult:
+        branch = f"feat/{task['id']}-{task['current_attempt']}"
+        return AgentResult(returncode=0, stdout="", stderr="some warning", branch=branch)
+
+    runtime._launch_agent = warning_agent
+    runtime._build_artifact = lambda task, attempt_id, workspace, branch: {}
+    runtime._create_pr = lambda task, branch, workspace: ""
+    runtime.run()
+
+    r = tc.get("/tasks/task-warn-001")
+    task = r.json()
+    messages = [e["message"] for e in task["trail"]]
+
+    # Success path — no silent_failure trail
+    assert not any("silent_failure" in m for m in messages)
+    # No FAILURE_RECORD for a success
+    assert not any("[FAILURE_RECORD]" in m for m in messages)
+    # Success trail entries appear
+    assert "agent completed, building artifact" in messages


### PR DESCRIPTION
## Summary
- Detect `returncode=0` + empty stdout + empty stderr as `FailureType.SILENT_FAILURE` (non-retryable, escalate).
- Emit a `logger.warning` and a human-readable trail entry before the existing `[FAILURE_RECORD]` path so the failure is visible (not silently harvested).
- Gate lives in the single shared `_process_one_task` in `antfarm/core/worker.py`, so planner / builder / reviewer all benefit.

## Why
PR #192 fixed one root cause (missing `planner.md` in worktrees), but the symptom — silent success on empty output — remained. Any misconfigured agent (missing agent definition, adapter misconfig) would exit cleanly without doing work, then flow into artifact-building and fail opaquely downstream.

## Test Plan
- [x] `ruff check .` passes
- [x] `pytest tests/test_worker.py -x -q` — 56 passed (4 new)
- [x] `pytest tests/ -x -q` — 954 passed
- [x] New coverage:
  - `test_classify_failure_silent_on_empty_output` — classifier returns `SILENT_FAILURE` for `(0, "", "")` and whitespace-only variants; regression check for `(0, "done", "")`
  - `test_build_failure_record_silent` — `retryable=False`, `recommended_action="escalate"`
  - `test_process_one_task_silent_failure_trails_warning` — trail contains `silent_failure` / `empty stdout`, `[FAILURE_RECORD]` emitted, `harvest` not called
  - `test_process_one_task_empty_stdout_with_stderr_not_silent` — regression: stderr-only output still takes success path

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)