### PR TITLE
feat(soldier): merge diagnostic events (P6)

### DIFF
--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -41,18 +41,81 @@ logger = logging.getLogger(__name__)
 WAKE_EVENT_TYPES: frozenset[str] = frozenset({"harvested", "kickback", "merged"})
 
 
+# ---------------------------------------------------------------------------
+# Merge diagnostic event vocabulary (v0.6.7)
+#
+# Soldier emits three diagnostic event types to the SSE bus so operators can
+# answer "why is this task still sitting in done/?" without reading soldier
+# logs. All are emitted with actor="soldier" via ``_emit``.
+#
+# - merge_attempted: Fires at the top of ``attempt_merge`` once per call.
+#   Detail format: ``attempt=<attempt_id> branch=<pr-branch>``. Canonical
+#   name going forward; ``merge_started`` is dual-emitted for backward
+#   compatibility during 0.6.x. (TODO: drop ``merge_started`` in 0.7.0.)
+#
+# - merge_skipped: Fires whenever Soldier evaluates a done, non-merged,
+#   non-infra task and chooses NOT to merge this tick. Detail format:
+#   ``reason=<short-code>``. Reason codes come from ``_MERGE_SKIP_REASONS``
+#   below — short, stable strings operators can grep.
+#
+# - merge_failed: Fires once per ``attempt_merge`` call that returns FAILED,
+#   BEFORE the caller invokes ``kickback_with_cascade``. Detail format:
+#   ``reason=<short-code>: <human message>`` where ``<short-code>`` is one of
+#   ``_MERGE_FAILED_REASONS``.
+#
+# Emit failures are best-effort: a broken event bus MUST NEVER break merge
+# logic. Failures below the ``_emit`` surface are swallowed and logged at
+# DEBUG.
+# ---------------------------------------------------------------------------
+
+_MERGE_SKIP_REASONS = frozenset(
+    {
+        "dep_unmerged",        # a dependency has not yet merged
+        "no_pr",               # current attempt has no branch/PR
+        "review_pending",      # review task was just created this tick
+        "review_in_progress",  # review task exists but is not done yet
+        "review_stale_sha",    # review verdict is for an older attempt SHA
+        "needs_changes",       # review verdict is not 'pass'
+        "already_merged",      # current_attempt is already MERGED
+        "superseded",          # current_attempt is None (post-kickback)
+    }
+)
+
+_MERGE_FAILED_REASONS = frozenset(
+    {
+        "merge_conflict",   # git merge reported a conflict
+        "test_failed",      # test_command returned non-zero
+        "rebase_failed",    # rebase/fast-forward failed
+        "push_failed",      # git push origin failed
+        "no_pr",            # current attempt has no branch
+        "fetch_failed",     # git fetch origin failed
+        "checkout_failed",  # could not checkout integration branch / temp
+        "unknown",          # catch-all for unclassified failures
+    }
+)
+
+
 def _emit(event_type: str, task_id: str, detail: str = "") -> None:
     """Emit an SSE event tagged with actor='soldier'.
 
     Lazy-imports ``_emit_event`` to avoid a circular import at module load
     time (serve.py imports Soldier) and to keep soldier importable in
     contexts where the FastAPI server module cannot be loaded.
+
+    Best-effort: ANY failure inside the emit pipeline is swallowed and
+    logged at DEBUG. A broken event bus MUST NEVER break merge logic.
     """
     try:
         from antfarm.core.serve import _emit_event
     except Exception:
+        logger.debug("soldier _emit: could not import _emit_event", exc_info=True)
         return
-    _emit_event(event_type, task_id, detail, actor="soldier")
+    try:
+        _emit_event(event_type, task_id, detail, actor="soldier")
+    except Exception:
+        logger.debug(
+            "soldier _emit: _emit_event(%s) raised", event_type, exc_info=True
+        )
 
 
 class MergeResult(StrEnum):
@@ -185,6 +248,10 @@ class Soldier:
 
         Like get_merge_queue() but does NOT gate on review verdict,
         since run_once_with_review() handles that itself.
+
+        Emits ``merge_skipped`` (actor=soldier) for done, non-infra tasks
+        filtered out here — see the reason-code vocabulary near the top of
+        this module.
         """
         all_tasks = self.colony.list_tasks()
 
@@ -199,12 +266,20 @@ class Soldier:
                 continue
             if is_infra_task(task):
                 continue
+            task_id = task.get("id", "")
             if self._has_merged_attempt(task):
+                _emit("merge_skipped", task_id, "reason=already_merged")
+                continue
+            # Post-kickback tasks have no current_attempt.
+            if not task.get("current_attempt"):
+                _emit("merge_skipped", task_id, "reason=superseded")
                 continue
             if not self._get_attempt_branch(task):
+                _emit("merge_skipped", task_id, "reason=no_pr")
                 continue
             deps = task.get("depends_on") or []
             if not all(dep in merged_task_ids for dep in deps):
+                _emit("merge_skipped", task_id, "reason=dep_unmerged")
                 continue
             eligible.append(task)
 
@@ -260,6 +335,8 @@ class Soldier:
                         self.kickback_with_cascade(task_id, self.last_failure_reason)
                     results.append((task_id, result))
                 else:
+                    # Diagnostic skip before kickback: needs_changes verdict.
+                    _emit("merge_skipped", task_id, "reason=needs_changes")
                     self.kickback_with_cascade(task_id, f"review failed: {reason}")
                     results.append((task_id, MergeResult.FAILED))
                 continue
@@ -273,6 +350,7 @@ class Soldier:
                     logger.info("created review task %s for %s", created_id, task_id)
                 else:
                     logger.warning("failed to create review task for %s", task_id)
+                _emit("merge_skipped", task_id, "reason=review_pending")
                 results.append((task_id, MergeResult.NEEDS_REVIEW))
                 continue
 
@@ -299,6 +377,7 @@ class Soldier:
                         "failed to re-review %s from run_once_with_review",
                         review_task_id,
                     )
+                _emit("merge_skipped", task_id, "reason=review_stale_sha")
                 results.append((task_id, MergeResult.NEEDS_REVIEW))
                 continue
 
@@ -313,6 +392,7 @@ class Soldier:
                 continue
             if review_status != "done":
                 # Still in progress (ready/active/kicked-back awaiting retry)
+                _emit("merge_skipped", task_id, "reason=review_in_progress")
                 results.append((task_id, MergeResult.NEEDS_REVIEW))
                 continue
 
@@ -342,6 +422,8 @@ class Soldier:
                     self.kickback_with_cascade(task_id, self.last_failure_reason)
                 results.append((task_id, result))
             else:
+                # Diagnostic skip before kickback: needs_changes verdict.
+                _emit("merge_skipped", task_id, "reason=needs_changes")
                 self.kickback_with_cascade(task_id, f"review failed: {reason}")
                 results.append((task_id, MergeResult.FAILED))
 
@@ -367,26 +449,37 @@ class Soldier:
                 merged_task_ids.add(t["id"])
 
         # Filter to done tasks with a branch and satisfied deps
-        # Exclude infra tasks (review tasks, etc.) — they are informational
+        # Exclude infra tasks (review tasks, etc.) — they are informational.
+        # Emit merge_skipped with a reason code at every decision point so
+        # operators can grep the SSE bus to answer "why didn't this merge?"
         eligible = []
         for task in all_tasks:
             if task.get("status") != "done":
                 continue
             if is_infra_task(task):
                 continue
+            task_id = task.get("id", "")
             # Skip already-merged tasks
             if self._has_merged_attempt(task):
+                _emit("merge_skipped", task_id, "reason=already_merged")
+                continue
+            # Post-kickback tasks have current_attempt=None.
+            if not task.get("current_attempt"):
+                _emit("merge_skipped", task_id, "reason=superseded")
                 continue
             if not self._get_attempt_branch(task):
+                _emit("merge_skipped", task_id, "reason=no_pr")
                 continue
             # Check all dependencies are merged
             deps = task.get("depends_on") or []
             if not all(dep in merged_task_ids for dep in deps):
+                _emit("merge_skipped", task_id, "reason=dep_unmerged")
                 continue
             # When review is required, gate on passing + fresh verdict
             if self.require_review:
                 passed, _reason = self.check_review_verdict(task)
                 if not passed:
+                    _emit("merge_skipped", task_id, "reason=needs_changes")
                     continue
             eligible.append(task)
 
@@ -422,12 +515,25 @@ class Soldier:
             MergeResult.MERGED on success, MergeResult.FAILED on any failure.
         """
         task_id = task.get("id", "")
+        attempt_id = task.get("current_attempt") or ""
         branch = self._get_attempt_branch(task)
         if not branch:
             self.last_failure_reason = "no branch on current attempt"
-            _emit("merge_failed", task_id, self.last_failure_reason)
+            # Fire merge_attempted so operators see soldier evaluated this
+            # task; then merge_failed with the normalized reason code.
+            _emit("merge_attempted", task_id, f"attempt={attempt_id} branch=")
+            _emit("merge_started", task_id, "")  # dual-emit for 0.6.x back-compat
+            _emit(
+                "merge_failed",
+                task_id,
+                f"reason=no_pr: {self.last_failure_reason}",
+            )
             return MergeResult.FAILED
 
+        # Canonical diagnostic event (new in 0.6.7).
+        attempt_detail = f"attempt={attempt_id} branch={branch}"
+        _emit("merge_attempted", task_id, attempt_detail)
+        # Dual-emit legacy event for 0.6.x back-compat. TODO: remove in 0.7.0.
         _emit("merge_started", task_id, branch)
 
         temp_branch = "antfarm/temp-merge"
@@ -441,7 +547,11 @@ class Soldier:
             )
             if r.returncode != 0:
                 self.last_failure_reason = f"git fetch failed: {r.stderr.decode().strip()}"
-                _emit("merge_failed", task_id, self.last_failure_reason)
+                _emit(
+                    "merge_failed",
+                    task_id,
+                    f"reason=fetch_failed: {self.last_failure_reason}",
+                )
                 return MergeResult.FAILED
 
             # Create temp branch from integration branch
@@ -461,7 +571,11 @@ class Soldier:
                 self.last_failure_reason = (
                     f"could not create temp branch: {r.stderr.decode().strip()}"
                 )
-                _emit("merge_failed", task_id, self.last_failure_reason)
+                _emit(
+                    "merge_failed",
+                    task_id,
+                    f"reason=checkout_failed: {self.last_failure_reason}",
+                )
                 return MergeResult.FAILED
 
             # Merge task branch (no-ff to preserve history)
@@ -475,7 +589,11 @@ class Soldier:
                 self.last_failure_reason = (
                     f"merge conflict merging {branch}: {r.stderr.decode().strip()}"
                 )
-                _emit("merge_failed", task_id, self.last_failure_reason)
+                _emit(
+                    "merge_failed",
+                    task_id,
+                    f"reason=merge_conflict: {self.last_failure_reason}",
+                )
                 return MergeResult.FAILED
 
             # Run tests
@@ -489,7 +607,11 @@ class Soldier:
                 self.last_failure_reason = (
                     f"tests failed: {r.stdout.decode().strip()} {r.stderr.decode().strip()}"
                 ).strip()
-                _emit("merge_failed", task_id, self.last_failure_reason)
+                _emit(
+                    "merge_failed",
+                    task_id,
+                    f"reason=test_failed: {self.last_failure_reason}",
+                )
                 return MergeResult.FAILED
 
             # Fast-forward integration branch
@@ -503,7 +625,11 @@ class Soldier:
                 self.last_failure_reason = (
                     f"could not checkout {self.integration_branch}: {r.stderr.decode().strip()}"
                 )
-                _emit("merge_failed", task_id, self.last_failure_reason)
+                _emit(
+                    "merge_failed",
+                    task_id,
+                    f"reason=checkout_failed: {self.last_failure_reason}",
+                )
                 return MergeResult.FAILED
 
             r = subprocess.run(
@@ -514,7 +640,11 @@ class Soldier:
             )
             if r.returncode != 0:
                 self.last_failure_reason = f"ff-only merge failed: {r.stderr.decode().strip()}"
-                _emit("merge_failed", task_id, self.last_failure_reason)
+                _emit(
+                    "merge_failed",
+                    task_id,
+                    f"reason=rebase_failed: {self.last_failure_reason}",
+                )
                 return MergeResult.FAILED
 
             # Push to origin
@@ -526,7 +656,11 @@ class Soldier:
             )
             if r.returncode != 0:
                 self.last_failure_reason = f"push failed: {r.stderr.decode().strip()}"
-                _emit("merge_failed", task_id, self.last_failure_reason)
+                _emit(
+                    "merge_failed",
+                    task_id,
+                    f"reason=push_failed: {self.last_failure_reason}",
+                )
                 return MergeResult.FAILED
 
             _emit("merge_succeeded", task_id, branch)

--- a/tests/test_soldier.py
+++ b/tests/test_soldier.py
@@ -1833,3 +1833,313 @@ def test_wait_for_event_passes_cursor_and_timeout_to_server(monkeypatch):
     assert method == "GET"
     assert url.endswith("/events")
     assert params == {"after": 42, "timeout": 4.0}
+
+
+# ---------------------------------------------------------------------------
+# Merge diagnostic events (#287 / P6): merge_attempted, merge_skipped,
+# merge_failed. Each test patches antfarm.core.soldier._emit to capture
+# emissions so soldier internals can be asserted against without coupling to
+# the SSE bus layout.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def captured_emits(monkeypatch):
+    """Capture all calls to antfarm.core.soldier._emit in an ordered list."""
+    from antfarm.core import soldier as soldier_mod
+
+    calls: list[tuple[str, str, str]] = []
+
+    def _fake_emit(event_type: str, task_id: str, detail: str = "") -> None:
+        calls.append((event_type, task_id, detail))
+
+    monkeypatch.setattr(soldier_mod, "_emit", _fake_emit)
+    return calls
+
+
+def _emit_types(calls: list[tuple[str, str, str]]) -> list[str]:
+    return [c[0] for c in calls]
+
+
+def test_attempt_merge_emits_merge_attempted(soldier_env, captured_emits):
+    """attempt_merge emits merge_attempted with attempt_id and branch in the detail."""
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _carry_and_harvest(cc, repo, "task-att-001", "feat/task-att-001")
+
+    # captured_emits is active via monkeypatch before run_once runs
+    soldier.run_once()
+
+    attempted = [c for c in captured_emits if c[0] == "merge_attempted"]
+    assert len(attempted) == 1
+    _, task_id, detail = attempted[0]
+    assert task_id == "task-att-001"
+    assert "branch=feat/task-att-001" in detail
+    # Attempt id should also appear in the detail string.
+    assert "attempt=" in detail and detail.split("attempt=")[1].split(" ")[0] != ""
+
+
+def test_attempt_merge_dual_emits_merge_started_for_backcompat(soldier_env, captured_emits):
+    """merge_started is still emitted alongside merge_attempted during 0.6.x."""
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _carry_and_harvest(cc, repo, "task-dual-001", "feat/task-dual-001")
+
+    soldier.run_once()
+
+    types = _emit_types(captured_emits)
+    assert "merge_attempted" in types
+    assert "merge_started" in types
+    # merge_attempted must precede merge_started (order matters for observers).
+    assert types.index("merge_attempted") < types.index("merge_started")
+
+
+def test_get_merge_queue_emits_skipped_for_unmerged_dep(soldier_env, captured_emits):
+    """A done task whose dependency is not yet merged emits merge_skipped
+    with reason=dep_unmerged."""
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    # Harvest task-a (not merged) and task-b which depends on task-a.
+    _carry_and_harvest(cc, repo, "task-dep-a", "feat/task-dep-a")
+    _carry_and_harvest(
+        cc, repo, "task-dep-b", "feat/task-dep-b", depends_on=["task-dep-a"]
+    )
+
+    # Clear emits from any prior steps, then invoke the filter path.
+    captured_emits.clear()
+    soldier.get_merge_queue()
+
+    skipped = [c for c in captured_emits if c[0] == "merge_skipped"]
+    dep_skipped = [c for c in skipped if c[1] == "task-dep-b"]
+    assert any("reason=dep_unmerged" in c[2] for c in dep_skipped), (
+        f"expected dep_unmerged skip for task-dep-b, got {skipped}"
+    )
+
+
+def test_get_merge_queue_emits_skipped_for_no_pr(soldier_env, captured_emits):
+    """A done task with no current_attempt branch emits reason=no_pr."""
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    # Harvest normally then surgically clear the branch field so the task
+    # looks like it has no PR.
+    _carry_and_harvest(cc, repo, "task-nopr", "feat/task-nopr")
+    task = cc.get_task("task-nopr")
+    attempt_id = task["current_attempt"]
+    # Overwrite branch via direct backend file mutation (FileBackend).
+    import json
+    from pathlib import Path
+
+    done_dir = Path(soldier_env["tmp_path"]) / ".antfarm" / "tasks" / "done"
+    task_path = done_dir / "task-nopr.json"
+    data = json.loads(task_path.read_text())
+    for att in data["attempts"]:
+        if att["attempt_id"] == attempt_id:
+            att["branch"] = None
+    task_path.write_text(json.dumps(data))
+
+    captured_emits.clear()
+    soldier.get_merge_queue()
+
+    skipped = [c for c in captured_emits if c[0] == "merge_skipped" and c[1] == "task-nopr"]
+    assert any("reason=no_pr" in c[2] for c in skipped), (
+        f"expected no_pr skip for task-nopr, got {skipped}"
+    )
+
+
+def test_run_once_with_review_emits_skipped_needs_changes_before_kickback(
+    soldier_env, captured_emits
+):
+    """A done task with a stored needs_changes verdict emits merge_skipped
+    with reason=needs_changes BEFORE the kickback fires."""
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _carry_and_harvest(cc, repo, "task-nc-001", "feat/task-nc-001")
+
+    # Store a needs_changes verdict directly on the task via the backend.
+    # Use the HTTP ColonyClient for parity with soldier's access.
+    task = cc.get_task("task-nc-001")
+    attempt_id = task["current_attempt"]
+
+    verdict = {
+        "provider": "claude_code",
+        "verdict": "needs_changes",
+        "summary": "placeholder",
+        "findings": [],
+        "severity": None,
+        "reviewed_commit_sha": "",
+        "reviewer_run_id": None,
+    }
+    cc.store_review_verdict("task-nc-001", attempt_id, verdict)
+
+    # Enable require_review on a fresh soldier sharing the same client.
+    review_soldier = Soldier(
+        colony_url="http://testserver",
+        repo_path=repo,
+        integration_branch="dev",
+        test_command=["true"],
+        poll_interval=0.0,
+        require_review=True,
+        client=soldier._client if hasattr(soldier, "_client") else soldier.colony._client,
+    )
+
+    captured_emits.clear()
+    review_soldier.run_once_with_review()
+
+    # Filter emissions for this task.
+    task_events = [c for c in captured_emits if c[1] == "task-nc-001"]
+    types = [c[0] for c in task_events]
+    assert "merge_skipped" in types, (
+        f"expected merge_skipped before kickback, got {types}"
+    )
+    # Ordering: merge_skipped (with needs_changes reason) must be emitted
+    # BEFORE any subsequent kickback-related event. Kickback itself is
+    # emitted by colony (actor=colony) not by soldier, so just assert that
+    # merge_skipped was recorded with the correct reason.
+    nc_skip = [c for c in task_events if c[0] == "merge_skipped"]
+    assert any("reason=needs_changes" in c[2] for c in nc_skip)
+
+
+def test_run_once_with_review_emits_skipped_review_in_progress(soldier_env, captured_emits):
+    """When a review task exists but is not done yet, soldier emits
+    merge_skipped with reason=review_in_progress."""
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _carry_and_harvest(cc, repo, "task-rip-001", "feat/task-rip-001")
+
+    # Create a review task that is still in ready status.
+    cc._client.post(
+        "/tasks",
+        json={
+            "id": "review-task-rip-001",
+            "title": "Review: task-rip-001",
+            "spec": (
+                "Review task-rip-001\n"
+                "Attempt-SHA: feat/task-rip-001\n"
+            ),
+            "depends_on": [],
+            "priority": 1,
+            "capabilities_required": ["review"],
+        },
+    ).raise_for_status()
+
+    review_soldier = Soldier(
+        colony_url="http://testserver",
+        repo_path=repo,
+        integration_branch="dev",
+        test_command=["true"],
+        poll_interval=0.0,
+        require_review=True,
+        client=soldier.colony._client,
+    )
+
+    captured_emits.clear()
+    review_soldier.run_once_with_review()
+
+    skipped = [
+        c for c in captured_emits if c[0] == "merge_skipped" and c[1] == "task-rip-001"
+    ]
+    assert any("reason=review_in_progress" in c[2] for c in skipped), (
+        f"expected review_in_progress skip, got {skipped}"
+    )
+
+
+def test_merge_failed_emitted_before_kickback_on_failure(soldier_env, captured_emits):
+    """On a failed attempt_merge, merge_failed must be emitted BEFORE the
+    caller invokes kickback_with_cascade (which itself calls colony.kickback)."""
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    # Soldier whose test_command always fails.
+    failing_soldier = Soldier(
+        colony_url="http://testserver",
+        repo_path=repo,
+        integration_branch="dev",
+        test_command=["false"],
+        poll_interval=0.0,
+        client=soldier_env["soldier"].colony._client,
+    )
+
+    _carry_and_harvest(cc, repo, "task-ord-001", "feat/task-ord-001")
+
+    # Instrument kickback_with_cascade so we know exactly when it runs.
+    kickback_order: list[int] = []
+    original = failing_soldier.kickback_with_cascade
+
+    def _tracking_kickback(*args, **kwargs):
+        kickback_order.append(len(captured_emits))
+        return original(*args, **kwargs)
+
+    failing_soldier.kickback_with_cascade = _tracking_kickback  # type: ignore[assignment]
+
+    captured_emits.clear()
+    failing_soldier.run_once()
+
+    # There must be at least one merge_failed before kickback was invoked.
+    assert kickback_order, "kickback was not invoked"
+    kb_idx = kickback_order[0]
+    pre_kb = captured_emits[:kb_idx]
+    types_pre = [c[0] for c in pre_kb]
+    assert "merge_failed" in types_pre, (
+        f"merge_failed was not emitted before kickback; pre-kickback emits: {pre_kb}"
+    )
+    # Failed detail should carry a normalized reason code.
+    failed = [c for c in pre_kb if c[0] == "merge_failed"]
+    assert any("reason=" in c[2] for c in failed)
+
+
+def test_emit_failure_does_not_break_merge(soldier_env, monkeypatch):
+    """Even if the emit pipeline raises, attempt_merge must still return
+    the correct MergeResult and not propagate the exception. Only the
+    soldier-side ``_emit`` wrapper is targeted here — colony-side
+    ``_emit_event`` is left untouched (colony emits are orthogonal)."""
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _carry_and_harvest(cc, repo, "task-emfail-001", "feat/task-emfail-001")
+
+    # Patch the soldier-side `_emit` wrapper so every soldier emission
+    # attempt hits the best-effort try/except path. If soldier is not
+    # robust to this, the merge will raise.
+    from antfarm.core import soldier as soldier_mod
+
+    # The real _emit swallows exceptions; to simulate an emit pipeline
+    # failure we instead force _emit_event to raise, but only when called
+    # by the soldier module (i.e. via the soldier._emit wrapper). The
+    # wrapper must catch it.
+    orig_emit = soldier_mod._emit
+
+    def _raising_emit(event_type, task_id, detail=""):
+        # Exercise the soldier _emit import + swallow pathway, then force
+        # a failure inside it by making serve._emit_event raise for this
+        # one call.
+        from antfarm.core import serve as serve_mod
+
+        real = serve_mod._emit_event
+
+        def _boom(*a, **kw):
+            raise RuntimeError("synthetic emit failure")
+
+        serve_mod._emit_event = _boom
+        try:
+            orig_emit(event_type, task_id, detail)
+        finally:
+            serve_mod._emit_event = real
+
+    monkeypatch.setattr(soldier_mod, "_emit", _raising_emit)
+
+    # Must not raise, must still merge cleanly.
+    results = soldier.run_once()
+    assert results == [("task-emfail-001", MergeResult.MERGED)]


### PR DESCRIPTION
## Summary

Soldier now emits three named diagnostic events so operators can answer "why is this task still sitting in `done/`?" without reading soldier logs or shelling into the worker box.

- `merge_attempted` — fires at the top of `attempt_merge` once per call. Detail: `attempt=<attempt_id> branch=<pr-branch>`. This is the canonical name going forward.
- `merge_skipped` — fires whenever soldier evaluates a done, non-merged, non-infra task and chooses NOT to merge this tick. Detail: `reason=<short-code>`.
- `merge_failed` — already existed; details are now normalized to `reason=<code>: <human message>` so consumers can grep the reason code. Still always fires before the caller invokes `kickback_with_cascade`.

All three are emitted with `actor="soldier"` via the existing `_emit` helper. `merge_started` is dual-emitted alongside `merge_attempted` for 0.6.x back-compat; TODO removes it in 0.7.0. `harvested` / `kickback` / `merged` / `merge_succeeded` emissions are unchanged.

## Naming reconciliation

- `merge_attempted` (new, canonical) is emitted at the same site today's `merge_started` fires.
- `merge_started` is kept as a dual-emit for 0.6.x back-compat, marked with a TODO to drop in 0.7.0.
- `merge_succeeded` is left untouched — orthogonal to this mission's three.
- `merge_failed` continues to fire exactly once per failed `attempt_merge`, BEFORE the kickback event. Details are normalized but the event name is unchanged.

## Reason-code vocabulary

Short, stable strings documented in a module-level `frozenset` near the top of `antfarm/core/soldier.py`.

`merge_skipped` reason codes:

| Site | Reason |
|------|--------|
| `get_merge_queue` / `_get_done_candidates`: current attempt already MERGED | `already_merged` |
| `get_merge_queue` / `_get_done_candidates`: current_attempt is None (post-kickback) | `superseded` |
| `get_merge_queue` / `_get_done_candidates`: current attempt has no branch | `no_pr` |
| `get_merge_queue` / `_get_done_candidates`: dependency not yet merged | `dep_unmerged` |
| `get_merge_queue`: review required and verdict not passing | `needs_changes` |
| `run_once_with_review`: review task was just created this tick | `review_pending` |
| `run_once_with_review`: review task exists but is not done | `review_in_progress` |
| `run_once_with_review`: review SHA is stale, re-readied | `review_stale_sha` |
| `run_once_with_review`: stored verdict is `needs_changes` before kickback fires | `needs_changes` |

`merge_failed` reason codes: `merge_conflict`, `test_failed`, `rebase_failed`, `push_failed`, `no_pr`, `fetch_failed`, `checkout_failed`, `unknown`.

## Robustness

`_emit` already swallowed `ImportError` for the lazy `serve._emit_event` import. This PR additionally wraps the actual `_emit_event` call in try/except so any downstream failure (bus full, serialization error, etc.) is logged at DEBUG and never propagates. Covered by a new test that forces `_emit_event` to raise and verifies `run_once()` still returns `MERGED`.

## Test plan

- [x] `ruff check .` passes
- [x] `pytest tests/ -x -q` passes (1035 tests)
- [x] New tests in `tests/test_soldier.py`:
  - `test_attempt_merge_emits_merge_attempted`
  - `test_attempt_merge_dual_emits_merge_started_for_backcompat`
  - `test_get_merge_queue_emits_skipped_for_unmerged_dep`
  - `test_get_merge_queue_emits_skipped_for_no_pr`
  - `test_run_once_with_review_emits_skipped_needs_changes_before_kickback`
  - `test_run_once_with_review_emits_skipped_review_in_progress`
  - `test_merge_failed_emitted_before_kickback_on_failure`
  - `test_emit_failure_does_not_break_merge`

Refs #287