### PR TITLE
Extend _emit_event with actor field

### DIFF
--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -48,13 +48,25 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def _emit_event(event_type: str, task_id: str, detail: str = "") -> None:
-    """Append an event to the SSE event bus."""
+def _emit_event(
+    event_type: str, task_id: str, detail: str = "", actor: str = "colony"
+) -> None:
+    """Append an event to the SSE event bus.
+
+    Args:
+        event_type: Short event name (e.g. "harvested", "merged", "plan_created").
+        task_id: Task ID the event relates to ("" if not task-scoped).
+        detail: Free-form human-readable detail string.
+        actor: Subsystem that produced the event ("colony", "queen", "autoscaler",
+            "soldier", "doctor", "worker", "runner"). Defaults to "colony", which
+            is correct for events emitted from inside colony HTTP handlers.
+    """
     global _event_counter
     _event_counter += 1
     _event_queue.append(
         {
             "id": _event_counter,
+            "actor": actor,
             "type": event_type,
             "task_id": task_id,
             "detail": detail,

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -847,6 +847,66 @@ def test_sse_events_on_harvest(tmp_path):
     assert len(events) >= 1
     assert events[0]["type"] == "harvested"
     assert events[0]["task_id"] == "task-001"
+    assert events[0]["actor"] == "colony"
+
+
+def test_emit_event_default_actor_is_colony():
+    """_emit_event without an actor argument defaults to actor='colony'."""
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    serve_mod._emit_event("harvested", "task-001", "pr=x branch=y")
+
+    assert len(serve_mod._event_queue) == 1
+    assert serve_mod._event_queue[0]["actor"] == "colony"
+
+
+def test_emit_event_accepts_explicit_actor():
+    """_emit_event records whatever actor the caller passes."""
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    serve_mod._emit_event("plan_created", "plan-001", "queen made a plan", actor="queen")
+
+    assert len(serve_mod._event_queue) == 1
+    event = serve_mod._event_queue[0]
+    assert event["actor"] == "queen"
+    assert event["type"] == "plan_created"
+    assert event["task_id"] == "plan-001"
+    assert event["detail"] == "queen made a plan"
+
+
+def test_sse_events_include_actor_field(tmp_path):
+    """The /events SSE payload includes the actor key for each event."""
+    import json as json_mod
+
+    from antfarm.core.backends.file import FileBackend
+
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend, enable_soldier=False)
+    client = TestClient(app)
+
+    _carry(client)
+    task = _forage(client).json()
+    attempt_id = task["current_attempt"]
+    client.post(
+        f"/tasks/{task['id']}/harvest",
+        json={"attempt_id": attempt_id, "pr": "pr-1", "branch": "feat/x"},
+    )
+
+    with client.stream("GET", "/events?after=0&timeout=2") as r:
+        assert r.status_code == 200
+        events = []
+        for line in r.iter_lines():
+            if line.startswith("data: "):
+                events.append(json_mod.loads(line[len("data: ") :]))
+
+    assert len(events) >= 1
+    assert all("actor" in event for event in events)
+    assert events[0]["actor"] == "colony"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
In antfarm/core/serve.py, add an `actor: str = 'colony'` parameter to `_emit_event(event_type, task_id, detail, actor)` and include it in the event dict appended to `_event_queue`. Update the three existing call sites (`harvested`, `kickback`, `merged`) to continue working with the default actor (they live inside colony HTTP handlers, so `actor='colony'` is appropriate). Add a test in tests/test_serve.py asserting: (a) default actor is 'colony' for existing emitters, (b) `_emit_event('x', 't', '