### PR TITLE
feat(soldier): event-driven merge trigger (P5)

### DIFF
--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -18,10 +18,13 @@ Policy:
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
 import subprocess
 import time
 from enum import StrEnum
+
+import httpx
 
 from antfarm.core.backends.base import TaskBackend
 from antfarm.core.colony_client import ColonyClient
@@ -30,6 +33,12 @@ from antfarm.core.models import ReviewVerdict
 from antfarm.core.review_pack import extract_verdict_from_review_task
 
 logger = logging.getLogger(__name__)
+
+# Event types that should wake the Soldier's run loop immediately.
+# - harvested: a task moved to done/ — may be merge-eligible now
+# - kickback: a task regressed — may unblock cascade or free scheduling
+# - merged: a dependency was merged — dependents may now be eligible
+WAKE_EVENT_TYPES: frozenset[str] = frozenset({"harvested", "kickback", "merged"})
 
 
 def _emit(event_type: str, task_id: str, detail: str = "") -> None:
@@ -79,6 +88,7 @@ class Soldier:
         client=None,
     ):
         self.colony = ColonyClient(colony_url, client=client)
+        self.colony_url = colony_url
         self.repo_path = repo_path
         self.integration_branch = integration_branch
         self.test_command = test_command or ["pytest", "-x", "-q"]
@@ -86,19 +96,27 @@ class Soldier:
         self.require_review = require_review
         self.poll_external_merges = poll_external_merges
         self.last_failure_reason = ""
+        # Event cursor for /events SSE stream. In-memory only; never persists.
+        self._event_cursor: int = 0
 
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
 
     def run(self) -> None:
-        """Main soldier loop. Runs indefinitely until interrupted."""
+        """Main soldier loop. Runs indefinitely until interrupted.
+
+        Between ticks, the loop waits on the colony's /events SSE stream
+        so it can wake immediately on ``harvested``/``kickback``/``merged``
+        events. On any connection failure the loop falls back to the
+        legacy polling behaviour (``time.sleep(self.poll_interval)``).
+        """
         while True:
             if self.require_review:
                 self.process_done_tasks()
             queue = self.get_merge_queue()
             if not queue:
-                time.sleep(self.poll_interval)
+                self._wait_for_event(timeout=self.poll_interval)
                 continue
             for task in queue:
                 if self._reconcile_external_merge(task):
@@ -556,6 +574,67 @@ class Soldier:
     # Private helpers
     # ------------------------------------------------------------------
 
+    def _wait_for_event(self, timeout: float) -> bool:
+        """Wait on the colony's /events SSE stream for a wake event.
+
+        Opens a streaming GET against ``/events?after=<cursor>&timeout=<timeout>``
+        and consumes SSE ``data:`` lines. Returns early as soon as an event with
+        ``type`` in :data:`WAKE_EVENT_TYPES` arrives. Other event types advance
+        the cursor but do not cause an early return.
+
+        Args:
+            timeout: Maximum seconds to wait for a wake event. Matches the
+                colony server's ``timeout`` query contract.
+
+        Returns:
+            True if woken by a relevant event; False on timeout or fallback.
+
+        Fallback behaviour:
+            If this Soldier was constructed via :meth:`from_backend` (in-process;
+            ``colony_url`` is empty) the SSE path is skipped and the method
+            does a plain ``time.sleep(timeout)``. On any connection, read, or
+            parse error the method logs a warning, does ``time.sleep(timeout)``,
+            and returns False. The polling path is always available as a
+            safety net.
+        """
+        # In-process Soldier (from_backend) has no meaningful colony_url.
+        # Skip SSE entirely and preserve the original polling behaviour.
+        if not self.colony_url:
+            time.sleep(timeout)
+            return False
+
+        url = f"{self.colony_url.rstrip('/')}/events"
+        params = {"after": self._event_cursor, "timeout": timeout}
+        # Read timeout slightly larger than server-side timeout so the server
+        # closes the stream first (graceful), not the client.
+        client_timeout = httpx.Timeout(timeout + 5.0, connect=5.0)
+        try:
+            with (
+                httpx.Client(timeout=client_timeout) as client,
+                client.stream("GET", url, params=params) as resp,
+            ):
+                resp.raise_for_status()
+                for line in resp.iter_lines():
+                    if not line or not line.startswith("data:"):
+                        continue
+                    payload = line[len("data:") :].strip()
+                    if not payload:
+                        continue
+                    event = json.loads(payload)
+                    event_id = event.get("id", 0)
+                    if isinstance(event_id, int) and event_id > self._event_cursor:
+                        self._event_cursor = event_id
+                    if event.get("type") in WAKE_EVENT_TYPES:
+                        return True
+                # Stream closed cleanly (server-side timeout). Act as a tick.
+                return False
+        except Exception as exc:
+            logger.warning(
+                "soldier event wait failed (%s); falling back to poll sleep", exc
+            )
+            time.sleep(timeout)
+            return False
+
     def _cleanup(self) -> None:
         """Restore repo to a clean state after a merge attempt (success or failure).
 
@@ -972,6 +1051,7 @@ class Soldier:
         """
         instance = cls.__new__(cls)
         instance.colony = _BackendAdapter(backend)
+        instance.colony_url = ""  # in-process: sentinel disables SSE wait
         instance.repo_path = repo_path
         instance.integration_branch = integration_branch
         instance.test_command = test_command or ["pytest", "-x", "-q"]
@@ -979,6 +1059,7 @@ class Soldier:
         instance.require_review = require_review
         instance.poll_external_merges = poll_external_merges
         instance.last_failure_reason = ""
+        instance._event_cursor = 0
         return instance
 
 

--- a/tests/test_soldier.py
+++ b/tests/test_soldier.py
@@ -8,11 +8,15 @@ and colony interactions are fully exercised without mocking.
 from __future__ import annotations
 
 import contextlib
+import json
 import subprocess
+import time
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
+from antfarm.core import soldier as soldier_module
 from antfarm.core.backends.file import FileBackend
 from antfarm.core.colony_client import ColonyClient
 from antfarm.core.serve import get_app
@@ -1601,3 +1605,231 @@ def test_soldier_does_not_re_emit_colony_event_types(soldier_env, clear_events):
             assert e["actor"] != "soldier", (
                 f"soldier must not re-emit colony-owned event {e['type']}: {e}"
             )
+
+
+# ---------------------------------------------------------------------------
+# P5: event-driven merge trigger — _wait_for_event tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeStreamResponse:
+    """Minimal stand-in for an httpx streaming Response used with a context manager."""
+
+    def __init__(self, lines: list[str], *, raise_on_enter: Exception | None = None):
+        self._lines = lines
+        self._raise_on_enter = raise_on_enter
+
+    def __enter__(self):
+        if self._raise_on_enter is not None:
+            raise self._raise_on_enter
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def raise_for_status(self):
+        return None
+
+    def iter_lines(self):
+        yield from self._lines
+
+
+class _FakeHttpxClient:
+    """Minimal httpx.Client replacement with a scripted stream() response."""
+
+    def __init__(
+        self,
+        lines: list[str] | None = None,
+        *,
+        stream_exc: Exception | None = None,
+        enter_exc: Exception | None = None,
+    ):
+        self._lines = lines or []
+        self._stream_exc = stream_exc
+        self._enter_exc = enter_exc
+        self.stream_calls: list[tuple[str, str, dict]] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def stream(self, method: str, url: str, params: dict | None = None, **kwargs):
+        self.stream_calls.append((method, url, params or {}))
+        if self._stream_exc is not None:
+            raise self._stream_exc
+        return _FakeStreamResponse(self._lines, raise_on_enter=self._enter_exc)
+
+
+def _make_soldier_for_event_tests(poll_interval: float = 5.0) -> Soldier:
+    """Construct a Soldier with a usable colony_url but no real HTTP."""
+    return Soldier(
+        colony_url="http://fake-colony:7433",
+        repo_path="/tmp/not-used",
+        integration_branch="dev",
+        poll_interval=poll_interval,
+    )
+
+
+def test_wait_for_event_wakes_on_harvested_under_one_second(monkeypatch):
+    """A wake event (harvested) must cause _wait_for_event to return quickly."""
+    soldier = _make_soldier_for_event_tests(poll_interval=5.0)
+
+    wake = {
+        "id": 1,
+        "actor": "colony",
+        "type": "harvested",
+        "task_id": "task-1",
+        "detail": "",
+        "ts": "now",
+    }
+    lines = [f"data: {json.dumps(wake)}", ""]
+    fake_client = _FakeHttpxClient(lines=lines)
+
+    monkeypatch.setattr(
+        soldier_module.httpx, "Client", lambda *a, **kw: fake_client
+    )
+
+    # If sleep is called here we fail — wake path must not sleep.
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(soldier_module.time, "sleep", lambda s: sleep_calls.append(s))
+
+    start = time.monotonic()
+    woken = soldier._wait_for_event(timeout=5.0)
+    elapsed = time.monotonic() - start
+
+    assert woken is True
+    assert elapsed < 1.0, f"expected fast wake, took {elapsed:.2f}s"
+    assert soldier._event_cursor == 1
+    assert sleep_calls == [], "wake path must not call time.sleep"
+
+
+def test_wait_for_event_ignores_unrelated_events_until_timeout(monkeypatch):
+    """Non-wake events advance the cursor but do not cause an early return."""
+    soldier = _make_soldier_for_event_tests(poll_interval=5.0)
+
+    unrelated = {
+        "id": 7,
+        "actor": "worker",
+        "type": "random_event",
+        "task_id": "task-x",
+        "detail": "",
+        "ts": "now",
+    }
+    # Provide exactly one non-wake event then let the fake stream end,
+    # simulating server-side timeout.
+    lines = [f"data: {json.dumps(unrelated)}", ""]
+    fake_client = _FakeHttpxClient(lines=lines)
+    monkeypatch.setattr(
+        soldier_module.httpx, "Client", lambda *a, **kw: fake_client
+    )
+
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(soldier_module.time, "sleep", lambda s: sleep_calls.append(s))
+
+    woken = soldier._wait_for_event(timeout=5.0)
+
+    assert woken is False
+    # Cursor advanced even though no wake happened.
+    assert soldier._event_cursor == 7
+    # Clean end-of-stream means a server-side timeout path — no fallback sleep.
+    assert sleep_calls == []
+
+
+def test_wait_for_event_timeout_returns_false_without_crashing(monkeypatch):
+    """Empty stream (server timeout) returns False — loop continues normally."""
+    soldier = _make_soldier_for_event_tests(poll_interval=5.0)
+
+    fake_client = _FakeHttpxClient(lines=[])
+    monkeypatch.setattr(
+        soldier_module.httpx, "Client", lambda *a, **kw: fake_client
+    )
+    monkeypatch.setattr(soldier_module.time, "sleep", lambda s: None)
+
+    woken = soldier._wait_for_event(timeout=5.0)
+    assert woken is False
+    assert soldier._event_cursor == 0
+
+
+def test_wait_for_event_connection_error_falls_back_to_sleep(monkeypatch):
+    """On httpx errors, log WARN + time.sleep(poll_interval); no exception escapes."""
+    soldier = _make_soldier_for_event_tests(poll_interval=5.0)
+
+    fake_client = _FakeHttpxClient(stream_exc=httpx.ConnectError("boom"))
+    monkeypatch.setattr(
+        soldier_module.httpx, "Client", lambda *a, **kw: fake_client
+    )
+
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(soldier_module.time, "sleep", lambda s: sleep_calls.append(s))
+
+    woken = soldier._wait_for_event(timeout=5.0)
+
+    assert woken is False
+    assert sleep_calls == [5.0], "fallback must sleep exactly poll_interval once"
+
+
+def test_wait_for_event_json_parse_error_falls_back_to_sleep(monkeypatch):
+    """Malformed SSE payload triggers the WARN + sleep fallback."""
+    soldier = _make_soldier_for_event_tests(poll_interval=3.0)
+
+    # "data: not-json" will fail json.loads inside the helper.
+    lines = ["data: not-json", ""]
+    fake_client = _FakeHttpxClient(lines=lines)
+    monkeypatch.setattr(
+        soldier_module.httpx, "Client", lambda *a, **kw: fake_client
+    )
+
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(soldier_module.time, "sleep", lambda s: sleep_calls.append(s))
+
+    woken = soldier._wait_for_event(timeout=3.0)
+
+    assert woken is False
+    assert sleep_calls == [3.0]
+
+
+def test_wait_for_event_in_process_soldier_uses_plain_sleep(tmp_path, monkeypatch):
+    """Soldier built via from_backend has no colony_url — must plain-sleep, not SSE."""
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    soldier = Soldier.from_backend(
+        backend=backend,
+        repo_path=str(tmp_path),
+        integration_branch="dev",
+        poll_interval=2.0,
+    )
+
+    # If httpx.Client is ever invoked, fail.
+    def _no_client(*a, **kw):
+        raise AssertionError("in-process soldier must not open SSE")
+
+    monkeypatch.setattr(soldier_module.httpx, "Client", _no_client)
+
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(soldier_module.time, "sleep", lambda s: sleep_calls.append(s))
+
+    woken = soldier._wait_for_event(timeout=2.0)
+
+    assert woken is False
+    assert sleep_calls == [2.0]
+
+
+def test_wait_for_event_passes_cursor_and_timeout_to_server(monkeypatch):
+    """The helper must use the current cursor and propagate timeout to /events."""
+    soldier = _make_soldier_for_event_tests(poll_interval=4.0)
+    soldier._event_cursor = 42
+
+    fake_client = _FakeHttpxClient(lines=[])
+    monkeypatch.setattr(
+        soldier_module.httpx, "Client", lambda *a, **kw: fake_client
+    )
+    monkeypatch.setattr(soldier_module.time, "sleep", lambda s: None)
+
+    soldier._wait_for_event(timeout=4.0)
+
+    assert len(fake_client.stream_calls) == 1
+    method, url, params = fake_client.stream_calls[0]
+    assert method == "GET"
+    assert url.endswith("/events")
+    assert params == {"after": 42, "timeout": 4.0}


### PR DESCRIPTION
## Summary

Replaces the unconditional `time.sleep(poll_interval)` between Soldier ticks with an event-aware wait backed by the colony's `/events` SSE stream. The Soldier now reacts to relevant colony events within 1s instead of waiting up to a full poll interval (default 30s), meaningfully reducing end-to-end merge latency in fan-out missions.

Polling is preserved as the safety net — any connection, read, or parse error logs at `WARNING` and falls through to `time.sleep(poll_interval)`.

## Wake event set

Today only three wake-worthy events are emitted by `serve.py::_emit_event`: `harvested`, `kickback`, `merged`. The spec's optional `review_approved` / `merge_requested` events are not yet wired end-to-end. Per the spec's "minimal viable wake set" fallback, this PR subscribes to:

- **`harvested`** — a task moved to `done/` and may now be merge-eligible.
- **`kickback`** — a task regressed; can unblock cascades and re-ready merge state.
- **`merged`** — an upstream merge may have unblocked dependents in the merge queue.

Adding a new `review_approved` emission in `serve.py` is deferred (the review verdict plumbing spans the reviewer worker, the Soldier, and the colony store — a clean emission site is not a ~20-line change). Work on that is left for a follow-up; the `harvested` event already fires on every done transition, which covers the same wake signal with one hop of latency.

## Design details

- `Soldier._wait_for_event(timeout)` opens `GET /events?after=<cursor>&timeout=<timeout>`, consumes `data:` SSE lines, advances the in-memory cursor, and returns early on any wake event.
- Cursor is in-memory only (no persistence across restarts — spec explicitly allows this).
- In-process Soldiers constructed via `Soldier.from_backend()` have no meaningful `colony_url`; they skip SSE and plain-sleep as before, so the embedded soldier thread inside `serve.py` keeps working unchanged.
- httpx read timeout is set to `poll_interval + 5s` so the server closes the stream first (graceful), not the client.

## Invariants preserved

- Polling fallback is always safe — no crash escapes `_wait_for_event`.
- `attempt_merge` / `run_once_with_review` are not touched.
- `run_once()` (used by tests) is not touched; only `run()`'s sleep call site is swapped.
- No AI/LLM.
- No blocking call exceeds `poll_interval + 5s`.

## Test plan

- [x] `test_wait_for_event_wakes_on_harvested_under_one_second` — wake in <1s with `poll_interval=5`.
- [x] `test_wait_for_event_ignores_unrelated_events_until_timeout` — non-wake events advance cursor but don't return early.
- [x] `test_wait_for_event_timeout_returns_false_without_crashing` — empty stream → False.
- [x] `test_wait_for_event_connection_error_falls_back_to_sleep` — `httpx.ConnectError` → WARN + `time.sleep(poll_interval)`.
- [x] `test_wait_for_event_json_parse_error_falls_back_to_sleep` — malformed SSE → same fallback.
- [x] `test_wait_for_event_in_process_soldier_uses_plain_sleep` — `from_backend` path never opens SSE.
- [x] `test_wait_for_event_passes_cursor_and_timeout_to_server` — verifies `/events` query contract.
- [x] `ruff check .` passes.
- [x] `pytest tests/ -x -q` — 1034 passed.

Refs #287