### PR TITLE
Emit Soldier merge lifecycle events

### DIFF
--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -32,6 +32,20 @@ from antfarm.core.review_pack import extract_verdict_from_review_task
 logger = logging.getLogger(__name__)
 
 
+def _emit(event_type: str, task_id: str, detail: str = "") -> None:
+    """Emit an SSE event tagged with actor='soldier'.
+
+    Lazy-imports ``_emit_event`` to avoid a circular import at module load
+    time (serve.py imports Soldier) and to keep soldier importable in
+    contexts where the FastAPI server module cannot be loaded.
+    """
+    try:
+        from antfarm.core.serve import _emit_event
+    except Exception:
+        return
+    _emit_event(event_type, task_id, detail, actor="soldier")
+
+
 class MergeResult(StrEnum):
     MERGED = "merged"
     FAILED = "failed"
@@ -389,10 +403,14 @@ class Soldier:
         Returns:
             MergeResult.MERGED on success, MergeResult.FAILED on any failure.
         """
+        task_id = task.get("id", "")
         branch = self._get_attempt_branch(task)
         if not branch:
             self.last_failure_reason = "no branch on current attempt"
+            _emit("merge_failed", task_id, self.last_failure_reason)
             return MergeResult.FAILED
+
+        _emit("merge_started", task_id, branch)
 
         temp_branch = "antfarm/temp-merge"
         try:
@@ -405,6 +423,7 @@ class Soldier:
             )
             if r.returncode != 0:
                 self.last_failure_reason = f"git fetch failed: {r.stderr.decode().strip()}"
+                _emit("merge_failed", task_id, self.last_failure_reason)
                 return MergeResult.FAILED
 
             # Create temp branch from integration branch
@@ -424,6 +443,7 @@ class Soldier:
                 self.last_failure_reason = (
                     f"could not create temp branch: {r.stderr.decode().strip()}"
                 )
+                _emit("merge_failed", task_id, self.last_failure_reason)
                 return MergeResult.FAILED
 
             # Merge task branch (no-ff to preserve history)
@@ -437,6 +457,7 @@ class Soldier:
                 self.last_failure_reason = (
                     f"merge conflict merging {branch}: {r.stderr.decode().strip()}"
                 )
+                _emit("merge_failed", task_id, self.last_failure_reason)
                 return MergeResult.FAILED
 
             # Run tests
@@ -450,6 +471,7 @@ class Soldier:
                 self.last_failure_reason = (
                     f"tests failed: {r.stdout.decode().strip()} {r.stderr.decode().strip()}"
                 ).strip()
+                _emit("merge_failed", task_id, self.last_failure_reason)
                 return MergeResult.FAILED
 
             # Fast-forward integration branch
@@ -463,6 +485,7 @@ class Soldier:
                 self.last_failure_reason = (
                     f"could not checkout {self.integration_branch}: {r.stderr.decode().strip()}"
                 )
+                _emit("merge_failed", task_id, self.last_failure_reason)
                 return MergeResult.FAILED
 
             r = subprocess.run(
@@ -473,6 +496,7 @@ class Soldier:
             )
             if r.returncode != 0:
                 self.last_failure_reason = f"ff-only merge failed: {r.stderr.decode().strip()}"
+                _emit("merge_failed", task_id, self.last_failure_reason)
                 return MergeResult.FAILED
 
             # Push to origin
@@ -484,8 +508,10 @@ class Soldier:
             )
             if r.returncode != 0:
                 self.last_failure_reason = f"push failed: {r.stderr.decode().strip()}"
+                _emit("merge_failed", task_id, self.last_failure_reason)
                 return MergeResult.FAILED
 
+            _emit("merge_succeeded", task_id, branch)
             return MergeResult.MERGED
 
         finally:
@@ -660,6 +686,7 @@ class Soldier:
         with contextlib.suppress(ValueError):
             self.colony.mark_merged(task_id, attempt_id)
         logger.info("reconciled externally-merged PR %s for %s", pr, task_id)
+        _emit("reconciled_external", task_id, f"pr={pr}")
         return True
 
     @staticmethod

--- a/tests/test_soldier.py
+++ b/tests/test_soldier.py
@@ -1436,3 +1436,168 @@ def test_run_once_falls_through_on_unknown(soldier_env, monkeypatch):
     results = soldier.run_once()
     assert calls == ["task-ext-unknown"]
     assert results == [("task-ext-unknown", MergeResult.MERGED)]
+
+
+# ---------------------------------------------------------------------------
+# Soldier activity-feed events (#191)
+#
+# Soldier emits SSE events to serve._event_queue at each merge-lifecycle
+# transition with actor="soldier":
+#   merge_started, merge_succeeded, merge_failed, reconciled_external.
+# Colony-owned events (harvested/kickback/merged) are emitted from serve.py
+# with actor="colony" and must not be re-emitted by soldier.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clear_events():
+    """Clear the SSE event queue before each event-assertion test."""
+    from antfarm.core import serve
+
+    serve._event_queue.clear()
+    yield serve._event_queue
+
+
+def _events_of_type(queue, event_type: str) -> list[dict]:
+    return [e for e in queue if e["type"] == event_type]
+
+
+def test_soldier_emits_merge_started_and_succeeded_on_green_merge(soldier_env, clear_events):
+    """On a clean merge, soldier emits merge_started then merge_succeeded."""
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _carry_and_harvest(cc, repo, "task-ev-ok", "feat/task-ev-ok")
+
+    results = soldier.run_once()
+    assert results == [("task-ev-ok", MergeResult.MERGED)]
+
+    started = _events_of_type(clear_events, "merge_started")
+    succeeded = _events_of_type(clear_events, "merge_succeeded")
+    assert len(started) == 1
+    assert len(succeeded) == 1
+
+    assert started[0]["actor"] == "soldier"
+    assert started[0]["task_id"] == "task-ev-ok"
+    assert started[0]["detail"] == "feat/task-ev-ok"
+
+    assert succeeded[0]["actor"] == "soldier"
+    assert succeeded[0]["task_id"] == "task-ev-ok"
+    assert succeeded[0]["detail"] == "feat/task-ev-ok"
+
+    # Ordering: started must come before succeeded.
+    assert started[0]["id"] < succeeded[0]["id"]
+
+
+def test_soldier_emits_merge_failed_on_conflict(soldier_env, clear_events):
+    """A merge conflict emits merge_failed with actor='soldier' and no merge_succeeded."""
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _commit_file(repo, "conflict-ev.txt", "base\n", "base on dev")
+    _git(["git", "push", "origin", "dev"], cwd=repo)
+
+    _carry_and_harvest(
+        cc,
+        repo,
+        "task-ev-conflict",
+        "feat/task-ev-conflict",
+        file_name="conflict-ev.txt",
+        file_content="branch change\n",
+    )
+
+    _commit_file(repo, "conflict-ev.txt", "dev diverged\n", "dev diverges")
+    _git(["git", "push", "origin", "dev"], cwd=repo)
+    _git(["git", "fetch", "origin"], cwd=repo)
+    _git(["git", "reset", "--hard", "origin/dev"], cwd=repo)
+
+    results = soldier.run_once()
+    assert results == [("task-ev-conflict", MergeResult.FAILED)]
+
+    failed = _events_of_type(clear_events, "merge_failed")
+    succeeded = _events_of_type(clear_events, "merge_succeeded")
+    assert len(failed) == 1
+    assert succeeded == []
+    assert failed[0]["actor"] == "soldier"
+    assert failed[0]["task_id"] == "task-ev-conflict"
+    assert "conflict" in failed[0]["detail"].lower()
+
+
+def test_soldier_emits_merge_failed_on_test_failure(soldier_env, clear_events):
+    """A test failure (non-zero test_command) emits merge_failed."""
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    failing_soldier = Soldier(
+        colony_url="http://testserver",
+        repo_path=repo,
+        integration_branch="dev",
+        test_command=["false"],
+        poll_interval=0.0,
+        client=soldier_env["soldier"].colony._client,
+    )
+
+    _carry_and_harvest(cc, repo, "task-ev-testfail", "feat/task-ev-testfail")
+
+    results = failing_soldier.run_once()
+    assert results == [("task-ev-testfail", MergeResult.FAILED)]
+
+    failed = _events_of_type(clear_events, "merge_failed")
+    succeeded = _events_of_type(clear_events, "merge_succeeded")
+    assert len(failed) == 1
+    assert succeeded == []
+    assert failed[0]["actor"] == "soldier"
+    assert failed[0]["task_id"] == "task-ev-testfail"
+    assert "test" in failed[0]["detail"].lower()
+
+
+def test_soldier_emits_reconciled_external_and_skips_merge_events(
+    soldier_env, clear_events, monkeypatch
+):
+    """When the PR is already merged on origin, soldier emits reconciled_external and
+    does not run the attempt_merge path (so no merge_started/succeeded fire)."""
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _carry_and_harvest(cc, repo, "task-ev-ext", "feat/task-ev-ext")
+
+    monkeypatch.setattr(Soldier, "_check_pr_merged_on_origin", lambda self, pr: True)
+
+    results = soldier.run_once()
+    assert results == [("task-ev-ext", MergeResult.MERGED)]
+
+    reconciled = _events_of_type(clear_events, "reconciled_external")
+    assert len(reconciled) == 1
+    assert reconciled[0]["actor"] == "soldier"
+    assert reconciled[0]["task_id"] == "task-ev-ext"
+    assert reconciled[0]["detail"].startswith("pr=")
+
+    # Reconciliation path short-circuits the merge attempt; soldier must not
+    # emit merge_started/merge_succeeded from that path.
+    assert _events_of_type(clear_events, "merge_started") == []
+    assert _events_of_type(clear_events, "merge_succeeded") == []
+
+
+def test_soldier_does_not_re_emit_colony_event_types(soldier_env, clear_events):
+    """Colony-owned events (harvested/kickback/merged) must not fire with actor='soldier'."""
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _carry_and_harvest(cc, repo, "task-ev-noreemit", "feat/task-ev-noreemit")
+
+    # Clear events emitted by the _carry_and_harvest setup (which calls colony
+    # endpoints that emit with actor='colony') so this assertion focuses on
+    # events soldier itself produces during run_once.
+    clear_events.clear()
+
+    soldier.run_once()
+
+    for e in clear_events:
+        if e["type"] in ("harvested", "kickback", "merged"):
+            assert e["actor"] != "soldier", (
+                f"soldier must not re-emit colony-owned event {e['type']}: {e}"
+            )


### PR DESCRIPTION
In antfarm/core/soldier.py, emit events via `_emit_event` with actor='soldier' at: the start of `attempt_merge` → `merge_started` (detail: branch), successful fast-forward path → `merge_succeeded`, failed/conflict/test-failure paths → `merge_failed` (detail: reason), and in `_reconcile_external_merge` when it detects an externally merged PR → `reconciled_external`. Pass the task_id through. Add tests in tests/test_soldier.py using the existing fixtures/mocks to assert each event fires with actor