### PR TITLE
feat(workspace): branch worktrees from unmerged dep (P2)

### DIFF
--- a/antfarm/core/worker.py
+++ b/antfarm/core/worker.py
@@ -375,7 +375,10 @@ class WorkerRuntime:
                 task_id, self.worker_id, "task claimed, creating workspace"
             )
 
-        workspace = self.workspace_mgr.create(task_id, attempt_id)
+        dep_branches = self._resolve_dep_branches(task)
+        workspace = self.workspace_mgr.create(
+            task_id, attempt_id, dep_branches=dep_branches
+        )
         logger.info("workspace created path=%s", workspace)
         _emit("workspace_created", task_id, workspace)
 
@@ -618,6 +621,57 @@ class WorkerRuntime:
                     )
 
         return True
+
+    # ------------------------------------------------------------------
+    # Dependency branch resolution
+    # ------------------------------------------------------------------
+
+    def _resolve_dep_branches(self, task: dict) -> list[str]:
+        """Resolve a task's unmerged dep branches for worktree base selection.
+
+        For each task ID in ``task["depends_on"]``:
+
+        1. Look up the dep via colony.get_task.
+        2. Keep deps where ``status == "done"`` and the current-attempt's
+           ``status != "merged"`` (i.e. harvested but not yet marked merged
+           by Soldier).
+        3. Collect each kept dep's current-attempt ``branch``; skip deps
+           with no branch (safe fallback to integration).
+
+        Returns an empty list if there are no deps or none are eligible.
+        WorkspaceManager uses the list length to decide base selection.
+        """
+        dep_ids = task.get("depends_on") or []
+        if not dep_ids:
+            return []
+
+        branches: list[str] = []
+        for dep_id in dep_ids:
+            try:
+                dep = self.colony.get_task(dep_id)
+            except Exception as exc:
+                logger.warning(
+                    "dep lookup failed dep_id=%s error=%s — skipping", dep_id, exc
+                )
+                continue
+            if not dep or dep.get("status") != "done":
+                continue
+            current_attempt_id = dep.get("current_attempt")
+            if not current_attempt_id:
+                continue
+            current_attempt = None
+            for att in dep.get("attempts", []):
+                if att.get("attempt_id") == current_attempt_id:
+                    current_attempt = att
+                    break
+            if current_attempt is None:
+                continue
+            if current_attempt.get("status") == "merged":
+                continue
+            branch = current_attempt.get("branch")
+            if branch:
+                branches.append(branch)
+        return branches
 
     # ------------------------------------------------------------------
     # Artifact building & PR creation

--- a/antfarm/core/workspace.py
+++ b/antfarm/core/workspace.py
@@ -5,8 +5,11 @@ branch (default: main). This provides filesystem isolation between concurrent
 agent sessions without requiring separate repository clones.
 """
 
+import logging
 import os
 import subprocess
+
+logger = logging.getLogger(__name__)
 
 
 class WorkspaceManager:
@@ -23,15 +26,34 @@ class WorkspaceManager:
         self.repo_path = repo_path
         self.integration_branch = integration_branch
 
-    def create(self, task_id: str, attempt_id: str) -> str:
+    def create(
+        self,
+        task_id: str,
+        attempt_id: str,
+        dep_branches: list[str] | None = None,
+    ) -> str:
         """Create a git worktree for a task attempt.
 
         Fetches origin, then creates a new branch and worktree rooted at
         ``{workspace_root}/{task_id}-{attempt_id}``.
 
+        The base ref for the new worktree is selected as follows:
+
+        - ``dep_branches`` is ``None`` or empty → ``origin/<integration_branch>``
+          (current behavior, byte-identical for the zero-dep case).
+        - Exactly one entry → ``origin/<dep_branch>``. Verified via
+          ``git rev-parse --verify``; if missing, falls back to the
+          integration branch and logs a warning.
+        - More than one entry → ``origin/<integration_branch>`` and a
+          warning is logged. Multi-dep branch graphs are out of scope for
+          the v0.6.7 efficiency pass.
+
         Args:
             task_id: Identifier for the task (e.g. "task-001").
             attempt_id: Identifier for the attempt (e.g. "att-001").
+            dep_branches: Optional list of pre-resolved dep attempt branch
+                names (without the ``origin/`` prefix). The caller (Worker)
+                is responsible for filtering to unmerged deps with branches.
 
         Returns:
             Absolute path to the created worktree.
@@ -55,6 +77,8 @@ class WorkspaceManager:
         branch = f"feat/{task_id}-{attempt_id}"
         workspace_path = os.path.join(self.workspace_root, f"{task_id}-{attempt_id}")
 
+        base_ref = self._select_base_ref(dep_branches)
+
         subprocess.run(
             [
                 "git",
@@ -63,7 +87,7 @@ class WorkspaceManager:
                 "-b",
                 branch,
                 workspace_path,
-                f"origin/{self.integration_branch}",
+                base_ref,
             ],
             cwd=self.repo_path,
             check=True,
@@ -72,6 +96,43 @@ class WorkspaceManager:
         )
 
         return workspace_path
+
+    def _select_base_ref(self, dep_branches: list[str] | None) -> str:
+        """Pick the base ref for a new worktree given resolved dep branches.
+
+        Encapsulates the single-unmerged-dep optimization. Always falls
+        back to the integration branch on ambiguity or missing refs, and
+        logs a warning in those cases so operators can diagnose drift.
+        """
+        integration_ref = f"origin/{self.integration_branch}"
+
+        if not dep_branches:
+            return integration_ref
+
+        if len(dep_branches) > 1:
+            logger.warning(
+                "multi-dep branch base not supported; falling back to integration "
+                "(deps=%s)",
+                dep_branches,
+            )
+            return integration_ref
+
+        dep_branch = dep_branches[0]
+        dep_ref = f"origin/{dep_branch}"
+        verify = subprocess.run(
+            ["git", "rev-parse", "--verify", dep_ref],
+            cwd=self.repo_path,
+            capture_output=True,
+            text=True,
+        )
+        if verify.returncode != 0:
+            logger.warning(
+                "dep branch %s not found; falling back to integration",
+                dep_ref,
+            )
+            return integration_ref
+
+        return dep_ref
 
     def validate(self, workspace_path: str) -> bool:
         """Check that a worktree path exists and has a clean working tree.

--- a/tests/test_review_execution.py
+++ b/tests/test_review_execution.py
@@ -582,7 +582,7 @@ def _make_worker_with_fake_colony(fake: _FakeColony) -> WorkerRuntime:
     runtime._heartbeat_thread = None
 
     class _WS:
-        def create(self, task_id, attempt_id):
+        def create(self, task_id, attempt_id, dep_branches=None):
             return "/tmp/ws/fake"
 
     runtime.workspace_mgr = _WS()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1752,3 +1752,83 @@ def test_invalid_poll_interval_raises(tmp_path, http_client):
             poll_interval=0,
             client=http_client,
         )
+
+
+# ---------------------------------------------------------------------------
+# v0.6.7 P2: Worker resolves depends_on → dep_branches for WorkspaceManager
+# ---------------------------------------------------------------------------
+
+
+def test_worker_passes_unmerged_dep_branch_to_workspace(tc, runtime):
+    """Worker resolves a harvested-but-unmerged dep and passes its branch.
+
+    Carries dep + child, marks the dep harvested (status=done, attempt done,
+    has a branch). The child is then foraged and WorkspaceManager.create must
+    be called with dep_branches=[<dep's current-attempt branch>].
+    """
+    # Carry dep, run a normal successful agent to harvest it
+    _carry(tc, task_id="task-dep")
+    runtime._launch_agent = _good_agent
+    runtime._build_artifact = lambda task, attempt_id, workspace, branch: {}
+    runtime._create_pr = lambda task, branch, workspace: ""
+    # Forage + harvest just the dep (no child yet)
+    runtime._process_one_task()
+
+    # The dep should now be done with a branch on its current attempt
+    dep = tc.get("/tasks/task-dep").json()
+    assert dep["status"] == "done"
+    dep_branch = None
+    for att in dep["attempts"]:
+        if att["attempt_id"] == dep["current_attempt"]:
+            dep_branch = att["branch"]
+            break
+    assert dep_branch, "dep attempt should have a branch after harvest"
+
+    # Carry the child that depends on it
+    r = tc.post("/tasks", json={
+        "id": "task-child", "title": "Child", "spec": "c",
+        "depends_on": ["task-dep"],
+    })
+    assert r.status_code == 201
+
+    # Now forage the child — WorkspaceManager.create should be called with
+    # dep_branches=[dep_branch]
+    runtime.workspace_mgr.create.reset_mock()
+    runtime._process_one_task()
+
+    # create() should have been called once for the child
+    runtime.workspace_mgr.create.assert_called_once()
+    _, kwargs = runtime.workspace_mgr.create.call_args
+    assert kwargs.get("dep_branches") == [dep_branch]
+
+
+def test_worker_skips_merged_deps(tc, runtime):
+    """If the dep's current attempt is MERGED, no dep branch is passed."""
+    # Carry + harvest dep
+    _carry(tc, task_id="task-dep-merged")
+    runtime._launch_agent = _good_agent
+    runtime._build_artifact = lambda task, attempt_id, workspace, branch: {}
+    runtime._create_pr = lambda task, branch, workspace: ""
+    runtime._process_one_task()
+
+    dep = tc.get("/tasks/task-dep-merged").json()
+    attempt_id = dep["current_attempt"]
+
+    # Mark the attempt as MERGED via the colony API
+    r = tc.post("/tasks/task-dep-merged/merge", json={"attempt_id": attempt_id})
+    assert r.status_code in (200, 201, 204)
+
+    # Carry child
+    r = tc.post("/tasks", json={
+        "id": "task-child-merged", "title": "Child", "spec": "c",
+        "depends_on": ["task-dep-merged"],
+    })
+    assert r.status_code == 201
+
+    runtime.workspace_mgr.create.reset_mock()
+    runtime._process_one_task()
+
+    runtime.workspace_mgr.create.assert_called_once()
+    _, kwargs = runtime.workspace_mgr.create.call_args
+    # Merged dep must NOT be included — falls back to integration
+    assert kwargs.get("dep_branches") == []

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,7 +1,9 @@
 """Tests for antfarm.core.workspace.WorkspaceManager."""
 
+import logging
 import os
 import subprocess
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -125,3 +127,122 @@ def test_validate_nonexistent_path(git_repo):
         integration_branch="dev",
     )
     assert mgr.validate("/nonexistent/path") is False
+
+
+# ---------------------------------------------------------------------------
+# v0.6.7 P2: dep_branches base-ref selection
+#
+# These tests mock subprocess.run so that only the base-ref selection logic
+# is exercised. We assert on the `worktree add` command's final positional
+# argument, which is the base ref the new branch is created from.
+# ---------------------------------------------------------------------------
+
+
+def _mk_run_capture(worktree_calls: list[list[str]], rev_parse_ok: bool = True):
+    """Build a subprocess.run stub.
+
+    - ``git fetch origin`` — returns success.
+    - ``git rev-parse --verify <ref>`` — returns 0 if rev_parse_ok else 1.
+    - ``git worktree add ...`` — records the command and returns success.
+    """
+    def fake_run(cmd, *args, **kwargs):
+        if cmd[:2] == ["git", "fetch"]:
+            return MagicMock(returncode=0, stdout="", stderr="")
+        if cmd[:2] == ["git", "rev-parse"]:
+            return MagicMock(
+                returncode=0 if rev_parse_ok else 1, stdout="", stderr=""
+            )
+        if cmd[:3] == ["git", "worktree", "add"]:
+            worktree_calls.append(list(cmd))
+            return MagicMock(returncode=0, stdout="", stderr="")
+        return MagicMock(returncode=0, stdout="", stderr="")
+
+    return fake_run
+
+
+def test_create_no_deps_uses_integration_branch(tmp_path):
+    """dep_branches=None → base is origin/<integration_branch>."""
+    mgr = WorkspaceManager(
+        workspace_root=str(tmp_path / "ws"),
+        repo_path=str(tmp_path / "repo"),
+        integration_branch="main",
+    )
+    captured: list[list[str]] = []
+    with patch.object(subprocess, "run", side_effect=_mk_run_capture(captured)):
+        mgr.create("task-001", "att-001", dep_branches=None)
+
+    assert len(captured) == 1
+    assert captured[0][-1] == "origin/main"
+
+
+def test_create_empty_deps_uses_integration_branch(tmp_path):
+    """dep_branches=[] behaves identically to None."""
+    mgr = WorkspaceManager(
+        workspace_root=str(tmp_path / "ws"),
+        repo_path=str(tmp_path / "repo"),
+        integration_branch="main",
+    )
+    captured: list[list[str]] = []
+    with patch.object(subprocess, "run", side_effect=_mk_run_capture(captured)):
+        mgr.create("task-001", "att-001", dep_branches=[])
+
+    assert len(captured) == 1
+    assert captured[0][-1] == "origin/main"
+
+
+def test_create_one_unmerged_dep_uses_dep_branch(tmp_path):
+    """Exactly one dep branch → base is origin/<dep_branch>."""
+    mgr = WorkspaceManager(
+        workspace_root=str(tmp_path / "ws"),
+        repo_path=str(tmp_path / "repo"),
+        integration_branch="main",
+    )
+    captured: list[list[str]] = []
+    with patch.object(subprocess, "run", side_effect=_mk_run_capture(captured)):
+        mgr.create(
+            "task-002", "att-001",
+            dep_branches=["feat/task-dep-att-001"],
+        )
+
+    assert len(captured) == 1
+    assert captured[0][-1] == "origin/feat/task-dep-att-001"
+
+
+def test_create_multiple_deps_falls_back_with_warning(tmp_path, caplog):
+    """More than one dep branch → falls back to integration with a warning."""
+    mgr = WorkspaceManager(
+        workspace_root=str(tmp_path / "ws"),
+        repo_path=str(tmp_path / "repo"),
+        integration_branch="main",
+    )
+    captured: list[list[str]] = []
+    with caplog.at_level(logging.WARNING, logger="antfarm.core.workspace"), \
+         patch.object(subprocess, "run", side_effect=_mk_run_capture(captured)):
+        mgr.create("task-003", "att-001", dep_branches=["a", "b"])
+
+    assert len(captured) == 1
+    assert captured[0][-1] == "origin/main"
+    assert any("multi-dep" in r.message for r in caplog.records)
+
+
+def test_create_missing_dep_ref_falls_back_with_warning(tmp_path, caplog):
+    """rev-parse --verify failure → falls back to integration with a warning."""
+    mgr = WorkspaceManager(
+        workspace_root=str(tmp_path / "ws"),
+        repo_path=str(tmp_path / "repo"),
+        integration_branch="main",
+    )
+    captured: list[list[str]] = []
+    with caplog.at_level(logging.WARNING, logger="antfarm.core.workspace"), \
+         patch.object(
+             subprocess, "run",
+             side_effect=_mk_run_capture(captured, rev_parse_ok=False),
+         ):
+        mgr.create(
+            "task-004", "att-001",
+            dep_branches=["feat/missing-dep-att-001"],
+        )
+
+    assert len(captured) == 1
+    assert captured[0][-1] == "origin/main"
+    assert any("not found" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- When a child task's sole dependency has been harvested but not yet marked MERGED by Soldier, the child's worktree now branches from `origin/<dep_branch>` instead of `origin/<integration_branch>`. This eliminates a class of avoidable merge drift observed in the v0.6.6 dogfood run.
- Zero-dep behavior is byte-identical to today (critical regression guard). Multi-dep cases and missing refs fall back to the integration branch with a warning log. Multi-dep branch graphs are out of scope.
- `WorkspaceManager.create` gains an optional `dep_branches` parameter. The Worker resolves `depends_on` against the colony, keeps deps that are `done` with a non-merged current attempt, and passes the resulting branch list in. `WorkspaceManager` itself stays free of colony knowledge.

## Test Plan
- [x] `pytest tests/ -x -q` — 1034 passed
- [x] `ruff check .` — clean
- [x] New `tests/test_workspace.py` cases: no-deps, empty list, one-dep, multi-dep fallback+warning, missing-ref fallback+warning
- [x] New `tests/test_worker.py` cases: unmerged dep branch passed through; merged dep skipped
- [x] Existing `test_review_execution.py` `_WS.create` fake updated for the new signature

Refs #287

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>