### PR TITLE
chore: rename v0.7.0 → v0.6.4 (stay in 0.6.x series)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 ### Changed
 - Colony identity is now a persisted UUID stored as `colony_id` in `{data_dir}/config.json`. Tmux session prefixes (`auto-<hash>-*`, `runner-<hash>-*`) derive from this UUID via the new `colony_session_hash()`, making identity stable across `mv`, NFS, and Docker bind-mounts. `colony_hash()` remains as a pure hashing primitive (used by `deploy.py`). **Breaking:** first startup after upgrade generates a new UUID; pre-upgrade tmux sessions use the old realpath-based hash and become orphans — run `antfarm doctor --sweep-legacy-tmux` after draining in-flight work. See UPGRADE.md for the escape hatch to preserve an old hash. (#238)
 
-## [0.7.0] - 2026-04-16
+## [0.6.4] - 2026-04-16
 
 ### Added
 - Document deploy identity model in UPGRADE.md — how (realpath config + colony_url) hash determines session ownership, with examples of shared vs isolated namespaces and the localhost-tunnel edge case. (#244)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -3,7 +3,7 @@
 This document describes breaking operational changes that require manual
 action between Antfarm versions.
 
-## 0.8.0 — Colony UUID Identity (#238)
+## Unreleased — Colony UUID Identity (#238)
 
 Colony identity is now a persisted UUID stored as ``colony_id`` inside
 ``{data_dir}/config.json``. The 8-char hash embedded in tmux session names
@@ -54,7 +54,7 @@ prevents silent collisions when two colonies run on the same host.
 **Old:** `auto-builder-3`, `runner-planner-1`
 **New:** `auto-<hash>-builder-3`, `runner-<hash>-planner-1`
 
-### Unreleased — deploy session names (#235)
+### 0.6.4 — deploy session names (#235)
 
 **Old:** `antfarm-node1-claude-0`
 **New:** `antfarm-<hash>-node1-claude-0` (hash derived from
@@ -109,7 +109,7 @@ tmux ls | awk -F: '/^(auto|runner)-[^-]+-[^-]+-[0-9]+:/ && !/^(auto|runner)-[0-9
 tmux ls | awk -F: '/^antfarm-/ && !/^antfarm-[0-9a-f]{8}-/ {print $1}' | xargs -r -n1 tmux kill-session -t
 ```
 
-## Cleanup — `antfarm doctor --sweep-legacy-tmux` (Unreleased / 0.7+)
+## Cleanup — `antfarm doctor --sweep-legacy-tmux` (0.6.4+)
 
 Preview matches:
 

--- a/docs/OPERATOR_GUIDE.md
+++ b/docs/OPERATOR_GUIDE.md
@@ -560,14 +560,14 @@ thanks to the persisted UUID.
 ## Upgrade guidance
 
 Version-specific operational changes live in `UPGRADE.md`. Highlights as
-of v0.7.0:
+of v0.6.4:
 
-- Colony identity is a persisted UUID (#238). Pre-upgrade tmux sessions
-  use the old realpath-based hash and become orphans — sweep them after
-  draining.
-- Autoscaler/runner session names are colony-scoped (#231).
-- Deploy session names are colony-scoped (#235).
-- Doctor `--sweep-legacy-tmux` is the one-time migration tool (#237).
+- Autoscaler/runner session names are colony-scoped (#231, v0.6.3).
+- Deploy session names are colony-scoped (#235, v0.6.4).
+- Doctor `--sweep-legacy-tmux` is the one-time migration tool (#237, v0.6.4).
+- Colony identity is a persisted UUID (#238, trunk — shipping in the
+  next release). Pre-upgrade tmux sessions use the old realpath-based
+  hash and become orphans — sweep them after draining.
 
 Always read the matching section of `UPGRADE.md` before upgrading a live
-colony, especially when moving across the v0.6.2 → v0.6.3 → v0.7.0 line.
+colony, especially when moving across the v0.6.2 → v0.6.3 → v0.6.4 line.

--- a/docs/OPERATOR_GUIDE.md
+++ b/docs/OPERATOR_GUIDE.md
@@ -530,7 +530,7 @@ Concrete symptoms with concrete fixes.
 
 ```
 .antfarm/
-  config.json                 # colony_id (UUID), repo_path, integration_branch, TTLs
+  config.json                 # repo_path, integration_branch, TTLs (colony_id UUID added in a future release — #238)
   tasks/
     ready/                    # backlog — moving a file IS claiming
     active/                   # claimed tasks
@@ -551,9 +551,12 @@ Tmux session naming:
 - Runner: `runner-<hash>-<role>-<N>`.
 - Deploy: `antfarm-<hash>-<node>-<agent>-<idx>`.
 
-`.antfarm/` is runtime state. Never commit it. If you need to move a
-colony, `mv` the directory — colony identity is stable across moves
-thanks to the persisted UUID.
+`.antfarm/` is runtime state. Never commit it. In v0.6.4, colony
+identity is derived from `realpath(data_dir)`, so `mv`, NFS remount,
+or Docker bind-mount re-pointing will change the tmux session hash
+prefix and orphan existing sessions — drain in-flight work before
+moving. A future release (#238) switches to a persisted UUID that
+survives these operations.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antfarm"
-version = "0.7.0"
+version = "0.6.4"
 description = "Lightweight orchestration layer for distributing coding work across multiple AI coding agents"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Rename the v0.7.0 release cut earlier today back to **v0.6.4**. v0.7.0 was bumped autonomously based on strict semver (two feat() commits in the bundle), but maintainer direction is to stay in 0.6.x for many patch versions before crossing to 0.7.0. No code changes — version/changelog/docs only.

## Changes

- \`pyproject.toml\` — version 0.7.0 → 0.6.4
- \`CHANGELOG.md\` — \`[0.7.0]\` section renamed to \`[0.6.4]\`
- \`UPGRADE.md\`:
  - "0.8.0 — Colony UUID" → "Unreleased — Colony UUID"
  - "Unreleased — deploy session names" → "0.6.4 — deploy session names"
  - "(Unreleased / 0.7+)" → "(0.6.4+)"
- \`docs/OPERATOR_GUIDE.md\` — highlights block re-anchored to v0.6.4; #238 marked as trunk-only (next release)

## Post-merge actions (manual, after this merges)

1. Delete v0.7.0 GitHub release
2. Delete v0.7.0 tag (remote + local)
3. Tag v0.6.4 from the merge commit, push tag
4. Create v0.6.4 GitHub release

## Test Plan

- [x] \`ruff check .\` passes
- [x] \`pytest tests/ -x -q\` → 972 passed
- [x] No remaining \`0.7.0\` or \`0.8.0\` strings outside git history