### PR TITLE
Extend _emit_event with actor field

### DIFF
--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -48,13 +48,25 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def _emit_event(event_type: str, task_id: str, detail: str = "") -> None:
-    """Append an event to the SSE event bus."""
+def _emit_event(
+    event_type: str, task_id: str, detail: str = "", actor: str = "colony"
+) -> None:
+    """Append an event to the SSE event bus.
+
+    Args:
+        event_type: Event kind (e.g. "harvested", "kickback", "merged").
+        task_id: Task identifier the event relates to. Empty string if not task-scoped.
+        detail: Free-form human-readable detail.
+        actor: Subsystem emitting the event (e.g. "colony", "queen", "autoscaler",
+            "soldier", "doctor", "worker"). Defaults to "colony" for legacy emitters
+            inside colony HTTP handlers.
+    """
     global _event_counter
     _event_counter += 1
     _event_queue.append(
         {
             "id": _event_counter,
+            "actor": actor,
             "type": event_type,
             "task_id": task_id,
             "detail": detail,

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -849,6 +849,69 @@ def test_sse_events_on_harvest(tmp_path):
     assert events[0]["task_id"] == "task-001"
 
 
+def test_emit_event_default_actor_is_colony():
+    """_emit_event defaults actor to 'colony' so legacy emitters keep working."""
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    serve_mod._emit_event("harvested", "task-001", "pr=pr-1 branch=feat/x")
+
+    assert len(serve_mod._event_queue) == 1
+    event = serve_mod._event_queue[0]
+    assert event["actor"] == "colony"
+    assert event["type"] == "harvested"
+    assert event["task_id"] == "task-001"
+
+
+def test_emit_event_custom_actor():
+    """_emit_event honors explicit actor argument."""
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    serve_mod._emit_event("x", "t", "d", actor="queen")
+
+    assert len(serve_mod._event_queue) == 1
+    event = serve_mod._event_queue[0]
+    assert event["actor"] == "queen"
+    assert event["type"] == "x"
+    assert event["task_id"] == "t"
+    assert event["detail"] == "d"
+
+
+def test_sse_payload_includes_actor(tmp_path):
+    """Events streamed via /events include the actor field."""
+    import json as json_mod
+
+    from antfarm.core.backends.file import FileBackend
+
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend, enable_soldier=False)
+    client = TestClient(app)
+
+    _carry(client)
+    task = _forage(client).json()
+    attempt_id = task["current_attempt"]
+
+    client.post(
+        f"/tasks/{task['id']}/harvest",
+        json={"attempt_id": attempt_id, "pr": "pr-1", "branch": "feat/x"},
+    )
+
+    with client.stream("GET", "/events?after=0&timeout=2") as r:
+        assert r.status_code == 200
+        events = []
+        for line in r.iter_lines():
+            if line.startswith("data: "):
+                events.append(json_mod.loads(line[len("data: ") :]))
+
+    assert len(events) >= 1
+    assert "actor" in events[0]
+    assert events[0]["actor"] == "colony"
+
+
 # ---------------------------------------------------------------------------
 # Doctor daemon thread (#147)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
In antfarm/core/serve.py, add an `actor: str = 'colony'` parameter to `_emit_event(event_type, task_id, detail, actor)` and include it in the event dict appended to `_event_queue`. Update the three existing call sites (`harvested`, `kickback`, `merged`) to continue working with the default actor (they live inside colony HTTP handlers, so `actor='colony'` is appropriate). Add a test in tests/test_serve.py asserting: (a) default actor is 'colony' for existing emitters, (b) `_emit_event('x', 't', '