### PR TITLE
fix(soldier): reconcile externally-merged PRs + antfarm mark-merged CLI (#264)

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -873,6 +873,17 @@ def harvest(
     click.echo(f"Task harvested: {result}")
 
 
+@main.command("mark-merged")
+@click.argument("task_id")
+@click.option("--attempt-id", required=True, help="The attempt ID to mark MERGED.")
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def mark_merged(task_id: str, attempt_id: str, colony_url: str, token: str | None):
+    """Manually reconcile a task whose PR was merged outside Antfarm."""
+    result = _post(colony_url, f"/tasks/{task_id}/merge", {"attempt_id": attempt_id}, token=token)
+    click.echo(f"Task marked merged: {result}")
+
+
 @main.command()
 @click.argument("resource")
 @click.option("--owner", required=True, help="Owner identifier for this guard.")

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -17,6 +17,7 @@ Policy:
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import subprocess
 import time
@@ -60,6 +61,7 @@ class Soldier:
         test_command: list[str] | None = None,
         poll_interval: float = 30.0,
         require_review: bool = False,
+        poll_external_merges: bool = True,
         client=None,
     ):
         self.colony = ColonyClient(colony_url, client=client)
@@ -68,6 +70,7 @@ class Soldier:
         self.test_command = test_command or ["pytest", "-x", "-q"]
         self.poll_interval = poll_interval
         self.require_review = require_review
+        self.poll_external_merges = poll_external_merges
         self.last_failure_reason = ""
 
     # ------------------------------------------------------------------
@@ -84,6 +87,8 @@ class Soldier:
                 time.sleep(self.poll_interval)
                 continue
             for task in queue:
+                if self._reconcile_external_merge(task):
+                    continue
                 result = self.attempt_merge(task)
                 attempt_id = task["current_attempt"]
                 if result == MergeResult.MERGED:
@@ -102,6 +107,9 @@ class Soldier:
         results = []
         queue = self.get_merge_queue()
         for task in queue:
+            if self._reconcile_external_merge(task):
+                results.append((task["id"], MergeResult.MERGED))
+                continue
             result = self.attempt_merge(task)
             attempt_id = task["current_attempt"]
             if result == MergeResult.MERGED:
@@ -587,6 +595,74 @@ class Soldier:
         return None
 
     @staticmethod
+    def _get_attempt_pr(task: dict) -> str | None:
+        """Extract the PR URL/identifier from the task's current attempt."""
+        current_attempt_id = task.get("current_attempt")
+        if not current_attempt_id:
+            return None
+        for attempt in task.get("attempts", []):
+            if attempt.get("attempt_id") == current_attempt_id:
+                return attempt.get("pr") or None
+        return None
+
+    def _check_pr_merged_on_origin(self, pr: str) -> bool | None:
+        """Check whether a PR has been merged on the origin (GitHub).
+
+        Shells out to ``gh pr view <pr> --json state -q '.state'``.
+
+        Returns:
+            True  — PR state is "MERGED"
+            False — PR state is "OPEN" or "CLOSED" (not merged)
+            None  — unable to determine (gh missing, network error, timeout,
+                    unexpected output). Callers should fall through to the
+                    normal merge path.
+        """
+        if not pr:
+            return None
+        try:
+            result = subprocess.run(
+                ["gh", "pr", "view", pr, "--json", "state", "-q", ".state"],
+                cwd=self.repo_path,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+        if result.returncode != 0:
+            return None
+        state = (result.stdout or "").strip()
+        if state == "MERGED":
+            return True
+        if state in ("OPEN", "CLOSED"):
+            return False
+        return None
+
+    def _reconcile_external_merge(self, task: dict) -> bool:
+        """Mark the task as merged if its PR was merged on origin.
+
+        Returns True if the attempt was reconciled (mark_merged called or
+        already-merged). Returns False if no reconciliation happened and the
+        caller should fall through to the normal merge path.
+        """
+        if not self.poll_external_merges:
+            return False
+        pr = self._get_attempt_pr(task)
+        if not pr:
+            return False
+        merged = self._check_pr_merged_on_origin(pr)
+        if merged is not True:
+            return False
+        task_id = task["id"]
+        attempt_id = task["current_attempt"]
+        # ValueError means already merged — idempotent no-op.
+        with contextlib.suppress(ValueError):
+            self.colony.mark_merged(task_id, attempt_id)
+        logger.info("reconciled externally-merged PR %s for %s", pr, task_id)
+        return True
+
+    @staticmethod
     def _has_merged_attempt(task: dict) -> bool:
         """Return True if the task has at least one attempt with status MERGED."""
         return any(attempt.get("status") == "merged" for attempt in task.get("attempts", []))
@@ -858,6 +934,7 @@ class Soldier:
         test_command: list[str] | None = None,
         poll_interval: float = 30.0,
         require_review: bool = True,
+        poll_external_merges: bool = True,
     ) -> Soldier:
         """Create a Soldier that talks directly to a TaskBackend.
 
@@ -873,6 +950,7 @@ class Soldier:
         instance.test_command = test_command or ["pytest", "-x", "-q"]
         instance.poll_interval = poll_interval
         instance.require_review = require_review
+        instance.poll_external_merges = poll_external_merges
         instance.last_failure_reason = ""
         return instance
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -560,6 +560,35 @@ def test_cli_harvest_posts_pr():
         assert payload["pr"] == "https://github.com/org/repo/pull/42"
 
 
+def test_mark_merged_command():
+    """mark-merged POSTs to /tasks/{id}/merge with {'attempt_id': ...}."""
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"ok": True}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mark-merged",
+                "task-001",
+                "--attempt-id",
+                "att-001",
+                "--colony-url",
+                "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        url = mock_post.call_args.args[0]
+        assert url.endswith("/tasks/task-001/merge")
+        payload = mock_post.call_args.kwargs.get("json")
+        assert payload == {"attempt_id": "att-001"}
+
+
 def test_cli_guard_acquires():
     """Guard POSTs to /guards/{resource}."""
     runner = CliRunner()

--- a/tests/test_soldier.py
+++ b/tests/test_soldier.py
@@ -1358,3 +1358,81 @@ def test_get_merge_queue_skips_review_capability_task(soldier_env):
 
     queue = soldier.get_merge_queue()
     assert not any(t["id"] == "task-cap-review-3" for t in queue)
+
+
+# ---------------------------------------------------------------------------
+# External merge reconciliation (#264)
+# ---------------------------------------------------------------------------
+
+
+def test_run_once_skips_externally_merged_pr(soldier_env, monkeypatch):
+    """When gh reports the PR as MERGED, mark_merged is called and attempt_merge is skipped."""
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _carry_and_harvest(cc, repo, "task-ext-merged", "feat/task-ext-merged")
+
+    # Fake: origin reports MERGED
+    monkeypatch.setattr(Soldier, "_check_pr_merged_on_origin", lambda self, pr: True)
+
+    # Fail loudly if attempt_merge is invoked — the reconciler should short-circuit.
+    def _fail(*_a, **_k):  # pragma: no cover — invoked only on regression
+        raise AssertionError("attempt_merge should not run when PR is already merged on origin")
+
+    monkeypatch.setattr(Soldier, "attempt_merge", _fail)
+
+    results = soldier.run_once()
+    assert results == [("task-ext-merged", MergeResult.MERGED)]
+
+    task = cc.get_task("task-ext-merged")
+    attempts = task["attempts"]
+    assert any(a["status"] == "merged" for a in attempts)
+
+
+def test_run_once_proceeds_when_pr_not_merged(soldier_env, monkeypatch):
+    """When gh reports the PR as not merged (False), the normal merge path runs."""
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _carry_and_harvest(cc, repo, "task-ext-open", "feat/task-ext-open")
+
+    monkeypatch.setattr(Soldier, "_check_pr_merged_on_origin", lambda self, pr: False)
+
+    calls: list[str] = []
+    real_attempt_merge = Soldier.attempt_merge
+
+    def _tracking(self, task):
+        calls.append(task["id"])
+        return real_attempt_merge(self, task)
+
+    monkeypatch.setattr(Soldier, "attempt_merge", _tracking)
+
+    results = soldier.run_once()
+    assert calls == ["task-ext-open"]
+    assert results == [("task-ext-open", MergeResult.MERGED)]
+
+
+def test_run_once_falls_through_on_unknown(soldier_env, monkeypatch):
+    """When gh status is unknown (None), the normal merge path runs."""
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _carry_and_harvest(cc, repo, "task-ext-unknown", "feat/task-ext-unknown")
+
+    monkeypatch.setattr(Soldier, "_check_pr_merged_on_origin", lambda self, pr: None)
+
+    calls: list[str] = []
+    real_attempt_merge = Soldier.attempt_merge
+
+    def _tracking(self, task):
+        calls.append(task["id"])
+        return real_attempt_merge(self, task)
+
+    monkeypatch.setattr(Soldier, "attempt_merge", _tracking)
+
+    results = soldier.run_once()
+    assert calls == ["task-ext-unknown"]
+    assert results == [("task-ext-unknown", MergeResult.MERGED)]


### PR DESCRIPTION
## Summary

- Soldier polls `gh pr view <pr> --json state` before each merge attempt. If the PR state is `MERGED`, Soldier calls `mark_merged` on the attempt and moves on — tasks merged outside Antfarm no longer sit in "Merge Ready" indefinitely, and their downstream deps unblock.
- Unknown states (gh missing, timeout, network error, unexpected output) fall through to the normal merge path — fail-safe. Controlled by a new `poll_external_merges` constructor flag (default `True`).
- New `antfarm mark-merged <task_id> --attempt-id <attempt>` CLI as an operator escape hatch. POSTs to the existing `/tasks/{id}/merge` endpoint — no new backend plumbing.

Implements Option A + Option C from the issue.

## Test plan

- [x] `test_run_once_skips_externally_merged_pr` — gh reports MERGED → `mark_merged` called, `attempt_merge` NOT called
- [x] `test_run_once_proceeds_when_pr_not_merged` — gh reports OPEN/CLOSED → normal merge path runs
- [x] `test_run_once_falls_through_on_unknown` — gh reports None (unknown) → normal merge path runs
- [x] `test_mark_merged_command` — CLI POSTs to `/tasks/<id>/merge` with `{"attempt_id": "..."}`
- [x] `ruff check .` — clean
- [x] `pytest tests/ -x -q` — 976 passed

Closes antfarm-ai/antfarm#264

🤖 Generated with [Claude Code](https://claude.com/claude-code)