### PR TITLE
Emit Soldier merge lifecycle events

### DIFF
--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -48,13 +48,25 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def _emit_event(event_type: str, task_id: str, detail: str = "") -> None:
-    """Append an event to the SSE event bus."""
+def _emit_event(
+    event_type: str, task_id: str, detail: str = "", actor: str = "colony"
+) -> None:
+    """Append an event to the SSE event bus.
+
+    Args:
+        event_type: Short event name (e.g. "harvested", "merged", "plan_created").
+        task_id: Task ID the event relates to ("" if not task-scoped).
+        detail: Free-form human-readable detail string.
+        actor: Subsystem that produced the event ("colony", "queen", "autoscaler",
+            "soldier", "doctor", "worker", "runner"). Defaults to "colony", which
+            is correct for events emitted from inside colony HTTP handlers.
+    """
     global _event_counter
     _event_counter += 1
     _event_queue.append(
         {
             "id": _event_counter,
+            "actor": actor,
             "type": event_type,
             "task_id": task_id,
             "detail": detail,

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -32,6 +32,20 @@ from antfarm.core.review_pack import extract_verdict_from_review_task
 logger = logging.getLogger(__name__)
 
 
+def _emit(event_type: str, task_id: str, detail: str = "") -> None:
+    """Emit an SSE event tagged with actor='soldier'.
+
+    Lazy import of ``_emit_event`` keeps this module decoupled from the
+    FastAPI server at import time — Soldier still runs without serve.py's
+    transitive imports being loadable.
+    """
+    try:
+        from antfarm.core.serve import _emit_event
+    except Exception:
+        return
+    _emit_event(event_type, task_id, detail, actor="soldier")
+
+
 class MergeResult(StrEnum):
     MERGED = "merged"
     FAILED = "failed"
@@ -389,10 +403,14 @@ class Soldier:
         Returns:
             MergeResult.MERGED on success, MergeResult.FAILED on any failure.
         """
+        task_id = task.get("id", "")
         branch = self._get_attempt_branch(task)
         if not branch:
             self.last_failure_reason = "no branch on current attempt"
+            _emit("merge_failed", task_id, self.last_failure_reason)
             return MergeResult.FAILED
+
+        _emit("merge_started", task_id, branch)
 
         temp_branch = "antfarm/temp-merge"
         try:
@@ -405,6 +423,7 @@ class Soldier:
             )
             if r.returncode != 0:
                 self.last_failure_reason = f"git fetch failed: {r.stderr.decode().strip()}"
+                _emit("merge_failed", task_id, self.last_failure_reason)
                 return MergeResult.FAILED
 
             # Create temp branch from integration branch
@@ -424,6 +443,7 @@ class Soldier:
                 self.last_failure_reason = (
                     f"could not create temp branch: {r.stderr.decode().strip()}"
                 )
+                _emit("merge_failed", task_id, self.last_failure_reason)
                 return MergeResult.FAILED
 
             # Merge task branch (no-ff to preserve history)
@@ -437,6 +457,7 @@ class Soldier:
                 self.last_failure_reason = (
                     f"merge conflict merging {branch}: {r.stderr.decode().strip()}"
                 )
+                _emit("merge_failed", task_id, self.last_failure_reason)
                 return MergeResult.FAILED
 
             # Run tests
@@ -450,6 +471,7 @@ class Soldier:
                 self.last_failure_reason = (
                     f"tests failed: {r.stdout.decode().strip()} {r.stderr.decode().strip()}"
                 ).strip()
+                _emit("merge_failed", task_id, self.last_failure_reason)
                 return MergeResult.FAILED
 
             # Fast-forward integration branch
@@ -463,6 +485,7 @@ class Soldier:
                 self.last_failure_reason = (
                     f"could not checkout {self.integration_branch}: {r.stderr.decode().strip()}"
                 )
+                _emit("merge_failed", task_id, self.last_failure_reason)
                 return MergeResult.FAILED
 
             r = subprocess.run(
@@ -473,6 +496,7 @@ class Soldier:
             )
             if r.returncode != 0:
                 self.last_failure_reason = f"ff-only merge failed: {r.stderr.decode().strip()}"
+                _emit("merge_failed", task_id, self.last_failure_reason)
                 return MergeResult.FAILED
 
             # Push to origin
@@ -484,8 +508,10 @@ class Soldier:
             )
             if r.returncode != 0:
                 self.last_failure_reason = f"push failed: {r.stderr.decode().strip()}"
+                _emit("merge_failed", task_id, self.last_failure_reason)
                 return MergeResult.FAILED
 
+            _emit("merge_succeeded", task_id, branch)
             return MergeResult.MERGED
 
         finally:
@@ -660,6 +686,7 @@ class Soldier:
         with contextlib.suppress(ValueError):
             self.colony.mark_merged(task_id, attempt_id)
         logger.info("reconciled externally-merged PR %s for %s", pr, task_id)
+        _emit("reconciled_external", task_id, f"pr={pr}")
         return True
 
     @staticmethod

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -847,6 +847,66 @@ def test_sse_events_on_harvest(tmp_path):
     assert len(events) >= 1
     assert events[0]["type"] == "harvested"
     assert events[0]["task_id"] == "task-001"
+    assert events[0]["actor"] == "colony"
+
+
+def test_emit_event_default_actor_is_colony():
+    """_emit_event without an actor argument defaults to actor='colony'."""
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    serve_mod._emit_event("harvested", "task-001", "pr=x branch=y")
+
+    assert len(serve_mod._event_queue) == 1
+    assert serve_mod._event_queue[0]["actor"] == "colony"
+
+
+def test_emit_event_accepts_explicit_actor():
+    """_emit_event records whatever actor the caller passes."""
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    serve_mod._emit_event("plan_created", "plan-001", "queen made a plan", actor="queen")
+
+    assert len(serve_mod._event_queue) == 1
+    event = serve_mod._event_queue[0]
+    assert event["actor"] == "queen"
+    assert event["type"] == "plan_created"
+    assert event["task_id"] == "plan-001"
+    assert event["detail"] == "queen made a plan"
+
+
+def test_sse_events_include_actor_field(tmp_path):
+    """The /events SSE payload includes the actor key for each event."""
+    import json as json_mod
+
+    from antfarm.core.backends.file import FileBackend
+
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend, enable_soldier=False)
+    client = TestClient(app)
+
+    _carry(client)
+    task = _forage(client).json()
+    attempt_id = task["current_attempt"]
+    client.post(
+        f"/tasks/{task['id']}/harvest",
+        json={"attempt_id": attempt_id, "pr": "pr-1", "branch": "feat/x"},
+    )
+
+    with client.stream("GET", "/events?after=0&timeout=2") as r:
+        assert r.status_code == 200
+        events = []
+        for line in r.iter_lines():
+            if line.startswith("data: "):
+                events.append(json_mod.loads(line[len("data: ") :]))
+
+    assert len(events) >= 1
+    assert all("actor" in event for event in events)
+    assert events[0]["actor"] == "colony"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_soldier.py
+++ b/tests/test_soldier.py
@@ -1436,3 +1436,179 @@ def test_run_once_falls_through_on_unknown(soldier_env, monkeypatch):
     results = soldier.run_once()
     assert calls == ["task-ext-unknown"]
     assert results == [("task-ext-unknown", MergeResult.MERGED)]
+
+
+# ---------------------------------------------------------------------------
+# Activity-feed events (#191)
+# ---------------------------------------------------------------------------
+
+
+def _drain_soldier_events() -> list[dict]:
+    """Return all soldier-tagged events currently in the SSE bus and clear state."""
+    import antfarm.core.serve as serve_mod
+
+    events = [dict(e) for e in serve_mod._event_queue if e.get("actor") == "soldier"]
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+    return events
+
+
+def _reset_event_bus() -> None:
+    import antfarm.core.serve as serve_mod
+
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+
+def test_merge_emits_started_and_succeeded_events(soldier_env):
+    """A successful merge emits merge_started then merge_succeeded with actor='soldier'."""
+    _reset_event_bus()
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _carry_and_harvest(cc, repo, "task-ev-ok", "feat/task-ev-ok")
+
+    results = soldier.run_once()
+    assert results == [("task-ev-ok", MergeResult.MERGED)]
+
+    events = _drain_soldier_events()
+    types = [e["type"] for e in events]
+    assert "merge_started" in types
+    assert "merge_succeeded" in types
+    # Ordering: started comes before succeeded
+    assert types.index("merge_started") < types.index("merge_succeeded")
+
+    started = next(e for e in events if e["type"] == "merge_started")
+    assert started["actor"] == "soldier"
+    assert started["task_id"] == "task-ev-ok"
+    assert "feat/task-ev-ok" in started["detail"]
+
+    succeeded = next(e for e in events if e["type"] == "merge_succeeded")
+    assert succeeded["actor"] == "soldier"
+    assert succeeded["task_id"] == "task-ev-ok"
+
+
+def test_merge_conflict_emits_merge_failed(soldier_env):
+    """A merge conflict emits merge_started then merge_failed with actor='soldier'."""
+    _reset_event_bus()
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    # Create a conflicting file on dev first
+    _commit_file(repo, "ev-conflict.txt", "dev base\n", "ev base")
+    _git(["git", "push", "origin", "dev"], cwd=repo)
+
+    _carry_and_harvest(
+        cc,
+        repo,
+        "task-ev-conflict",
+        "feat/task-ev-conflict",
+        file_name="ev-conflict.txt",
+        file_content="task change\n",
+    )
+
+    # Diverge dev after the branch was made to force a conflict
+    _commit_file(repo, "ev-conflict.txt", "dev diverged\n", "ev diverge")
+    _git(["git", "push", "origin", "dev"], cwd=repo)
+    _git(["git", "fetch", "origin"], cwd=repo)
+    _git(["git", "reset", "--hard", "origin/dev"], cwd=repo)
+
+    results = soldier.run_once()
+    assert results == [("task-ev-conflict", MergeResult.FAILED)]
+
+    events = _drain_soldier_events()
+    types = [e["type"] for e in events]
+    assert "merge_started" in types
+    assert "merge_failed" in types
+    # merge_succeeded must NOT fire on failure
+    assert "merge_succeeded" not in types
+
+    failed = next(e for e in events if e["type"] == "merge_failed")
+    assert failed["actor"] == "soldier"
+    assert failed["task_id"] == "task-ev-conflict"
+    assert "conflict" in failed["detail"].lower()
+
+
+def test_test_failure_emits_merge_failed(soldier_env):
+    """A test failure after a clean merge emits merge_failed with actor='soldier'."""
+    _reset_event_bus()
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    failing_soldier = Soldier(
+        colony_url="http://testserver",
+        repo_path=repo,
+        integration_branch="dev",
+        test_command=["false"],
+        poll_interval=0.0,
+        client=soldier_env["soldier"].colony._client,
+    )
+
+    _carry_and_harvest(cc, repo, "task-ev-test-fail", "feat/task-ev-test-fail")
+
+    results = failing_soldier.run_once()
+    assert results == [("task-ev-test-fail", MergeResult.FAILED)]
+
+    events = _drain_soldier_events()
+    types = [e["type"] for e in events]
+    assert "merge_started" in types
+    assert "merge_failed" in types
+    assert "merge_succeeded" not in types
+
+    failed = next(e for e in events if e["type"] == "merge_failed")
+    assert failed["actor"] == "soldier"
+    assert failed["task_id"] == "task-ev-test-fail"
+    assert "test" in failed["detail"].lower()
+
+
+def test_reconcile_external_emits_reconciled_event(soldier_env, monkeypatch):
+    """When a PR is already merged on origin, reconciled_external fires with actor='soldier'."""
+    _reset_event_bus()
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _carry_and_harvest(cc, repo, "task-ev-ext", "feat/task-ev-ext")
+
+    # Fake: origin reports MERGED
+    monkeypatch.setattr(Soldier, "_check_pr_merged_on_origin", lambda self, pr: True)
+
+    results = soldier.run_once()
+    assert results == [("task-ev-ext", MergeResult.MERGED)]
+
+    events = _drain_soldier_events()
+    types = [e["type"] for e in events]
+    assert "reconciled_external" in types
+    # When reconciled externally, attempt_merge is skipped — so no
+    # merge_started / merge_succeeded / merge_failed events fire.
+    assert "merge_started" not in types
+    assert "merge_succeeded" not in types
+    assert "merge_failed" not in types
+
+    reconciled = next(e for e in events if e["type"] == "reconciled_external")
+    assert reconciled["actor"] == "soldier"
+    assert reconciled["task_id"] == "task-ev-ext"
+    assert "pr=" in reconciled["detail"]
+
+
+def test_soldier_does_not_duplicate_harvest_or_merged_events(soldier_env):
+    """Soldier must not re-emit harvested/kickback/merged events — those are
+    emitted by colony HTTP handlers in serve.py under actor='colony'."""
+    _reset_event_bus()
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _carry_and_harvest(cc, repo, "task-ev-dedup", "feat/task-ev-dedup")
+    soldier.run_once()
+
+    # All soldier-tagged events must use merge_* / reconciled_external types.
+    events = _drain_soldier_events()
+    soldier_types = {e["type"] for e in events}
+    for colony_type in ("harvested", "kickback", "merged"):
+        assert colony_type not in soldier_types, (
+            f"soldier must not emit '{colony_type}' (actor='soldier') — "
+            f"that is the colony's responsibility"
+        )


### PR DESCRIPTION
In antfarm/core/soldier.py, emit events via `_emit_event` with actor='soldier' at: the start of `attempt_merge` → `merge_started` (detail: branch), successful fast-forward path → `merge_succeeded`, failed/conflict/test-failure paths → `merge_failed` (detail: reason), and in `_reconcile_external_merge` when it detects an externally merged PR → `reconciled_external`. Pass the task_id through. Add tests in tests/test_soldier.py using the existing fixtures/mocks to assert each event fires with actor