### PR TITLE
Emit Autoscaler and Runner worker lifecycle events

### DIFF
--- a/antfarm/core/autoscaler.py
+++ b/antfarm/core/autoscaler.py
@@ -35,6 +35,19 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _emit(event_type: str, task_id: str, detail: str = "") -> None:
+    """Emit an SSE event tagged with actor='autoscaler'.
+
+    Lazy import of ``_emit_event`` keeps autoscaler decoupled from FastAPI
+    transitive imports at module load time.
+    """
+    try:
+        from antfarm.core.serve import _emit_event
+    except Exception:
+        return
+    _emit_event(event_type, task_id, detail, actor="autoscaler")
+
+
 # ---------------------------------------------------------------------------
 # Standalone helpers — shared by Autoscaler and MultiNodeAutoscaler
 # ---------------------------------------------------------------------------
@@ -311,6 +324,7 @@ class Autoscaler:
             if self._pm.start(name, cmd, log_path, role=role):
                 self.managed[name] = ManagedWorker(name=name, role=role, worker_id=worker_id)
                 logger.info("autoscaler started worker name=%s role=%s", name, role)
+                _emit("worker_spawned", "", f"role={role} name={name}")
                 return
             if attempt == 0:
                 logger.info("start failed for %s, retrying with bumped counter", name)
@@ -356,6 +370,7 @@ class Autoscaler:
             self._pm.stop(name)
             logger.info("autoscaler stopped idle worker name=%s role=%s", name, role)
             del self.managed[name]
+            _emit("worker_retired", "", f"role={role} name={name}")
             return True
         return False
 

--- a/antfarm/core/runner.py
+++ b/antfarm/core/runner.py
@@ -28,6 +28,19 @@ from antfarm.core.process_manager import colony_session_hash, get_process_manage
 logger = logging.getLogger(__name__)
 
 
+def _emit(event_type: str, task_id: str, detail: str = "") -> None:
+    """Emit an SSE event tagged with actor='runner'.
+
+    Lazy import of ``_emit_event`` keeps runner decoupled from FastAPI
+    transitive imports at module load time.
+    """
+    try:
+        from antfarm.core.serve import _emit_event
+    except Exception:
+        return
+    _emit_event(event_type, task_id, detail, actor="runner")
+
+
 # ---------------------------------------------------------------------------
 # Data models
 # ---------------------------------------------------------------------------
@@ -362,17 +375,21 @@ class Runner:
                 role = mw.role
                 self._pm.cleanup(name)
                 del self.managed[name]
+                _emit("worker_died", "", f"role={role} name={name}")
                 # Only restart if still desired
                 if desired.get(role, 0) > self._count_role(role):
                     self._start_worker(role)
+                    _emit("worker_restarted", "", f"role={role} name={name}")
 
     def _cleanup_exited(self) -> None:
         """Remove managed workers whose processes have exited."""
         for name in list(self.managed):
             if not self._pm.is_alive(name):
+                role = self.managed[name].role
                 logger.info("runner cleaned up exited worker name=%s", name)
                 self._pm.cleanup(name)
                 del self.managed[name]
+                _emit("worker_died", "", f"role={role} name={name}")
 
     def _count_role(self, role: str) -> int:
         """Count alive managed workers of a given role."""

--- a/tests/test_autoscaler.py
+++ b/tests/test_autoscaler.py
@@ -677,3 +677,101 @@ class TestAdoptExisting:
 
         assert a.managed == {}
         assert a._counter == 0
+
+
+# ---------------------------------------------------------------------------
+# Activity-feed events (#191)
+# ---------------------------------------------------------------------------
+
+
+def _drain_actor_events(actor: str) -> list[dict]:
+    """Return events for a given actor and reset the SSE bus."""
+    import antfarm.core.serve as serve_mod
+
+    events = [dict(e) for e in serve_mod._event_queue if e.get("actor") == actor]
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+    return events
+
+
+def _reset_event_bus() -> None:
+    import antfarm.core.serve as serve_mod
+
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+
+class TestActivityFeedEvents:
+    @patch("antfarm.core.autoscaler.os.makedirs")
+    def test_start_worker_emits_worker_spawned(self, _mock_makedirs):
+        _reset_event_bus()
+        pm = _mock_pm()
+        a = _make_autoscaler(_pm=pm)
+
+        a._start_worker("builder")
+
+        events = _drain_actor_events("autoscaler")
+        spawned = [e for e in events if e["type"] == "worker_spawned"]
+        assert len(spawned) == 1
+        assert spawned[0]["actor"] == "autoscaler"
+        assert "role=builder" in spawned[0]["detail"]
+        assert f"name={a._prefix}builder-1" in spawned[0]["detail"]
+
+    @patch("antfarm.core.autoscaler.os.makedirs")
+    def test_start_worker_no_event_when_start_fails(self, _mock_makedirs):
+        _reset_event_bus()
+        pm = _mock_pm()
+        pm.start.return_value = False  # both attempts fail
+
+        a = _make_autoscaler(_pm=pm)
+        a._start_worker("builder")
+
+        events = _drain_actor_events("autoscaler")
+        assert [e for e in events if e["type"] == "worker_spawned"] == []
+
+    def test_stop_idle_worker_emits_worker_retired(self):
+        _reset_event_bus()
+        pm = _mock_pm()
+        pm.is_alive.return_value = True
+
+        a = _make_autoscaler(_pm=pm, poll_interval=30.0)
+        a.managed["auto-builder-1"] = ManagedWorker(
+            name="auto-builder-1", role="builder", worker_id="local/auto-builder-1"
+        )
+        a.backend.list_workers.return_value = [
+            _worker(
+                "local/auto-builder-1",
+                status="idle",
+                last_heartbeat=_aged_hb(60),
+            ),
+        ]
+
+        stopped = a._stop_idle_worker("builder")
+        assert stopped is True
+
+        events = _drain_actor_events("autoscaler")
+        retired = [e for e in events if e["type"] == "worker_retired"]
+        assert len(retired) == 1
+        assert retired[0]["actor"] == "autoscaler"
+        assert "role=builder" in retired[0]["detail"]
+        assert "name=auto-builder-1" in retired[0]["detail"]
+
+    def test_stop_idle_worker_no_event_when_skipped(self):
+        _reset_event_bus()
+        pm = _mock_pm()
+        pm.is_alive.return_value = True
+
+        a = _make_autoscaler(_pm=pm, poll_interval=30.0)
+        a.managed["auto-builder-1"] = ManagedWorker(
+            name="auto-builder-1", role="builder", worker_id="local/auto-builder-1"
+        )
+        # Active (not idle) — skip
+        a.backend.list_workers.return_value = [
+            _worker("local/auto-builder-1", status="active"),
+        ]
+
+        stopped = a._stop_idle_worker("builder")
+        assert stopped is False
+
+        events = _drain_actor_events("autoscaler")
+        assert [e for e in events if e["type"] == "worker_retired"] == []

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -370,3 +370,131 @@ class TestStalePidsDirSweep:
             patch("antfarm.core.colony_client.ColonyClient"),
         ):
             r.run()  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# Activity-feed events (#191)
+# ---------------------------------------------------------------------------
+
+
+def _drain_actor_events(actor: str) -> list[dict]:
+    """Return events for a given actor and reset the SSE bus."""
+    import antfarm.core.serve as serve_mod
+
+    events = [dict(e) for e in serve_mod._event_queue if e.get("actor") == actor]
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+    return events
+
+
+def _reset_event_bus() -> None:
+    import antfarm.core.serve as serve_mod
+
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+
+class TestActivityFeedEvents:
+    def test_cleanup_exited_emits_worker_died(self, tmp_path):
+        """Dead workers detected by _cleanup_exited emit worker_died with actor='runner'."""
+        from antfarm.core.runner import ManagedWorker
+
+        _reset_event_bus()
+        r = _make_runner(tmp_path)
+        pm = _mock_pm()
+        # "dead" exited; "alive" still alive
+        pm.is_alive.side_effect = lambda name: name != "dead-builder-1"
+        r._pm = pm
+        r.managed["dead-builder-1"] = ManagedWorker(
+            name="dead-builder-1", role="builder"
+        )
+        r.managed["alive-reviewer-1"] = ManagedWorker(
+            name="alive-reviewer-1", role="reviewer"
+        )
+
+        r._cleanup_exited()
+
+        events = _drain_actor_events("runner")
+        died = [e for e in events if e["type"] == "worker_died"]
+        assert len(died) == 1
+        assert died[0]["actor"] == "runner"
+        assert "role=builder" in died[0]["detail"]
+        assert "name=dead-builder-1" in died[0]["detail"]
+
+    def test_restart_crashed_emits_worker_died_and_restarted(self, tmp_path):
+        """_restart_crashed emits worker_died and worker_restarted when desired."""
+        from antfarm.core.runner import ManagedWorker
+
+        _reset_event_bus()
+        r = _make_runner(tmp_path)
+        pm = _mock_pm()
+        # The crashed worker reads as not alive; everything else is alive.
+        pm.is_alive.side_effect = lambda name: name != "crashed-builder-1"
+        r._pm = pm
+        r.managed["crashed-builder-1"] = ManagedWorker(
+            name="crashed-builder-1", role="builder"
+        )
+        # Desire one builder so the restart path runs
+        r._desired = DesiredState(generation=1, desired={"builder": 1})
+
+        r._restart_crashed()
+
+        events = _drain_actor_events("runner")
+        died = [e for e in events if e["type"] == "worker_died"]
+        restarted = [e for e in events if e["type"] == "worker_restarted"]
+
+        assert len(died) == 1
+        assert died[0]["actor"] == "runner"
+        assert "role=builder" in died[0]["detail"]
+        assert "name=crashed-builder-1" in died[0]["detail"]
+
+        assert len(restarted) == 1
+        assert restarted[0]["actor"] == "runner"
+        assert "role=builder" in restarted[0]["detail"]
+        # restarted detail names the *original* (dead) worker, not the new one
+        assert "name=crashed-builder-1" in restarted[0]["detail"]
+
+        # ProcessManager.start was called exactly once (the restart)
+        assert pm.start.call_count == 1
+
+    def test_restart_crashed_no_restart_event_when_not_desired(self, tmp_path):
+        """If role is no longer desired, only worker_died fires (no restart)."""
+        from antfarm.core.runner import ManagedWorker
+
+        _reset_event_bus()
+        r = _make_runner(tmp_path)
+        pm = _mock_pm()
+        pm.is_alive.side_effect = lambda name: name != "crashed-builder-1"
+        r._pm = pm
+        r.managed["crashed-builder-1"] = ManagedWorker(
+            name="crashed-builder-1", role="builder"
+        )
+        # Desire zero builders — restart should NOT fire
+        r._desired = DesiredState(generation=1, desired={"builder": 0})
+
+        r._restart_crashed()
+
+        events = _drain_actor_events("runner")
+        died = [e for e in events if e["type"] == "worker_died"]
+        restarted = [e for e in events if e["type"] == "worker_restarted"]
+
+        assert len(died) == 1
+        assert restarted == []
+        assert pm.start.call_count == 0
+
+    def test_cleanup_exited_no_event_when_all_alive(self, tmp_path):
+        """No worker_died events when every managed worker is still alive."""
+        from antfarm.core.runner import ManagedWorker
+
+        _reset_event_bus()
+        r = _make_runner(tmp_path)
+        pm = _mock_pm(alive=True)
+        r._pm = pm
+        r.managed["happy-builder-1"] = ManagedWorker(
+            name="happy-builder-1", role="builder"
+        )
+
+        r._cleanup_exited()
+
+        events = _drain_actor_events("runner")
+        assert [e for e in events if e["type"] == "worker_died"] == []


### PR DESCRIPTION
In antfarm/core/autoscaler.py, emit `worker_spawned` in `_start_worker` (detail: role+name) and `worker_retired` in `_stop_idle_worker` (detail: role+name) with actor='autoscaler'. In antfarm/core/runner.py, emit `worker_restarted` in `_restart_crashed` and `worker_died` where exited workers are detected (inside `_cleanup_exited` or `_restart_crashed`) with actor='runner'. If runner is not currently active in a deployment, the emissions still fire whenever the code paths execute; no feature-flag