### PR TITLE
feat(colony): persist UUID identity in config.json (#238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Changed
+- Colony identity is now a persisted UUID stored as `colony_id` in `{data_dir}/config.json`. Tmux session prefixes (`auto-<hash>-*`, `runner-<hash>-*`) derive from this UUID via the new `colony_session_hash()`, making identity stable across `mv`, NFS, and Docker bind-mounts. `colony_hash()` remains as a pure hashing primitive (used by `deploy.py`). **Breaking:** first startup after upgrade generates a new UUID; pre-upgrade tmux sessions use the old realpath-based hash and become orphans — run `antfarm doctor --sweep-legacy-tmux` after draining in-flight work. See UPGRADE.md for the escape hatch to preserve an old hash. (#238)
+
 ## [0.7.0] - 2026-04-16
 
 ### Added

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,6 +3,46 @@
 This document describes breaking operational changes that require manual
 action between Antfarm versions.
 
+## 0.8.0 — Colony UUID Identity (#238)
+
+Colony identity is now a persisted UUID stored as ``colony_id`` inside
+``{data_dir}/config.json``. The 8-char hash embedded in tmux session names
+(``auto-<hash>-*``, ``runner-<hash>-*``) is derived from this UUID rather
+than from ``os.path.realpath(data_dir)``.
+
+**Why:** realpath-based identity was fragile. Moving ``.antfarm`` with
+``mv``, remounting it via NFS, or re-pointing a Docker bind-mount all
+produced a new hash, silently orphaning every running tmux session.
+A persisted UUID is stable across all three.
+
+**Consequence:** the first startup after upgrade generates a new UUID for
+each colony. Tmux sessions spawned by a pre-upgrade build used the old
+realpath-based hash, so they no longer match the colony's new prefix and
+become unmanaged orphans.
+
+**Recovery:** drain in-flight work (see the "Before you sweep" section
+below), then clean up:
+
+```bash
+antfarm doctor --sweep-legacy-tmux
+```
+
+**Escape hatch (advanced).** To preserve the old hash across the upgrade —
+e.g., when you have legacy sessions you cannot drain safely — compute the
+pre-upgrade realpath hash and seed it as ``colony_id`` in
+``config.json`` *before* the first post-upgrade startup:
+
+```bash
+python3 -c "import hashlib, os; print(hashlib.sha256(os.path.realpath('.antfarm').encode()).hexdigest()[:8])"
+# -> a1b2c3d4
+
+# then seed config.json (jq preserves other keys):
+jq '.colony_id = "a1b2c3d4"' .antfarm/config.json > /tmp/c && mv /tmp/c .antfarm/config.json
+```
+
+Any non-empty string is accepted as ``colony_id`` — the value is simply
+rehashed through SHA-256. Future operators should prefer the UUID default.
+
 ## Session-name format changes
 
 Antfarm now prefixes tmux session names with an 8-char hash of the colony's

--- a/antfarm/core/autoscaler.py
+++ b/antfarm/core/autoscaler.py
@@ -23,7 +23,11 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from antfarm.core.backends.base import TaskBackend
-from antfarm.core.process_manager import ProcessManager, colony_hash, get_process_manager
+from antfarm.core.process_manager import (
+    ProcessManager,
+    colony_session_hash,
+    get_process_manager,
+)
 
 if TYPE_CHECKING:
     from antfarm.core.actuator import Actuator  # noqa: F401
@@ -189,7 +193,11 @@ class Autoscaler:
         self.managed: dict[str, ManagedWorker] = {}
         self._stopped = False
         self._counter = 0
-        self._prefix = f"auto-{colony_hash(config.data_dir)}-"
+        # Ensure data_dir exists before deriving the session prefix — the
+        # persisted-UUID identity needs a real directory. See also
+        # Runner.__init__ for the matching guard.
+        os.makedirs(config.data_dir, exist_ok=True)
+        self._prefix = f"auto-{colony_session_hash(config.data_dir)}-"
         self._pm = (
             _pm
             if _pm is not None

--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -733,11 +733,12 @@ def doctor(fix: bool, data_dir: str, sweep_legacy_tmux: bool, yes: bool):
         sys.exit(2)
 
     if sweep_legacy_tmux:
-        from antfarm.core.process_manager import colony_hash
+        from antfarm.core.process_manager import colony_id, colony_session_hash
 
-        h = colony_hash(data_dir)
+        cid = colony_id(data_dir)
+        h = colony_session_hash(data_dir)
         real = os.path.realpath(data_dir)
-        click.echo(f"Colony hash: {h} (data_dir: {real})")
+        click.echo(f"Colony id: {cid} hash: {h} (data_dir: {real})")
         click.echo(
             "Legacy sessions (no hash) will be killed; all hashed sessions will be untouched."
         )

--- a/antfarm/core/doctor.py
+++ b/antfarm/core/doctor.py
@@ -1091,9 +1091,10 @@ def check_tmux_available(config: dict) -> list[Finding]:
 def check_orphan_tmux_sessions(config: dict, fix: bool = False) -> list[Finding]:
     """Detect tmux sessions owned by THIS colony that have no matching metadata.
 
-    Session names carry an 8-char SHA-256 hash of the colony's resolved
-    ``data_dir`` (see :func:`antfarm.core.process_manager.colony_hash`), so
-    this check considers only sessions matching one of THIS colony's prefixes:
+    Session names carry an 8-char SHA-256 hash of the colony's persisted
+    UUID identity (see :func:`antfarm.core.process_manager.colony_session_hash`),
+    so this check considers only sessions matching one of THIS colony's
+    prefixes:
 
     - ``auto-{hash}-`` — autoscaler-spawned workers
     - ``runner-{hash}-`` — Runner-spawned workers
@@ -1133,13 +1134,13 @@ def check_orphan_tmux_sessions(config: dict, fix: bool = False) -> list[Finding]
         # tmux server not running — no sessions to check
         return []
 
-    from antfarm.core.process_manager import colony_hash, parse_session_name
+    from antfarm.core.process_manager import colony_session_hash, parse_session_name
 
     data_dir = config.get("data_dir", "")
     if not data_dir:
         return []
 
-    h = colony_hash(data_dir)
+    h = colony_session_hash(data_dir)
     own_prefixes = (f"auto-{h}-", f"runner-{h}-")
     processes_dir = Path(data_dir) / "processes"
 

--- a/antfarm/core/process_manager.py
+++ b/antfarm/core/process_manager.py
@@ -9,6 +9,7 @@ Use get_process_manager() to get the right implementation.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import json
 import logging
@@ -16,6 +17,8 @@ import os
 import shlex
 import shutil
 import subprocess
+import tempfile
+import uuid
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -28,21 +31,134 @@ logger = logging.getLogger(__name__)
 SESSION_NAME_SEP = "-"
 
 
-def colony_hash(data_dir: str) -> str:
-    """Stable 8-char hex hash for this colony's tmux session prefix.
+def colony_hash(key: str) -> str:
+    """Stable 8-char hex hash primitive.
 
-    Resolves symlinks so ``data_dir``, ``./data_dir``, and the corresponding
-    absolute path collapse to the same hash. Operators who physically move
-    the directory get a new prefix — acceptable, since a move implies restart.
+    Applies ``os.path.realpath`` to the input before hashing so a directory,
+    a relative path to it, and a symlink pointing at it all collapse to the
+    same hash. For non-path inputs (e.g., ``deploy.py``'s composite
+    ``realpath(config)|colony_url`` key), realpath is a near no-op.
+
+    This function is now a pure hashing primitive. For colony identity that
+    is stable across ``mv``/NFS/Docker bind-mounts, callers should use
+    :func:`colony_session_hash`, which derives its key from a persisted UUID
+    rather than the filesystem path.
 
     Args:
-        data_dir: Colony data directory (``.antfarm/`` path or Runner state dir).
+        key: Arbitrary string (historically a colony ``data_dir`` path).
 
     Returns:
-        First 8 hex chars of SHA-256 over the resolved realpath.
+        First 8 hex chars of SHA-256 over ``realpath(key)``.
     """
-    real = os.path.realpath(data_dir)
+    real = os.path.realpath(key)
     return hashlib.sha256(real.encode("utf-8")).hexdigest()[:8]
+
+
+def colony_id(data_dir: str) -> str:
+    """Return the persisted colony identity UUID for ``data_dir``.
+
+    Colony identity is stored as the ``colony_id`` key inside
+    ``{data_dir}/config.json``. On first call the file is created or updated
+    with a fresh ``uuid.uuid4()`` value; subsequent calls return the same
+    value. A UUID is stable across filesystem operations that change the
+    path (``mv``, NFS remounts, Docker bind-mount re-pointing), while the
+    legacy ``realpath(data_dir)`` hash was not.
+
+    Concurrency: reads and writes are serialized by an ``fcntl.flock`` on
+    a sidecar lock file ``{data_dir}/.config.lock`` and the write is atomic
+    (temp file + ``fsync`` + ``os.replace``), so two threads/processes that
+    race through first-call generation agree on a single id and never lose
+    unrelated config keys.
+
+    Edge case: when ``data_dir`` does not yet exist, no file is created and
+    a synthetic ``"legacy:" + realpath(data_dir)`` sentinel is returned.
+    The sentinel is deterministic per path, will not collide with any real
+    UUID, and lets :func:`colony_session_hash` still produce a stable
+    string before the colony has materialized on disk.
+
+    Args:
+        data_dir: Colony data directory (``.antfarm/`` or Runner state dir).
+
+    Returns:
+        The persisted colony id string. May be any non-empty string; callers
+        must not assume a strict UUID shape.
+    """
+    if not os.path.isdir(data_dir):
+        # Safety net for pre-create edge cases (e.g., doctor scanning a path
+        # that hasn't been initialized yet). Do NOT create the directory —
+        # that would hide real configuration bugs.
+        return "legacy:" + os.path.realpath(data_dir)
+
+    config_path = os.path.join(data_dir, "config.json")
+    lock_path = os.path.join(data_dir, ".config.lock")
+
+    # flock serializes first-call UUID generation across threads AND processes.
+    import fcntl
+
+    lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+
+        cfg: dict = {}
+        if os.path.exists(config_path):
+            try:
+                with open(config_path) as f:
+                    loaded = json.load(f)
+                    if isinstance(loaded, dict):
+                        cfg = loaded
+            except (json.JSONDecodeError, OSError):
+                # Corrupt config.json — preserve nothing; a fresh id is
+                # strictly better than failing colony startup.
+                cfg = {}
+
+        existing = cfg.get("colony_id")
+        if isinstance(existing, str) and existing:
+            return existing
+
+        new_id = str(uuid.uuid4())
+        cfg["colony_id"] = new_id
+
+        # Atomic write: tempfile + fsync + os.replace. Preserves all other
+        # keys. Same-directory temp guarantees os.replace is atomic on POSIX.
+        # NamedTemporaryFile context-managed to avoid SIM115; delete=False
+        # lets us survive context exit and rename into place.
+        tmp_name: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                dir=data_dir,
+                prefix=".config.json.",
+                suffix=".tmp",
+                delete=False,
+            ) as tmp:
+                tmp_name = tmp.name
+                json.dump(cfg, tmp, indent=2)
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.replace(tmp_name, config_path)
+            tmp_name = None  # ownership transferred
+        finally:
+            if tmp_name is not None:
+                with contextlib.suppress(OSError):
+                    os.unlink(tmp_name)
+
+        return new_id
+    finally:
+        with contextlib.suppress(OSError):
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+
+
+def colony_session_hash(data_dir: str) -> str:
+    """Return the 8-char session-prefix hash derived from the persisted UUID.
+
+    This is the correct identity for tmux session naming: it is stable
+    across ``mv``, NFS remounts, and Docker bind-mount re-pointing, and it
+    differs between distinct colonies sharing the same path.
+
+    Equivalent to ``colony_hash(colony_id(data_dir))``.
+    """
+    return colony_hash(colony_id(data_dir))
 
 
 def parse_session_name(name: str, prefix: str) -> tuple[str, int] | None:

--- a/antfarm/core/runner.py
+++ b/antfarm/core/runner.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass, field
 from fastapi import FastAPI
 from pydantic import BaseModel, Field
 
-from antfarm.core.process_manager import colony_hash, get_process_manager
+from antfarm.core.process_manager import colony_session_hash, get_process_manager
 
 logger = logging.getLogger(__name__)
 
@@ -125,7 +125,14 @@ class Runner:
         self._lock = threading.Lock()
         self._colony = None  # ColonyClient, set in run()
 
-        self._prefix = f"runner-{colony_hash(self.state_dir)}-"
+        # Ensure state_dir exists before deriving the session prefix —
+        # colony_session_hash() needs a real directory to persist its UUID.
+        # Otherwise the first init would return a "legacy:" sentinel hash
+        # and a later call (after run() created state_dir) would see a
+        # different UUID-based hash, splitting managed sessions across
+        # two prefixes.
+        os.makedirs(self.state_dir, exist_ok=True)
+        self._prefix = f"runner-{colony_session_hash(self.state_dir)}-"
         self._pm = get_process_manager(prefix=self._prefix, state_dir=self.state_dir)
 
     def run(self) -> None:

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -359,6 +359,15 @@ def get_app(
     """
     global _backend, _max_attempts
 
+    # Ensure a persisted colony id exists BEFORE any other code (including
+    # the config.json read below) touches the file. colony_id() serializes
+    # its own read-modify-write, so calling it first guarantees subsequent
+    # readers see a consistent config.json with the colony_id key present.
+    if os.path.isdir(data_dir):
+        from antfarm.core.process_manager import colony_id as _ensure_colony_id
+
+        _ensure_colony_id(data_dir)
+
     # Load config up front so backend construction can see repo_path.
     repo_path: str | None = None
     integration_branch = "main"
@@ -395,10 +404,15 @@ def get_app(
         # Fires only when uvicorn actually starts — not on every get_app() call,
         # which would spam test suite logs.
         try:
-            from antfarm.core.process_manager import colony_hash
+            from antfarm.core.process_manager import colony_id, colony_session_hash
 
             resolved = os.path.realpath(data_dir)
-            logger.info("colony hash: %s (data_dir: %s)", colony_hash(data_dir), resolved)
+            logger.info(
+                "colony id: %s hash: %s (data_dir: %s)",
+                colony_id(data_dir),
+                colony_session_hash(data_dir),
+                resolved,
+            )
         except ImportError:
             pass
         yield

--- a/tests/test_autoscaler.py
+++ b/tests/test_autoscaler.py
@@ -79,12 +79,12 @@ def _mock_pm() -> MagicMock:
 
 
 def test_autoscaler_uses_hashed_prefix(tmp_path):
-    """Autoscaler's ProcessManager prefix is ``auto-{colony_hash(data_dir)}-``."""
-    from antfarm.core.process_manager import colony_hash
+    """Autoscaler's ProcessManager prefix is ``auto-{colony_session_hash(data_dir)}-``."""
+    from antfarm.core.process_manager import colony_session_hash
 
     data_dir = str(tmp_path / ".antfarm")
     a = _make_autoscaler(data_dir=data_dir)
-    expected = f"auto-{colony_hash(data_dir)}-"
+    expected = f"auto-{colony_session_hash(data_dir)}-"
     assert a._prefix == expected
 
 
@@ -627,11 +627,11 @@ class TestAdoptExisting:
         """
         from unittest.mock import MagicMock, patch
 
-        from antfarm.core.process_manager import TmuxProcessManager, colony_hash
+        from antfarm.core.process_manager import TmuxProcessManager, colony_session_hash
 
         data_dir = str(tmp_path / ".antfarm")
         os.makedirs(data_dir, exist_ok=True)
-        prefix = f"auto-{colony_hash(data_dir)}-"
+        prefix = f"auto-{colony_session_hash(data_dir)}-"
         pm = TmuxProcessManager(prefix=prefix, state_dir=data_dir)
 
         list_result = MagicMock()
@@ -656,11 +656,11 @@ class TestAdoptExisting:
         """
         from unittest.mock import MagicMock, patch
 
-        from antfarm.core.process_manager import TmuxProcessManager, colony_hash
+        from antfarm.core.process_manager import TmuxProcessManager, colony_session_hash
 
         data_dir = str(tmp_path / ".antfarm")
         os.makedirs(data_dir, exist_ok=True)
-        prefix = f"auto-{colony_hash(data_dir)}-"
+        prefix = f"auto-{colony_session_hash(data_dir)}-"
         pm = TmuxProcessManager(prefix=prefix, state_dir=data_dir)
 
         # Foreign hash that is very unlikely to collide with the real hash.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -400,7 +400,8 @@ def test_cli_doctor_sweep_prints_colony_hash_before_preview(tmp_path: Path):
         )
 
     assert result.exit_code == 0, result.output
-    assert "Colony hash:" in result.output
+    assert "Colony id:" in result.output
+    assert "hash:" in result.output
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_colony_id.py
+++ b/tests/test_colony_id.py
@@ -1,0 +1,131 @@
+"""Tests for the persisted-UUID colony identity (#238)."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import uuid
+
+from antfarm.core.process_manager import colony_hash, colony_id, colony_session_hash
+
+
+def test_colony_id_generated_on_first_call(tmp_path):
+    """Empty data_dir: first call generates a UUID and writes config.json."""
+    data_dir = str(tmp_path)
+    cid = colony_id(data_dir)
+    # Must parse as a UUID (no exception = pass).
+    uuid.UUID(cid)
+
+    config_path = os.path.join(data_dir, "config.json")
+    assert os.path.exists(config_path)
+    with open(config_path) as f:
+        cfg = json.load(f)
+    assert cfg["colony_id"] == cid
+
+
+def test_colony_id_persisted_across_calls(tmp_path):
+    """Two calls against the same data_dir return the same id."""
+    data_dir = str(tmp_path)
+    first = colony_id(data_dir)
+    second = colony_id(data_dir)
+    assert first == second
+
+
+def test_colony_id_not_regenerated_when_present(tmp_path):
+    """Pre-seeded config.json::colony_id is returned verbatim."""
+    data_dir = str(tmp_path)
+    seeded = str(uuid.uuid4())
+    with open(os.path.join(data_dir, "config.json"), "w") as f:
+        json.dump({"colony_id": seeded}, f)
+
+    assert colony_id(data_dir) == seeded
+
+
+def test_colony_id_preserves_existing_config_keys(tmp_path):
+    """Generating a new id must not clobber unrelated config keys."""
+    data_dir = str(tmp_path)
+    with open(os.path.join(data_dir, "config.json"), "w") as f:
+        json.dump({"repo_path": "/foo"}, f)
+
+    cid = colony_id(data_dir)
+
+    with open(os.path.join(data_dir, "config.json")) as f:
+        cfg = json.load(f)
+    assert cfg["repo_path"] == "/foo"
+    assert cfg["colony_id"] == cid
+
+
+def test_colony_id_fallback_when_data_dir_missing(tmp_path):
+    """Missing data_dir: return a non-empty sentinel, create no file."""
+    data_dir = str(tmp_path / "does-not-exist")
+    result = colony_id(data_dir)
+
+    assert result
+    assert result.startswith("legacy:")
+    assert not os.path.exists(data_dir)
+
+
+def test_colony_id_accepts_non_uuid_strings(tmp_path):
+    """Any non-empty string in config.json::colony_id is returned verbatim."""
+    data_dir = str(tmp_path)
+    with open(os.path.join(data_dir, "config.json"), "w") as f:
+        json.dump({"colony_id": "custom-name"}, f)
+
+    assert colony_id(data_dir) == "custom-name"
+
+
+def test_colony_id_concurrent_writers(tmp_path):
+    """Racing first-call generations converge on a single id."""
+    data_dir = str(tmp_path)
+    results: list[str] = []
+    barrier = threading.Barrier(5)
+
+    def worker():
+        barrier.wait()
+        results.append(colony_id(data_dir))
+
+    threads = [threading.Thread(target=worker) for _ in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(set(results)) == 1, results
+    with open(os.path.join(data_dir, "config.json")) as f:
+        cfg = json.load(f)
+    assert cfg["colony_id"] == results[0]
+
+
+def test_colony_session_hash_derives_from_id(tmp_path):
+    """colony_session_hash == colony_hash(colony_id(data_dir)) and 8 hex chars."""
+    data_dir = str(tmp_path)
+    h = colony_session_hash(data_dir)
+
+    assert h == colony_hash(colony_id(data_dir))
+    assert len(h) == 8
+    assert all(c in "0123456789abcdef" for c in h)
+
+
+def test_colony_session_hash_stable_across_realpath_change(tmp_path):
+    """Same colony_id in two different paths yields the same session hash.
+
+    This is the property the legacy ``colony_hash(data_dir)`` lacked:
+    moving the directory previously produced a new prefix, orphaning all
+    running tmux sessions. Pinning identity to a persisted UUID means two
+    colonies at different paths with the same ``colony_id`` produce the
+    same hash — i.e., hash tracks identity, not location.
+    """
+    shared_id = str(uuid.uuid4())
+
+    dir_a = tmp_path / "a"
+    dir_a.mkdir()
+    with open(dir_a / "config.json", "w") as f:
+        json.dump({"colony_id": shared_id}, f)
+
+    dir_b = tmp_path / "b"
+    dir_b.mkdir()
+    with open(dir_b / "config.json", "w") as f:
+        json.dump({"colony_id": shared_id}, f)
+
+    assert colony_session_hash(str(dir_a)) == colony_session_hash(str(dir_b))

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -717,13 +717,13 @@ def test_check_orphan_tmux_sessions_detects_orphans(tmp_path):
     from unittest.mock import MagicMock, patch
 
     from antfarm.core.doctor import check_orphan_tmux_sessions
-    from antfarm.core.process_manager import colony_hash
+    from antfarm.core.process_manager import colony_session_hash
 
     data_dir = tmp_path / ".antfarm"
     processes_dir = data_dir / "processes"
     processes_dir.mkdir(parents=True)
 
-    h = colony_hash(str(data_dir))
+    h = colony_session_hash(str(data_dir))
     known = f"auto-{h}-builder-1"
     orphan = f"auto-{h}-planner-2"
 
@@ -837,12 +837,12 @@ def test_orphan_own_prefix_detected_as_warning(tmp_path):
     from unittest.mock import MagicMock, patch
 
     from antfarm.core.doctor import check_orphan_tmux_sessions
-    from antfarm.core.process_manager import colony_hash
+    from antfarm.core.process_manager import colony_session_hash
 
     data_dir = tmp_path / ".antfarm"
     (data_dir / "processes").mkdir(parents=True)
 
-    h = colony_hash(str(data_dir))
+    h = colony_session_hash(str(data_dir))
     orphan = f"runner-{h}-builder-7"
 
     mock_result = MagicMock()
@@ -890,12 +890,12 @@ def test_orphan_fix_kills_session(tmp_path):
     from unittest.mock import MagicMock, patch
 
     from antfarm.core.doctor import check_orphan_tmux_sessions
-    from antfarm.core.process_manager import colony_hash
+    from antfarm.core.process_manager import colony_session_hash
 
     data_dir = tmp_path / ".antfarm"
     (data_dir / "processes").mkdir(parents=True)
 
-    h = colony_hash(str(data_dir))
+    h = colony_session_hash(str(data_dir))
     own_orphan = f"auto-{h}-builder-3"
     peer = "auto-ffffffff-builder-3"
 
@@ -936,12 +936,12 @@ def _run_orphan_fix_with_kill_result(tmp_path, kill_returncode: int, kill_stderr
     from unittest.mock import MagicMock, patch
 
     from antfarm.core.doctor import check_orphan_tmux_sessions
-    from antfarm.core.process_manager import colony_hash
+    from antfarm.core.process_manager import colony_session_hash
 
     data_dir = tmp_path / ".antfarm"
     (data_dir / "processes").mkdir(parents=True)
 
-    h = colony_hash(str(data_dir))
+    h = colony_session_hash(str(data_dir))
     own_orphan = f"auto-{h}-builder-3"
 
     list_result = MagicMock()
@@ -1038,12 +1038,12 @@ def test_check_orphan_tmux_sessions_fix_mixed_batch(tmp_path):
     from unittest.mock import MagicMock, patch
 
     from antfarm.core.doctor import check_orphan_tmux_sessions
-    from antfarm.core.process_manager import colony_hash
+    from antfarm.core.process_manager import colony_session_hash
 
     data_dir = tmp_path / ".antfarm"
     (data_dir / "processes").mkdir(parents=True)
 
-    h = colony_hash(str(data_dir))
+    h = colony_session_hash(str(data_dir))
     session_clean = f"auto-{h}-builder-1"
     session_race = f"auto-{h}-builder-2"
     session_fail = f"auto-{h}-builder-3"
@@ -1110,15 +1110,15 @@ def test_two_mock_colonies_dont_cross_see(tmp_path):
     from unittest.mock import MagicMock, patch
 
     from antfarm.core.doctor import check_orphan_tmux_sessions
-    from antfarm.core.process_manager import colony_hash
+    from antfarm.core.process_manager import colony_session_hash
 
     dir_a = tmp_path / "colony-a"
     dir_b = tmp_path / "colony-b"
     (dir_a / "processes").mkdir(parents=True)
     (dir_b / "processes").mkdir(parents=True)
 
-    h_a = colony_hash(str(dir_a))
-    h_b = colony_hash(str(dir_b))
+    h_a = colony_session_hash(str(dir_a))
+    h_b = colony_session_hash(str(dir_b))
     assert h_a != h_b
 
     name_a = f"auto-{h_a}-builder-1"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -58,11 +58,11 @@ class TestRunnerDefaults:
         assert r._pm is not None
 
     def test_runner_uses_hashed_prefix(self, tmp_path):
-        """Runner's ProcessManager prefix is ``runner-{colony_hash(state_dir)}-`` (#231)."""
-        from antfarm.core.process_manager import colony_hash
+        """Runner's ProcessManager prefix is ``runner-{colony_session_hash(state_dir)}-`` (#238)."""
+        from antfarm.core.process_manager import colony_session_hash
 
         r = _make_runner(tmp_path)
-        expected = f"runner-{colony_hash(r.state_dir)}-"
+        expected = f"runner-{colony_session_hash(r.state_dir)}-"
         assert r._prefix == expected
 
 
@@ -308,10 +308,10 @@ class TestAdoptExistingWorkers:
         the legacy name lacks the hash token so ``list_managed()`` filters it
         out before it reaches ``_adopt_existing_workers``.
         """
-        from antfarm.core.process_manager import TmuxProcessManager, colony_hash
+        from antfarm.core.process_manager import TmuxProcessManager, colony_session_hash
 
         r = _make_runner(tmp_path)
-        prefix = f"runner-{colony_hash(r.state_dir)}-"
+        prefix = f"runner-{colony_session_hash(r.state_dir)}-"
         r._pm = TmuxProcessManager(prefix=prefix, state_dir=r.state_dir)
         r._prefix = prefix
 

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -913,11 +913,11 @@ def test_carry_accepts_mission_id(client):
 
 
 def test_startup_logs_colony_hash(tmp_path, caplog):
-    """Colony hash log fires once when the server actually starts (lifespan startup)."""
+    """Colony id+hash log fires once when the server actually starts (lifespan startup)."""
     import logging
 
     from antfarm.core.backends.file import FileBackend
-    from antfarm.core.process_manager import colony_hash
+    from antfarm.core.process_manager import colony_id, colony_session_hash
 
     data_dir = str(tmp_path / ".antfarm")
     backend = FileBackend(root=data_dir)
@@ -925,27 +925,30 @@ def test_startup_logs_colony_hash(tmp_path, caplog):
     app = get_app(backend=backend, data_dir=data_dir)
 
     # Log must NOT appear from get_app() alone — only on server startup.
-    pre_start_matching = [r for r in caplog.records if "colony hash:" in r.getMessage()]
-    assert not pre_start_matching, "colony hash log must not fire on get_app(), only on startup"
+    pre_start_matching = [r for r in caplog.records if "colony id:" in r.getMessage()]
+    assert not pre_start_matching, "colony id log must not fire on get_app(), only on startup"
 
     # Startup fires when TestClient enters its context manager.
     with caplog.at_level(logging.INFO, logger="antfarm.core.serve"), TestClient(app):
         pass
 
-    expected_hash = colony_hash(data_dir)
+    expected_id = colony_id(data_dir)
+    expected_hash = colony_session_hash(data_dir)
     matching = [
         r
         for r in caplog.records
-        if "colony hash:" in r.getMessage() and expected_hash in r.getMessage()
+        if "colony id:" in r.getMessage()
+        and expected_id in r.getMessage()
+        and expected_hash in r.getMessage()
     ]
     assert matching, (
-        f"expected colony hash log on startup, got: {[r.getMessage() for r in caplog.records]}"
+        f"expected colony id log on startup, got: {[r.getMessage() for r in caplog.records]}"
     )
     assert os.path.realpath(data_dir) in matching[0].getMessage()
 
 
 def test_get_app_does_not_log_colony_hash(tmp_path, caplog):
-    """get_app() must not emit colony hash log — it only fires on server startup."""
+    """get_app() must not emit colony id/hash log — it only fires on server startup."""
     import logging
 
     from antfarm.core.backends.file import FileBackend
@@ -956,7 +959,7 @@ def test_get_app_does_not_log_colony_hash(tmp_path, caplog):
     with caplog.at_level(logging.INFO, logger="antfarm.core.serve"):
         get_app(backend=backend, data_dir=data_dir)
 
-    noisy = [r for r in caplog.records if "colony hash:" in r.getMessage()]
+    noisy = [r for r in caplog.records if "colony id:" in r.getMessage()]
     assert not noisy, (
-        f"get_app() must not log colony hash, but got: {[r.getMessage() for r in noisy]}"
+        f"get_app() must not log colony id, but got: {[r.getMessage() for r in noisy]}"
     )


### PR DESCRIPTION
## Summary

- Colony identity is now a persisted UUID (`colony_id` key in `{data_dir}/config.json`) instead of a hash of `os.path.realpath(data_dir)`.
- New `colony_session_hash(data_dir)` derives the 8-char tmux prefix hash from the UUID, making identity stable across `mv`, NFS remounts, and Docker bind-mount re-pointing.
- `colony_hash(key)` stays as a pure hashing primitive so `deploy.py` (which passes a composite `realpath(fleet_config)|colony_url` key) keeps its existing behaviour.

## API

- `colony_hash(key: str) -> str` — unchanged hashing primitive (realpath + SHA-256[:8]).
- `colony_id(data_dir: str) -> str` — returns the persisted UUID. First call generates one, writes it atomically (`tempfile` + `fsync` + `os.replace`) under `fcntl.flock`, and preserves all other `config.json` keys. Returns a `legacy:<realpath>` sentinel when `data_dir` does not yet exist; any non-empty string is accepted verbatim.
- `colony_session_hash(data_dir: str) -> str` — thin `colony_hash(colony_id(...))` wrapper.

## Call-site migration

- `autoscaler.py`, `runner.py`, `doctor.py::check_orphan_tmux_sessions`, CLI `doctor --sweep-legacy-tmux`, and `serve.py` lifespan startup log all switch to `colony_session_hash`.
- Serve's startup log now emits `colony id: <uuid> hash: <8hex> (data_dir: <realpath>)`.
- Runner and Autoscaler `mkdir(state_dir/data_dir, exist_ok=True)` before deriving the prefix, so the first init can't fall back to the `legacy:` sentinel and then differ from a later UUID-based call.
- `deploy.py` is intentionally untouched — its composite key does not need per-colony UUID identity.

## Breaking change

First startup after upgrade generates a fresh UUID per colony. Pre-upgrade tmux sessions use the old realpath-based hash and become unmanaged orphans.

**Recovery:**

1. Drain in-flight work (see UPGRADE.md "Before you sweep").
2. `antfarm doctor --sweep-legacy-tmux`

**Escape hatch:** to preserve an old hash, compute `sha256(realpath(.antfarm))[:8]` and seed it as `colony_id` in `config.json` before the first post-upgrade startup. Any non-empty string is accepted. Documented in UPGRADE.md.

## Test plan

- [x] `pytest tests/ -x -q` → 963 passed (was 954 baseline; +9 from new `test_colony_id.py`).
- [x] `ruff check .` passes.
- [x] `ruff format tests/test_colony_id.py antfarm/core/process_manager.py` — no diffs.
- [x] New test file `tests/test_colony_id.py` covers: first-call generation, persistence, pre-seeded values (UUID + non-UUID), preservation of unrelated keys, missing-dir sentinel, 5-thread concurrent writer race, session-hash derivation, and path-independence of session hash.
- [x] Updated call-site tests (`test_serve.py`, `test_cli.py`, `test_runner.py`, `test_autoscaler.py`, `test_doctor.py`) to use `colony_session_hash`.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)