### PR TITLE
fix(worker): backoff-in-place on empty queue (P4)

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -409,6 +409,23 @@ def worker():
 @click.option(
     "--capabilities", default=None, help="Comma-separated worker capabilities (e.g. gpu,docker)."
 )  # noqa: E501
+@click.option(
+    "--poll-interval",
+    type=float,
+    default=30.0,
+    show_default=True,
+    help="Seconds to sleep between empty forage polls.",
+)
+@click.option(
+    "--max-empty-polls",
+    type=int,
+    default=None,
+    help=(
+        "Max consecutive empty forages before exit. "
+        "Unset = role-based default (reviewer=10, builder=5, planner=0). "
+        "0 = exit on first empty."
+    ),
+)
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def worker_start(
@@ -420,6 +437,8 @@ def worker_start(
     repo_path: str,
     integration_branch: str,
     capabilities: str | None,
+    poll_interval: float,
+    max_empty_polls: int | None,
     colony_url: str,
     token: str | None,
 ):
@@ -445,6 +464,8 @@ def worker_start(
         workspace_root=ws_root,
         repo_path=repo_path,
         integration_branch=integration_branch,
+        poll_interval=poll_interval,
+        max_empty_polls=max_empty_polls,
         capabilities=caps,
         token=token,
     )

--- a/antfarm/core/worker.py
+++ b/antfarm/core/worker.py
@@ -230,6 +230,13 @@ class WorkerRuntime:
         repo_path: Path to the git repository used as the worktree source.
         integration_branch: Branch new worktrees are created from.
         heartbeat_interval: Seconds between heartbeat posts (default 30).
+        poll_interval: Seconds to sleep between empty forage polls (default 30).
+            Must be > 0; non-positive values raise ValueError.
+        max_empty_polls: Max consecutive empty forages before the worker exits.
+            When None (default), the role-based default applies:
+            reviewer=10, builder=5, planner=0 (exit on first empty). An explicit
+            integer overrides the role default; 0 preserves the original
+            "exit immediately on first empty" semantics as an opt-in.
         client: Optional httpx.Client for dependency injection in tests.
         token: Optional bearer token for colony authentication.
     """
@@ -244,15 +251,22 @@ class WorkerRuntime:
         repo_path: str,
         integration_branch: str = "main",
         heartbeat_interval: float = 30.0,
+        poll_interval: float = 30.0,
+        max_empty_polls: int | None = None,
         capabilities: list[str] | None = None,
         client: httpx.Client | None = None,
         token: str | None = None,
     ):
+        if poll_interval <= 0:
+            raise ValueError(
+                f"poll_interval must be > 0, got {poll_interval}"
+            )
         self.worker_id = f"{node_id}/{name}"
         self.node_id = node_id
         self.agent_type = agent_type
         self.workspace_root = workspace_root
         self.heartbeat_interval = heartbeat_interval
+        self.poll_interval = poll_interval
         self.capabilities = capabilities or []
         self._token = token
         self._data_dir = os.environ.get("ANTFARM_DATA_DIR", ".antfarm")
@@ -263,16 +277,21 @@ class WorkerRuntime:
         if "review" in caps:
             # Reviewers wait up to 5min for builders to harvest review tasks.
             self._role = "reviewer"
-            self._max_idle_polls = 10  # 10 * 30s = 5min
+            role_max_idle_polls = 10  # 10 * 30s = 5min
         elif "plan" in caps:
             # Planners produce one batch of child tasks and exit promptly.
             self._role = "planner"
-            self._max_idle_polls = 0
+            role_max_idle_polls = 0
         else:
             # Builders wait up to 2.5min so they outlast a typical planner run
             # and don't race the planner when started together (#144).
             self._role = "builder"
-            self._max_idle_polls = 5  # 5 * 30s = 2.5min
+            role_max_idle_polls = 5  # 5 * 30s = 2.5min
+
+        # Explicit CLI override wins over role default; None preserves it (#272).
+        self._max_idle_polls = (
+            role_max_idle_polls if max_empty_polls is None else max_empty_polls
+        )
 
         self.colony = ColonyClient(colony_url, client=client, token=token)
         self.workspace_mgr = WorkspaceManager(workspace_root, repo_path, integration_branch)
@@ -315,7 +334,7 @@ class WorkerRuntime:
                     idle_polls += 1
                     logger.debug("queue empty, polling (%d/%d) worker_id=%s role=%s",
                                  idle_polls, max_idle_polls, self.worker_id, self._role)
-                    time.sleep(30)
+                    time.sleep(self.poll_interval)
                 else:
                     idle_polls = 0  # reset on successful forage
         finally:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -922,6 +922,39 @@ def test_worker_start_explicit_name_overrides():
     assert captured_kwargs["name"] == "my-worker"
 
 
+def test_worker_start_poll_flags_flow_through():
+    """--poll-interval and --max-empty-polls are passed to WorkerRuntime."""
+    runner = CliRunner()
+    captured_kwargs = {}
+
+    def fake_worker_runtime(**kwargs):
+        captured_kwargs.update(kwargs)
+        return MagicMock()
+
+    with patch("antfarm.core.worker.WorkerRuntime", side_effect=fake_worker_runtime):
+        result = runner.invoke(
+            main,
+            [
+                "worker",
+                "start",
+                "--agent",
+                "claude-code",
+                "--node",
+                "n1",
+                "--poll-interval",
+                "5",
+                "--max-empty-polls",
+                "3",
+                "--colony-url",
+                "http://localhost:7433",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured_kwargs["poll_interval"] == 5.0
+    assert captured_kwargs["max_empty_polls"] == 3
+
+
 # ---------------------------------------------------------------------------
 # plan --carry dependency resolution (#93)
 # ---------------------------------------------------------------------------

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1543,3 +1543,212 @@ def test_agent_launched_detail_reflects_agent_type(tmp_path, http_client, tc):
     launched = [e for e in _worker_events() if e["type"] == "agent_launched"]
     assert len(launched) == 1
     assert launched[0]["detail"] == "codex"
+
+
+# ---------------------------------------------------------------------------
+# Configurable empty-poll backoff (#272)
+# ---------------------------------------------------------------------------
+
+
+def _make_runtime_with_polls(
+    tmp_path, http_client, name, capabilities, *, max_empty_polls=None, poll_interval=30.0
+):
+    rt = WorkerRuntime(
+        colony_url="http://test",
+        node_id="node-1",
+        name=name,
+        agent_type="generic",
+        workspace_root=str(tmp_path / "workspaces"),
+        repo_path=str(tmp_path),
+        integration_branch="main",
+        heartbeat_interval=999.0,
+        poll_interval=poll_interval,
+        max_empty_polls=max_empty_polls,
+        capabilities=capabilities,
+        client=http_client,
+    )
+    rt.workspace_mgr.create = MagicMock(return_value=str(tmp_path / "ws"))
+    return rt
+
+
+def test_first_empty_does_not_exit(tmp_path, http_client):
+    """With max_empty_polls=2, a single empty forage sleeps and re-polls."""
+    rt = _make_runtime_with_polls(
+        tmp_path, http_client, "w-first", capabilities=[], max_empty_polls=2
+    )
+
+    call_count = [0]
+
+    def fake_forage(worker_id):
+        call_count[0] += 1
+        return None
+
+    rt.colony.forage = fake_forage
+    rt.run()
+
+    # 1 initial + 2 retries = 3 total forage calls before exit
+    assert call_count[0] == 3
+
+
+def test_exits_after_max_empty_polls(tmp_path, http_client):
+    """With max_empty_polls=2, worker exits after the threshold is reached."""
+    rt = _make_runtime_with_polls(
+        tmp_path, http_client, "w-max", capabilities=[], max_empty_polls=2
+    )
+
+    call_count = [0]
+
+    def fake_forage(worker_id):
+        call_count[0] += 1
+        return None
+
+    rt.colony.forage = fake_forage
+    rt.run()
+
+    # After 3 empties (1 initial + 2 retries) the loop exits — not 4+.
+    assert call_count[0] == 3
+
+
+def test_successful_forage_resets_empty_counter(tmp_path, http_client):
+    """A task mid-sequence resets the empty counter so polling continues after."""
+    rt = _make_runtime_with_polls(
+        tmp_path, http_client, "w-reset", capabilities=[], max_empty_polls=2
+    )
+
+    sequence = [None, {"id": "t1", "current_attempt": "a1"}, None, None, None]
+    idx = [0]
+
+    def fake_forage(worker_id):
+        value = sequence[idx[0]] if idx[0] < len(sequence) else None
+        idx[0] += 1
+        return value
+
+    rt.colony.forage = fake_forage
+
+    # Short-circuit _process_one_task for the single non-empty to avoid
+    # running the full agent pipeline.
+    original_process = rt._process_one_task
+
+    def fake_process_one_task():
+        task = rt.colony.forage(rt.worker_id)
+        if task is None:
+            return False
+        rt._last_task_id = task["id"]
+        return True
+
+    rt._process_one_task = fake_process_one_task
+
+    rt.run()
+
+    # Sequence: empty, task (resets counter), empty, empty, empty-exit.
+    # The second empty-run block counts up to 3 empties (1+2 retries) before exit.
+    # Total forage calls = len(sequence) = 5.
+    assert idx[0] == 5
+    del original_process
+
+
+def test_exit_still_deregisters(tmp_path, http_client):
+    """Even when the loop exits on empty queue, deregister_worker runs."""
+    rt = _make_runtime_with_polls(
+        tmp_path, http_client, "w-dereg", capabilities=[], max_empty_polls=1
+    )
+
+    deregistered = []
+
+    rt.colony.forage = lambda worker_id: None
+    original_dereg = rt.colony.deregister_worker
+
+    def tracking_dereg(worker_id):
+        deregistered.append(worker_id)
+        return original_dereg(worker_id)
+
+    rt.colony.deregister_worker = tracking_dereg
+    rt.run()
+
+    assert deregistered == [rt.worker_id]
+
+
+def test_poll_interval_honored(tmp_path, http_client, monkeypatch):
+    """time.sleep is called with the configured poll_interval, not 30."""
+    import threading as _threading
+
+    import antfarm.core.worker as worker_mod
+
+    rt = _make_runtime_with_polls(
+        tmp_path,
+        http_client,
+        "w-pi",
+        capabilities=[],
+        max_empty_polls=2,
+        poll_interval=7.5,
+    )
+    rt.colony.forage = lambda worker_id: None
+
+    # Only capture sleeps from the main run thread. Background heartbeat
+    # threads spawned by unrelated test fixtures can share this module's
+    # monkeypatched time.sleep and would otherwise pollute our capture.
+    sleeps: list[float] = []
+    main_tid = _threading.get_ident()
+
+    def capture(s):
+        if _threading.get_ident() == main_tid:
+            sleeps.append(s)
+
+    monkeypatch.setattr(worker_mod.time, "sleep", capture)
+    rt.run()
+
+    # 1 initial forage (empty) + 2 retries = 2 sleeps before exit,
+    # each at the configured poll_interval.
+    assert sleeps == [7.5, 7.5]
+
+
+def test_max_empty_polls_zero_exits_immediately(tmp_path, http_client):
+    """max_empty_polls=0 preserves the exit-on-first-empty opt-in."""
+    rt = _make_runtime_with_polls(
+        tmp_path, http_client, "w-zero", capabilities=[], max_empty_polls=0
+    )
+
+    call_count = [0]
+
+    def fake_forage(worker_id):
+        call_count[0] += 1
+        return None
+
+    rt.colony.forage = fake_forage
+    rt.run()
+
+    assert call_count[0] == 1
+
+
+def test_role_defaults_preserved_when_unset(tmp_path, http_client):
+    """max_empty_polls=None keeps reviewer=10, builder=5, planner=0."""
+    reviewer = _make_runtime_with_polls(
+        tmp_path, http_client, "r1", capabilities=["review"], max_empty_polls=None
+    )
+    builder = _make_runtime_with_polls(
+        tmp_path, http_client, "b1", capabilities=[], max_empty_polls=None
+    )
+    planner = _make_runtime_with_polls(
+        tmp_path, http_client, "p1", capabilities=["plan"], max_empty_polls=None
+    )
+
+    assert reviewer._max_idle_polls == 10
+    assert builder._max_idle_polls == 5
+    assert planner._max_idle_polls == 0
+
+
+def test_invalid_poll_interval_raises(tmp_path, http_client):
+    """poll_interval <= 0 raises ValueError in __init__."""
+    with pytest.raises(ValueError, match="poll_interval"):
+        WorkerRuntime(
+            colony_url="http://test",
+            node_id="node-1",
+            name="bad",
+            agent_type="generic",
+            workspace_root=str(tmp_path / "workspaces"),
+            repo_path=str(tmp_path),
+            integration_branch="main",
+            heartbeat_interval=999.0,
+            poll_interval=0,
+            client=http_client,
+        )


### PR DESCRIPTION
## Summary

- `WorkerRuntime.__init__` now accepts `poll_interval` (default 30.0) and `max_empty_polls` (default `None` — role-based behavior preserved).
- `time.sleep(self.poll_interval)` replaces the hard-coded 30s backoff in `run()`.
- `antfarm worker start` exposes `--poll-interval FLOAT` and `--max-empty-polls INT` and wires them through. `max_empty_polls=0` remains a valid opt-in for the original exit-on-first-empty semantics.

## Test plan

- [x] `ruff check .` passes
- [x] `pytest tests/ -x -q` — 1036 passed
- [x] New worker tests: first empty does not exit, threshold exit, successful forage resets counter, finally deregister runs, `poll_interval` honored via `time.sleep`, `max_empty_polls=0` exits immediately, role defaults preserved when unset, `poll_interval<=0` raises.
- [x] New CLI test: `--poll-interval 5 --max-empty-polls 3` flow through to `WorkerRuntime` kwargs.
- [x] Default behavior (no new flags) identical to v0.6.6: existing `test_builder_polls_on_empty_queue`, `test_planner_exits_immediately_on_empty_queue`, `test_reviewer_polls_unchanged` unchanged and green.

Refs #287
Closes #272