### PR TITLE
Add scout --watch SSE streaming mode

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -581,15 +581,62 @@ def _render_scout(status: dict, prev: dict | None) -> None:
         click.echo(f"{key:<25} {value_str}")
 
 
+def _format_event(event: dict) -> str:
+    """Format an SSE event dict as an activity-feed line: ``HH:MM:SS  <actor:12>  <detail>``."""
+    ts = event.get("ts", "") or ""
+    time_part = ts.split("T", 1)[1][:8] if "T" in ts else ts[:8]
+    actor = str(event.get("actor") or event.get("type") or "")
+    detail = event.get("detail", "")
+    return f"{time_part}  {actor:<12}  {detail}"
+
+
+def _scout_watch(colony_url: str, token: str | None) -> None:
+    """Stream ``/events`` via SSE, printing one formatted line per event.
+
+    Reconnects on connection close and carries the cursor forward so no events
+    are lost across reconnects. Exits cleanly on KeyboardInterrupt.
+    """
+    events_url = f"{colony_url.rstrip('/')}/events"
+    headers = _auth_headers(token)
+    cursor = 0
+    try:
+        while True:
+            try:
+                with httpx.stream(
+                    "GET",
+                    events_url,
+                    params={"after": cursor, "timeout": 30},
+                    headers=headers,
+                    timeout=None,
+                ) as r:
+                    r.raise_for_status()
+                    for line in r.iter_lines():
+                        if not line.startswith("data: "):
+                            continue
+                        raw = line[len("data: ") :]
+                        try:
+                            event = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
+                        event_id = event.get("id")
+                        if isinstance(event_id, int) and event_id > cursor:
+                            cursor = event_id
+                        click.echo(_format_event(event))
+            except httpx.HTTPError:
+                # Brief backoff before reconnect; cursor is preserved.
+                time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+
+
 @main.command()
-@click.option("--watch", is_flag=True, default=False, help="Re-poll continuously.")
-@click.option("--tui", is_flag=True, default=False, help="Launch rich TUI dashboard.")
 @click.option(
-    "--interval",
-    default=5,
-    show_default=True,
-    help="Seconds between polls (with --watch).",
+    "--watch",
+    is_flag=True,
+    default=False,
+    help="Stream live activity feed via /events SSE.",
 )
+@click.option("--tui", is_flag=True, default=False, help="Launch rich TUI dashboard.")
 @click.option(
     "--refresh",
     default=2.0,
@@ -601,12 +648,11 @@ def _render_scout(status: dict, prev: dict | None) -> None:
 def scout(
     watch: bool,
     tui: bool,
-    interval: int,
     refresh: float,
     colony_url: str,
     token: str | None,
 ):
-    """Show colony status as a table."""
+    """Show colony status as a table, or stream live activity feed with --watch."""
     if tui:
         from antfarm.core.tui import AntfarmTUI
 
@@ -614,21 +660,12 @@ def scout(
         dashboard.run()
         return
 
-    if not watch:
-        status = _get(colony_url, "/status", token=token)
-        _render_scout(status, None)
+    if watch:
+        _scout_watch(colony_url, token)
         return
 
-    prev_status = None
-    try:
-        while True:
-            click.clear()
-            status = _get(colony_url, "/status", token=token)
-            _render_scout(status, prev_status)
-            prev_status = status
-            time.sleep(interval)
-    except KeyboardInterrupt:
-        pass
+    status = _get(colony_url, "/status", token=token)
+    _render_scout(status, None)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import httpx
 from click.testing import CliRunner
 
 from antfarm.core.cli import main
@@ -198,36 +199,173 @@ def test_cli_scout_uses_env_url(monkeypatch):
         assert "my-colony:8000" in call_url
 
 
-def test_scout_watch_basic():
-    """--watch polls repeatedly; KeyboardInterrupt after first sleep exits cleanly."""
+def _make_stream_ctx(lines: list[str]) -> MagicMock:
+    """Build a MagicMock that mimics ``httpx.stream(...)`` used as a context manager."""
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.iter_lines.return_value = iter(lines)
+    ctx = MagicMock()
+    ctx.__enter__.return_value = response
+    ctx.__exit__.return_value = False
+    return ctx
+
+
+def test_scout_watch_streams_events():
+    """--watch opens /events SSE stream and prints formatted rows."""
     runner = CliRunner()
 
-    status_data = {
-        "tasks_ready": 3,
-        "tasks_active": 1,
-        "tasks_done": 7,
-        "workers": 2,
-        "nodes": 1,
-    }
+    events = [
+        {
+            "id": 1,
+            "type": "harvested",
+            "actor": "runner",
+            "task_id": "task-1",
+            "detail": "pr=42 branch=feat/x",
+            "ts": "2026-04-16T14:32:11.000000+00:00",
+        },
+        {
+            "id": 2,
+            "type": "merged",
+            "actor": "soldier",
+            "task_id": "task-1",
+            "detail": "attempt=att-001",
+            "ts": "2026-04-16T14:33:02.000000+00:00",
+        },
+    ]
+    lines = [f"data: {json.dumps(e)}" for e in events]
 
-    with (
-        patch("antfarm.core.cli.httpx.get") as mock_get,
-        patch("antfarm.core.cli.time.sleep", side_effect=KeyboardInterrupt),
-    ):
-        mock_resp = MagicMock()
-        mock_resp.status_code = 200
-        mock_resp.json.return_value = status_data
-        mock_get.return_value = mock_resp
+    call_count = {"n": 0}
 
+    def fake_stream(method, url, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return _make_stream_ctx(lines)
+        # Second reconnect: simulate Ctrl-C to terminate the command.
+        raise KeyboardInterrupt
+
+    with patch("antfarm.core.cli.httpx.stream", side_effect=fake_stream):
         result = runner.invoke(
             main,
-            ["scout", "--watch", "--interval", "1", "--colony-url", "http://localhost:7433"],
+            ["scout", "--watch", "--colony-url", "http://localhost:7433"],
         )
 
-        assert result.exit_code == 0, result.output
-        assert "tasks_ready" in result.output
-        assert "3" in result.output
-        mock_get.assert_called_once()
+    assert result.exit_code == 0, result.output
+    assert "14:32:11" in result.output
+    assert "runner" in result.output
+    assert "pr=42 branch=feat/x" in result.output
+    assert "14:33:02" in result.output
+    assert "soldier" in result.output
+    assert "attempt=att-001" in result.output
+
+
+def test_scout_watch_tracks_cursor_across_reconnects():
+    """Cursor from prior batch is passed as ``after`` on the next connect."""
+    runner = CliRunner()
+
+    batch1 = [
+        {
+            "id": 3,
+            "type": "harvested",
+            "actor": "runner",
+            "task_id": "task-a",
+            "detail": "d1",
+            "ts": "2026-04-16T14:32:11+00:00",
+        }
+    ]
+    batch2 = [
+        {
+            "id": 7,
+            "type": "merged",
+            "actor": "soldier",
+            "task_id": "task-a",
+            "detail": "d2",
+            "ts": "2026-04-16T14:33:02+00:00",
+        }
+    ]
+
+    calls: list[dict] = []
+
+    def fake_stream(method, url, **kwargs):
+        calls.append(kwargs.get("params", {}))
+        if len(calls) == 1:
+            return _make_stream_ctx([f"data: {json.dumps(e)}" for e in batch1])
+        if len(calls) == 2:
+            return _make_stream_ctx([f"data: {json.dumps(e)}" for e in batch2])
+        raise KeyboardInterrupt
+
+    with patch("antfarm.core.cli.httpx.stream", side_effect=fake_stream):
+        result = runner.invoke(
+            main,
+            ["scout", "--watch", "--colony-url", "http://localhost:7433"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert calls[0].get("after") == 0
+    assert calls[1].get("after") == 3
+    assert "d1" in result.output
+    assert "d2" in result.output
+
+
+def test_scout_watch_ctrl_c_exits_cleanly():
+    """KeyboardInterrupt during iter_lines exits with status 0."""
+    runner = CliRunner()
+
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.iter_lines.side_effect = KeyboardInterrupt
+    ctx = MagicMock()
+    ctx.__enter__.return_value = response
+    ctx.__exit__.return_value = False
+
+    with patch("antfarm.core.cli.httpx.stream", return_value=ctx):
+        result = runner.invoke(
+            main,
+            ["scout", "--watch", "--colony-url", "http://localhost:7433"],
+        )
+
+    assert result.exit_code == 0, result.output
+
+
+def test_scout_watch_reconnects_on_http_error():
+    """Transient HTTPError triggers backoff + reconnect; cursor is preserved."""
+    runner = CliRunner()
+
+    batch1 = [
+        {
+            "id": 5,
+            "type": "harvested",
+            "actor": "runner",
+            "task_id": "task-b",
+            "detail": "ok",
+            "ts": "2026-04-16T14:32:11+00:00",
+        }
+    ]
+
+    calls: list[dict] = []
+
+    def fake_stream(method, url, **kwargs):
+        calls.append(kwargs.get("params", {}))
+        if len(calls) == 1:
+            return _make_stream_ctx([f"data: {json.dumps(e)}" for e in batch1])
+        if len(calls) == 2:
+            raise httpx.ConnectError("server down")
+        raise KeyboardInterrupt
+
+    with (
+        patch("antfarm.core.cli.httpx.stream", side_effect=fake_stream),
+        patch("antfarm.core.cli.time.sleep"),
+    ):
+        result = runner.invoke(
+            main,
+            ["scout", "--watch", "--colony-url", "http://localhost:7433"],
+        )
+
+    assert result.exit_code == 0, result.output
+    # First call starts at cursor 0; after batch1 the cursor should advance to 5.
+    assert calls[0].get("after") == 0
+    assert calls[1].get("after") == 5
+    # Third call (after HTTPError backoff) retains the advanced cursor.
+    assert calls[2].get("after") == 5
 
 
 def test_scout_oneshot_unchanged():


### PR DESCRIPTION
In antfarm/core/cli.py, repurpose the existing `scout --watch` flag so that when set (without `--tui`), instead of re-polling `/status`, it opens an SSE connection via `httpx.stream('GET', '{colony_url}/events', params={'after': cursor, 'timeout': 30}, timeout=None)` in a reconnect loop and prints each event to stdout as one line `HH:MM:SS  <actor:12>  <detail>`. The previous `--interval` status-polling behavior is removed for plain `--watch` (the `--tui` branch keeps its polling). Exit cleanly 