### PR TITLE
refactor(soldier): use is_infra_task in get_merge_queue (#261)

### DIFF
--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -327,12 +327,12 @@ class Soldier:
                 merged_task_ids.add(t["id"])
 
         # Filter to done tasks with a branch and satisfied deps
-        # Exclude review tasks (id starts with "review-") — they are informational
+        # Exclude infra tasks (review tasks, etc.) — they are informational
         eligible = []
         for task in all_tasks:
             if task.get("status") != "done":
                 continue
-            if task.get("id", "").startswith("review-"):
+            if is_infra_task(task):
                 continue
             # Skip already-merged tasks
             if self._has_merged_attempt(task):

--- a/tests/test_soldier.py
+++ b/tests/test_soldier.py
@@ -1334,3 +1334,27 @@ def test_get_done_candidates_skips_review_capability_task(soldier_env):
 
     candidates = soldier._get_done_candidates()
     assert not any(t["id"] == "task-cap-review-2" for t in candidates)
+
+
+def test_get_merge_queue_skips_review_capability_task(soldier_env):
+    """Task with capabilities_required=['review'] but non-'review-' id is
+    excluded from the merge queue via get_merge_queue.
+
+    Exercises the is_infra_task() consolidation in get_merge_queue: previously
+    only ids starting with 'review-' were skipped. Now any task whose
+    capabilities include 'review' is treated as infra and excluded.
+    """
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _carry_and_harvest_with_caps(
+        cc,
+        repo,
+        "task-cap-review-3",
+        "feat/task-cap-review-3",
+        capabilities_required=["review"],
+    )
+
+    queue = soldier.get_merge_queue()
+    assert not any(t["id"] == "task-cap-review-3" for t in queue)


### PR DESCRIPTION
## Summary
- Replace inline `task.get("id", "").startswith("review-")` check in `get_merge_queue` with the shared `is_infra_task()` helper (imported since #260).
- Completes the `is_infra_task` consolidation started in #260 — any task whose capabilities include `review` is now consistently excluded from the merge queue, not just tasks whose id happens to start with `review-`.
- Adds `test_get_merge_queue_skips_review_capability_task` mirroring the pattern of the analogous `_get_done_candidates` test from #260.

Closes #261

## Test plan
- [x] `ruff check .` passes
- [x] `ruff format` leaves touched files unchanged
- [x] `pytest tests/ -x -q` — 972 passed (baseline 971, +1 new test)

Generated with [Claude Code](https://claude.com/claude-code)