### PR TITLE
chore: v0.6.2 polish (#211)

### DIFF
--- a/antfarm/core/doctor.py
+++ b/antfarm/core/doctor.py
@@ -1124,12 +1124,19 @@ def check_orphan_tmux_sessions(config: dict, fix: bool = False) -> list[Finding]
     if not shutil.which("tmux"):
         return []
 
-    result = subprocess.run(
-        ["tmux", "list-sessions", "-F", "#{session_name}"],
-        capture_output=True,
-        text=True,
-        env={**os.environ, "LC_ALL": "C"},
-    )
+    try:
+        result = subprocess.run(
+            ["tmux", "list-sessions", "-F", "#{session_name}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env={**os.environ, "LC_ALL": "C"},
+        )
+    except (OSError, subprocess.SubprocessError, subprocess.TimeoutExpired):
+        # tmux binary unreachable or hung — treat as no sessions.
+        # subprocess.TimeoutExpired is a subclass of SubprocessError but is
+        # listed explicitly to match the issue's intent and clarify coverage.
+        return []
     if result.returncode != 0:
         # tmux server not running — no sessions to check
         return []
@@ -1171,12 +1178,20 @@ def check_orphan_tmux_sessions(config: dict, fix: bool = False) -> list[Finding]
             # Session name is already colony-hash-scoped (see #231), so we never
             # kill a peer colony's session — this is what makes the race-tolerant
             # behavior safe to default-on.
-            kill = subprocess.run(
-                ["tmux", "kill-session", "-t", name],
-                capture_output=True,
-                text=True,
-                env={**os.environ, "LC_ALL": "C"},
-            )
+            try:
+                kill = subprocess.run(
+                    ["tmux", "kill-session", "-t", name],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
+                    env={**os.environ, "LC_ALL": "C"},
+                )
+            except subprocess.TimeoutExpired:
+                # tmux kill-session hung — leave finding unfixed with explicit note.
+                finding.fixed = False
+                finding.message += " — kill timed out"
+                findings.append(finding)
+                continue
             if kill.returncode == 0:
                 finding.fixed = True
             else:
@@ -1245,6 +1260,13 @@ def sweep_legacy_tmux_sessions(
     Run it only after confirming there is no peer colony still using the
     legacy format.
 
+    False-positive risk: the legacy pattern matches any session named
+    ``auto-<word>-<int>`` (and ``runner-<word>-<int>``, ``antfarm-...-<int>``)
+    where ``<word>`` is not an 8-char hex token. A user-owned tmux session
+    such as ``auto-save-5`` will match by design. Safety relies on the
+    interactive gate in the CLI (``--yes`` confirmation or operator prompt)
+    rather than on pattern precision; never call this function unattended.
+
     Args:
         config: Doctor config dict (unused; signature mirrors other checks).
         confirmed: When True, kill each match. Default False (dry-run preview).
@@ -1257,12 +1279,17 @@ def sweep_legacy_tmux_sessions(
         return []
 
     env = {**os.environ, "LC_ALL": "C"}
-    result = subprocess.run(
-        ["tmux", "list-sessions", "-F", "#{session_name}"],
-        capture_output=True,
-        text=True,
-        env=env,
-    )
+    try:
+        result = subprocess.run(
+            ["tmux", "list-sessions", "-F", "#{session_name}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            env=env,
+        )
+    except (OSError, subprocess.SubprocessError, subprocess.TimeoutExpired):
+        # tmux binary unreachable or hung — nothing to sweep.
+        return []
     if result.returncode != 0:
         # tmux server not running — nothing to sweep
         return []

--- a/antfarm/core/runner.py
+++ b/antfarm/core/runner.py
@@ -254,7 +254,14 @@ class Runner:
             }
 
     def stop(self) -> None:
-        """Stop all managed workers and clean up."""
+        """Shutdown: stop all managed workers.
+
+        Metadata cleanup policy: stop() kills sessions/processes but does NOT
+        remove metadata files. Metadata is cleaned up during the next adoption
+        pass (stale metadata with dead processes gets removed). Same policy as
+        autoscaler.stop() — metadata should outlive the runner process so
+        restart adoption works.
+        """
         self._stopped = True
         with self._lock:
             for name in list(self.managed):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1385,3 +1385,120 @@ def test_run_doctor_sweep_legacy_tmux_flag_invokes_sweep():
     legacy = [f for f in findings if f.check == "legacy_tmux_session"]
     assert len(legacy) == 1
     assert legacy[0].fixed is True
+
+
+# ---------------------------------------------------------------------------
+# Defensive subprocess hardening (issue #211)
+# ---------------------------------------------------------------------------
+
+
+def test_check_orphan_tmux_sessions_returns_empty_on_subprocess_timeout():
+    """tmux list-sessions hanging (TimeoutExpired) → [] rather than crashing."""
+    import subprocess
+    from unittest.mock import patch
+
+    from antfarm.core.doctor import check_orphan_tmux_sessions
+
+    with (
+        patch("antfarm.core.doctor.shutil.which", return_value="/usr/bin/tmux"),
+        patch(
+            "antfarm.core.doctor.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["tmux"], timeout=5),
+        ),
+    ):
+        assert check_orphan_tmux_sessions({"data_dir": "/x"}) == []
+
+
+def test_check_orphan_tmux_sessions_returns_empty_on_oserror():
+    """tmux binary unavailable (OSError from subprocess) → [] rather than crashing."""
+    from unittest.mock import patch
+
+    from antfarm.core.doctor import check_orphan_tmux_sessions
+
+    with (
+        patch("antfarm.core.doctor.shutil.which", return_value="/usr/bin/tmux"),
+        patch("antfarm.core.doctor.subprocess.run", side_effect=OSError("boom")),
+    ):
+        assert check_orphan_tmux_sessions({"data_dir": "/x"}) == []
+
+
+def test_sweep_legacy_returns_empty_on_subprocess_error():
+    """sweep_legacy_tmux_sessions: SubprocessError from list-sessions → [] (no crash)."""
+    import subprocess
+    from unittest.mock import patch
+
+    from antfarm.core.doctor import sweep_legacy_tmux_sessions
+
+    with (
+        patch("antfarm.core.doctor.shutil.which", return_value="/usr/bin/tmux"),
+        patch(
+            "antfarm.core.doctor.subprocess.run",
+            side_effect=subprocess.SubprocessError("boom"),
+        ),
+    ):
+        assert sweep_legacy_tmux_sessions({"data_dir": "/x"}, confirmed=False) == []
+        assert sweep_legacy_tmux_sessions({"data_dir": "/x"}, confirmed=True) == []
+
+
+def test_check_orphan_kill_timeout_does_not_mark_fixed(tmp_path):
+    """Orphan detected, but tmux kill-session hangs → finding.fixed=False with timeout note."""
+    import subprocess
+    from unittest.mock import MagicMock, patch
+
+    from antfarm.core.doctor import check_orphan_tmux_sessions
+    from antfarm.core.process_manager import colony_session_hash
+
+    data_dir = tmp_path / ".antfarm"
+    (data_dir / "processes").mkdir(parents=True)
+
+    h = colony_session_hash(str(data_dir))
+    own_orphan = f"auto-{h}-builder-7"
+
+    list_result = MagicMock()
+    list_result.returncode = 0
+    list_result.stdout = f"{own_orphan}\n"
+
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["tmux", "list-sessions"]:
+            return list_result
+        if cmd[:2] == ["tmux", "kill-session"]:
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=5)
+        raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+    with (
+        patch("antfarm.core.doctor.shutil.which", return_value="/usr/bin/tmux"),
+        patch("antfarm.core.doctor.subprocess.run", side_effect=fake_run),
+    ):
+        findings = check_orphan_tmux_sessions({"data_dir": str(data_dir)}, fix=True)
+
+    assert len(findings) == 1
+    assert findings[0].fixed is False
+    assert "kill timed out" in findings[0].message
+
+
+def test_sweep_legacy_matches_user_sessions_by_design():
+    """Legacy pattern matches user sessions like ``auto-save-5`` by design.
+
+    Interactive confirmation in the CLI is the safety net — the pattern
+    cannot distinguish antfarm's legacy sessions from unrelated user-owned
+    sessions that happen to share the shape. See
+    :func:`antfarm.core.doctor.sweep_legacy_tmux_sessions` for the documented
+    false-positive risk.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from antfarm.core.doctor import sweep_legacy_tmux_sessions
+
+    list_result = MagicMock()
+    list_result.returncode = 0
+    list_result.stdout = "auto-save-5\n"
+
+    with (
+        patch("antfarm.core.doctor.shutil.which", return_value="/usr/bin/tmux"),
+        patch("antfarm.core.doctor.subprocess.run", return_value=list_result),
+    ):
+        findings = sweep_legacy_tmux_sessions({"data_dir": "/x"}, confirmed=False)
+
+    assert len(findings) == 1
+    assert findings[0].check == "legacy_tmux_session"
+    assert "auto-save-5" in findings[0].message


### PR DESCRIPTION
## Summary
- Harden both `subprocess.run(["tmux", "list-sessions", ...])` calls in `doctor.py` with `timeout=5` and `try/except (OSError, subprocess.SubprocessError, subprocess.TimeoutExpired)` so a hung or missing tmux binary degrades to "no sessions" instead of crashing the doctor pass.
- Harden the `tmux kill-session` call in `check_orphan_tmux_sessions`: `timeout=5` plus a dedicated `TimeoutExpired` path that leaves the finding unfixed and appends `kill timed out` to the message.
- Replace `runner.stop()`'s one-line docstring with a Google-style docstring matching `autoscaler.stop()` — documents the metadata-outlives-the-process policy that makes restart adoption work.
- Document the accepted false-positive risk in `sweep_legacy_tmux_sessions` (pattern matches `auto-save-5` by design) and point at the interactive CLI gate as the safety net.

Item 2 of #211 (`_adopt_existing` metadata load isolation) is already implemented — `_list_metadata` in `antfarm/core/process_manager.py` wraps each per-file load in `try/except (json.JSONDecodeError, OSError, KeyError): continue`, so a single bad metadata file does not abort the adoption pass.

## Test Plan
- [x] `ruff check .` — clean
- [x] `ruff format antfarm/core/doctor.py antfarm/core/runner.py tests/test_doctor.py` — no changes
- [x] `pytest tests/ -x -q` — 969 passed (was 964 baseline; +5 new tests for timeout/OSError/SubprocessError paths plus the documented legacy-sweep false-positive)
- [x] New tests:
  - `test_check_orphan_tmux_sessions_returns_empty_on_subprocess_timeout`
  - `test_check_orphan_tmux_sessions_returns_empty_on_oserror`
  - `test_sweep_legacy_returns_empty_on_subprocess_error`
  - `test_check_orphan_kill_timeout_does_not_mark_fixed`
  - `test_sweep_legacy_matches_user_sessions_by_design`

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)