### PR TITLE
Emit Queen lifecycle events

### DIFF
--- a/antfarm/core/queen.py
+++ b/antfarm/core/queen.py
@@ -27,6 +27,7 @@ from antfarm.core.missions import (
     is_infra_task,
     link_task_to_mission,
 )
+from antfarm.core.serve import _emit_event
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +120,10 @@ class Queen:
         """
         plan_task_id = mission.get("plan_task_id")
         if plan_task_id is None:
+            spec = mission.get("spec") or ""
+            title = spec.strip().splitlines()[0] if spec.strip() else ""
+            detail = f"{mission['mission_id']}: {title}" if title else mission["mission_id"]
+            _emit_event("mission_created", "", detail, actor="queen")
             plan_task_id = self._create_plan_task(mission)
             self.backend.update_mission(
                 mission["mission_id"],
@@ -231,6 +236,12 @@ class Queen:
 
         if verdict["verdict"] == "pass":
             artifact = PlanArtifact.from_dict(mission["plan_artifact"])
+            _emit_event(
+                "plan_approved",
+                mission.get("plan_task_id") or "",
+                f"mission={mission['mission_id']} tasks={artifact.task_count}",
+                actor="queen",
+            )
             self._spawn_child_tasks(mission, artifact)
             self._transition(mission, MissionStatus.BUILDING)
             self._maybe_generate_context(mission)
@@ -295,6 +306,15 @@ class Queen:
                 mission,
                 MissionStatus.COMPLETE,
                 extras={"report": report.to_dict(), "completed_at": _now_iso()},
+            )
+            _emit_event(
+                "mission_complete",
+                "",
+                (
+                    f"mission={mission['mission_id']} "
+                    f"merged={report.merged_tasks} blocked={report.blocked_tasks}"
+                ),
+                actor="queen",
             )
             return
 
@@ -388,6 +408,12 @@ class Queen:
 
         with contextlib.suppress(ValueError):
             link_task_to_mission(self.backend, task, mission_id)
+        _emit_event(
+            "plan_task_created",
+            plan_task_id,
+            f"mission={mission_id}",
+            actor="queen",
+        )
         return plan_task_id
 
     def _create_plan_review_task(self, mission: dict, artifact: PlanArtifact) -> str:
@@ -523,6 +549,12 @@ class Queen:
             with contextlib.suppress(ValueError):
                 link_task_to_mission(self.backend, task, mission_id)
 
+        _emit_event(
+            "tasks_seeded",
+            "",
+            f"mission={mission_id} count={len(child_ids)}",
+            actor="queen",
+        )
         return child_ids
 
     # --- artifact extraction ---

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -48,13 +48,25 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def _emit_event(event_type: str, task_id: str, detail: str = "") -> None:
-    """Append an event to the SSE event bus."""
+def _emit_event(
+    event_type: str, task_id: str, detail: str = "", actor: str = "colony"
+) -> None:
+    """Append an event to the SSE event bus.
+
+    Args:
+        event_type: Short event name (e.g. "harvested", "merged", "plan_created").
+        task_id: Task ID the event relates to ("" if not task-scoped).
+        detail: Free-form human-readable detail string.
+        actor: Subsystem that produced the event ("colony", "queen", "autoscaler",
+            "soldier", "doctor", "worker", "runner"). Defaults to "colony", which
+            is correct for events emitted from inside colony HTTP handlers.
+    """
     global _event_counter
     _event_counter += 1
     _event_queue.append(
         {
             "id": _event_counter,
+            "actor": actor,
             "type": event_type,
             "task_id": task_id,
             "detail": detail,

--- a/tests/test_queen.py
+++ b/tests/test_queen.py
@@ -1242,3 +1242,159 @@ def test_queen_context_written_in_correct_data_dir(env, tmp_path):
     # The context file must exist under the custom data_dir
     expected = _os.path.join(data_dir, "missions", f"{mission['mission_id']}_context.md")
     assert _os.path.isfile(expected)
+
+
+# ---------------------------------------------------------------------------
+# Queen activity-feed events (#191)
+#
+# Queen emits SSE events to serve._event_queue at decision points:
+#   mission_created, plan_task_created, plan_approved, tasks_seeded,
+#   mission_complete — all with actor="queen".
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clear_events():
+    """Clear the SSE event queue before each event-assertion test."""
+    from antfarm.core import serve
+
+    serve._event_queue.clear()
+    yield serve._event_queue
+
+
+def _event_types(queue) -> list[str]:
+    return [e["type"] for e in queue]
+
+
+def _find_event(queue, event_type: str) -> dict | None:
+    for e in queue:
+        if e["type"] == event_type:
+            return e
+    return None
+
+
+def test_queen_emits_mission_created_and_plan_task_created(env, clear_events):
+    backend = env["backend"]
+    queen = env["queen"]
+
+    mission = _create_mission(backend, spec="Build a widget\nsecond line")
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)
+
+    mc = _find_event(clear_events, "mission_created")
+    assert mc is not None
+    assert mc["actor"] == "queen"
+    assert mission["mission_id"] in mc["detail"]
+    assert "Build a widget" in mc["detail"]
+    # mission-level event → empty task_id
+    assert mc["task_id"] == ""
+
+    ptc = _find_event(clear_events, "plan_task_created")
+    assert ptc is not None
+    assert ptc["actor"] == "queen"
+    assert ptc["task_id"] == f"plan-{mission['mission_id']}"
+    assert mission["mission_id"] in ptc["detail"]
+
+
+def test_queen_emits_plan_approved_on_review_pass(env, clear_events):
+    backend = env["backend"]
+    queen = env["queen"]
+
+    mission = _create_mission(backend)
+    m = backend.get_mission(mission["mission_id"])
+
+    # Planning → REVIEWING_PLAN
+    queen._advance(m)
+    m = backend.get_mission(mission["mission_id"])
+    artifact = _make_plan_artifact(plan_task_id=m["plan_task_id"])
+    _harvest_plan_task_with_artifact(backend, m["plan_task_id"], artifact)
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)
+
+    # Verdict pass → plan_approved event
+    clear_events.clear()
+    review_task_id = f"review-plan-{mission['mission_id']}"
+    _set_review_verdict_on_task(backend, review_task_id, _make_review_verdict("pass"))
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)
+
+    evt = _find_event(clear_events, "plan_approved")
+    assert evt is not None
+    assert evt["actor"] == "queen"
+    expected_plan_id = f"plan-{mission['mission_id']}"
+    assert evt["task_id"] in (m.get("plan_task_id"), expected_plan_id)
+    assert mission["mission_id"] in evt["detail"]
+
+
+def test_queen_emits_tasks_seeded_on_spawn(env, clear_events):
+    backend = env["backend"]
+    queen = env["queen"]
+
+    mission = _create_mission(backend, config_overrides={"require_plan_review": False})
+    m = backend.get_mission(mission["mission_id"])
+
+    # Planning → BUILDING (which spawns children)
+    queen._advance(m)
+    m = backend.get_mission(mission["mission_id"])
+    artifact = _make_plan_artifact(plan_task_id=m["plan_task_id"], task_count=3)
+    _harvest_plan_task_with_artifact(backend, m["plan_task_id"], artifact)
+
+    clear_events.clear()
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)
+
+    evt = _find_event(clear_events, "tasks_seeded")
+    assert evt is not None
+    assert evt["actor"] == "queen"
+    assert evt["task_id"] == ""
+    assert "count=3" in evt["detail"]
+    assert mission["mission_id"] in evt["detail"]
+
+
+def test_queen_emits_mission_complete_on_all_merged(env, clear_events):
+    backend = env["backend"]
+    queen = env["queen"]
+
+    mission = _create_mission(backend, config_overrides={"require_plan_review": False})
+    m = backend.get_mission(mission["mission_id"])
+
+    queen._advance(m)
+    m = backend.get_mission(mission["mission_id"])
+    artifact = _make_plan_artifact(plan_task_id=m["plan_task_id"])
+    _harvest_plan_task_with_artifact(backend, m["plan_task_id"], artifact)
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)  # → BUILDING
+
+    # Mark all children merged
+    slug = queen._mission_slug(mission["mission_id"])
+    for i in range(2):
+        child_id = f"task-{slug}-{i + 1:02d}"
+        child = backend.get_task(child_id)
+        child["status"] = "done"
+        child["current_attempt"] = f"att-c{i}"
+        child["attempts"] = [
+            {
+                "attempt_id": f"att-c{i}",
+                "worker_id": "test-worker",
+                "status": "merged",
+                "branch": f"feat/{child_id}",
+                "pr": f"https://github.com/test/pr/{i}",
+                "started_at": _now_iso(),
+                "completed_at": _now_iso(),
+            }
+        ]
+        _force_task_state(backend, child_id, child)
+
+    clear_events.clear()
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)
+
+    m = backend.get_mission(mission["mission_id"])
+    assert m["status"] == "complete"
+
+    evt = _find_event(clear_events, "mission_complete")
+    assert evt is not None
+    assert evt["actor"] == "queen"
+    assert evt["task_id"] == ""
+    assert mission["mission_id"] in evt["detail"]
+    assert "merged=2" in evt["detail"]

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -847,6 +847,66 @@ def test_sse_events_on_harvest(tmp_path):
     assert len(events) >= 1
     assert events[0]["type"] == "harvested"
     assert events[0]["task_id"] == "task-001"
+    assert events[0]["actor"] == "colony"
+
+
+def test_emit_event_default_actor_is_colony():
+    """_emit_event without an actor argument defaults to actor='colony'."""
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    serve_mod._emit_event("harvested", "task-001", "pr=x branch=y")
+
+    assert len(serve_mod._event_queue) == 1
+    assert serve_mod._event_queue[0]["actor"] == "colony"
+
+
+def test_emit_event_accepts_explicit_actor():
+    """_emit_event records whatever actor the caller passes."""
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    serve_mod._emit_event("plan_created", "plan-001", "queen made a plan", actor="queen")
+
+    assert len(serve_mod._event_queue) == 1
+    event = serve_mod._event_queue[0]
+    assert event["actor"] == "queen"
+    assert event["type"] == "plan_created"
+    assert event["task_id"] == "plan-001"
+    assert event["detail"] == "queen made a plan"
+
+
+def test_sse_events_include_actor_field(tmp_path):
+    """The /events SSE payload includes the actor key for each event."""
+    import json as json_mod
+
+    from antfarm.core.backends.file import FileBackend
+
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend, enable_soldier=False)
+    client = TestClient(app)
+
+    _carry(client)
+    task = _forage(client).json()
+    attempt_id = task["current_attempt"]
+    client.post(
+        f"/tasks/{task['id']}/harvest",
+        json={"attempt_id": attempt_id, "pr": "pr-1", "branch": "feat/x"},
+    )
+
+    with client.stream("GET", "/events?after=0&timeout=2") as r:
+        assert r.status_code == 200
+        events = []
+        for line in r.iter_lines():
+            if line.startswith("data: "):
+                events.append(json_mod.loads(line[len("data: ") :]))
+
+    assert len(events) >= 1
+    assert all("actor" in event for event in events)
+    assert events[0]["actor"] == "colony"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
In antfarm/core/queen.py, call `_emit_event` (imported from antfarm.core.serve) with actor='queen' at these decision points: mission transitions to planning → `mission_created` (detail: mission id + title), plan task creation in `_create_plan_task` → `plan_task_created`, approval path in `_advance_reviewing_plan` after a verdict approves → `plan_approved`, child seeding in `_spawn_child_tasks` → `tasks_seeded` (detail: count), mission transition to complete in `_transition`/`_generate_report` → 