### PR TITLE
fix(missions): cancel mission purges live tasks to done/ with cancellation metadata

### DIFF
--- a/antfarm/core/autoscaler.py
+++ b/antfarm/core/autoscaler.py
@@ -82,6 +82,7 @@ def compute_desired(
         for t in tasks
         if t["status"] == "done"
         and not t["id"].startswith("review-")
+        and not t.get("cancelled_at")
         and not has_verdict(t)
         and not has_merged_attempt(t)
     ]

--- a/antfarm/core/backends/base.py
+++ b/antfarm/core/backends/base.py
@@ -477,3 +477,23 @@ class TaskBackend(ABC):
     def update_mission(self, mission_id: str, updates: dict) -> None:
         """Shallow-merge ``updates`` into the mission JSON. Atomic write."""
         ...
+
+    @abstractmethod
+    def cancel_mission_tasks(self, mission_id: str, reason: str) -> list[str]:
+        """Atomically cancel a mission and purge all non-terminal tasks to done/.
+
+        Sets mission status to "cancelled" and, for every task whose
+        ``mission_id`` matches and whose status is in {ready, blocked, active,
+        paused}: supersedes ``current_attempt`` (if any), stamps
+        ``cancelled_at`` and ``cancelled_reason`` on the task dict, appends a
+        trail entry with ``action_type="cancel"``, sets ``status="done"``, and
+        renames the file into ``done/``.
+
+        Args:
+            mission_id: ID of the mission to cancel.
+            reason: Human-readable reason recorded on each cancelled task.
+
+        Returns:
+            List of task IDs that were moved to done/.
+        """
+        ...

--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -1044,3 +1044,122 @@ class FileBackend(TaskBackend):
             data.update(updates)
             data["updated_at"] = _now_iso()
             self._write_json(path, data)
+
+    def cancel_mission_tasks(self, mission_id: str, reason: str) -> list[str]:
+        """Purge all non-terminal tasks for this mission into done/ and cancel the mission.
+
+        Non-terminal tasks (ready, blocked, active, paused) are moved to done/
+        with cancellation metadata and their current attempt superseded.
+
+        Already-done-but-unmerged tasks are stamped with cancelled_at/cancelled_reason
+        in-place so the Soldier and TUI can filter them out of the merge queue.
+
+        Operates under self._lock. PR closes happen after the lock is released
+        to avoid blocking other workers during subprocess execution.
+
+        Returns:
+            List of task IDs moved to done/ (non-terminal tasks only).
+        """
+        _NON_TERMINAL_STATUSES = {"ready", "blocked", "active", "paused"}
+        # Map from logical status to source path helper
+        _source_path_map = {
+            "ready": self._ready_path,
+            "blocked": self._blocked_path,
+            "active": self._active_path,
+            "paused": self._paused_path,
+        }
+        superseded_attempts: list[tuple[dict, str]] = []
+        moved_task_ids: list[str] = []
+
+        with self._lock:
+            now = _now_iso()
+            all_tasks = self.list_tasks()
+            for task in all_tasks:
+                if task.get("mission_id") != mission_id:
+                    continue
+                status = task.get("status", "")
+                task_id = task["id"]
+
+                if status in _NON_TERMINAL_STATUSES:
+                    source_path_fn = _source_path_map[status]
+                    source_path = source_path_fn(task_id)
+                    if not source_path.exists():
+                        continue
+
+                    data = self._read_json(source_path)
+
+                    # Supersede current attempt (operator override — skip transition assertion)
+                    current_attempt_id = data.get("current_attempt")
+                    if current_attempt_id:
+                        for a in data["attempts"]:
+                            if a["attempt_id"] == current_attempt_id:
+                                a["status"] = AttemptStatus.SUPERSEDED.value
+                                a["completed_at"] = now
+                                superseded_attempts.append((dict(a), task_id))
+                                break
+                        data["current_attempt"] = None
+
+                    # Stamp cancellation metadata
+                    data["cancelled_at"] = now
+                    data["cancelled_reason"] = reason
+
+                    # Append cancel trail entry
+                    trail_entry = TrailEntry(
+                        ts=now,
+                        worker_id="system",
+                        message=f"mission cancelled: {reason}",
+                        action_type="cancel",
+                    )
+                    data.setdefault("trail", [])
+                    data["trail"].append(trail_entry.to_dict())
+
+                    # Transition to done (operator override — no lifecycle assertion)
+                    data["status"] = TaskStatus.DONE.value
+                    data["updated_at"] = now
+
+                    self._write_json(source_path, data)
+                    os.rename(source_path, self._done_path(task_id))
+                    moved_task_ids.append(task_id)
+
+                elif status == "done" and not task.get("cancelled_at"):
+                    # Already-done tasks: stamp cancellation so Soldier and TUI can filter.
+                    # Skip tasks that are already merged — they're truly terminal.
+                    if self._has_merged_attempt(task):
+                        continue
+                    done_path = self._done_path(task_id)
+                    if not done_path.exists():
+                        continue
+                    data = self._read_json(done_path)
+                    data["cancelled_at"] = now
+                    data["cancelled_reason"] = reason
+                    data["updated_at"] = now
+                    trail_entry = TrailEntry(
+                        ts=now,
+                        worker_id="system",
+                        message=f"mission cancelled: {reason}",
+                        action_type="cancel",
+                    )
+                    data.setdefault("trail", [])
+                    data["trail"].append(trail_entry.to_dict())
+                    self._write_json(done_path, data)
+
+            # Cancel the mission itself
+            mission_path = self._mission_path(mission_id)
+            if mission_path.exists():
+                mission_data = self._read_json(mission_path)
+                mission_data["status"] = "cancelled"
+                mission_data["completed_at"] = now
+                mission_data["updated_at"] = now
+                self._write_json(mission_path, mission_data)
+
+        # Close superseded PRs OUTSIDE the lock to avoid stalling other workers.
+        for attempt, _task_id in superseded_attempts:
+            self._close_superseded_pr(attempt, f"mission {mission_id} cancelled")
+
+        return moved_task_ids
+
+    def _has_merged_attempt(self, task: dict) -> bool:
+        """Return True if any attempt on the task has status=merged."""
+        return any(
+            a.get("status") == AttemptStatus.MERGED.value for a in task.get("attempts", [])
+        )

--- a/antfarm/core/backends/github.py
+++ b/antfarm/core/backends/github.py
@@ -990,3 +990,6 @@ class GitHubBackend(TaskBackend):
 
     def update_mission(self, mission_id: str, updates: dict) -> None:
         raise NotImplementedError(_GITHUB_BACKEND_MSG)
+
+    def cancel_mission_tasks(self, mission_id: str, reason: str) -> list[str]:
+        raise NotImplementedError(_GITHUB_BACKEND_MSG)

--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -1423,8 +1423,9 @@ def mission_report(mission_id: str, fmt: str, colony_url: str, token: str | None
 @TOKEN_OPTION
 def mission_cancel(mission_id: str, colony_url: str, token: str | None):
     """Cancel a mission."""
-    _post(colony_url, f"/missions/{mission_id}/cancel", {}, token=token)
-    click.echo(f"Mission cancelled: {mission_id}")
+    result = _post(colony_url, f"/missions/{mission_id}/cancel", {}, token=token)
+    cancelled_tasks = result.get("cancelled_tasks", []) if result else []
+    click.echo(f"Mission cancelled: {mission_id} ({len(cancelled_tasks)} task(s) moved to done)")
 
 
 @mission.command("list")

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -935,15 +935,15 @@ def get_app(
 
     @app.post("/missions/{mission_id}/cancel", status_code=200)
     def cancel_mission(mission_id: str):
-        """Cancel a mission. Idempotent for terminal states."""
+        """Cancel a mission and purge all non-terminal tasks to done/. Idempotent."""
         mission = _backend.get_mission(mission_id)
         if mission is None:
             raise HTTPException(status_code=404, detail=f"Mission '{mission_id}' not found")
         terminal = {"complete", "failed", "cancelled"}
         if mission["status"] in terminal:
-            return {"ok": True}
-        _backend.update_mission(mission_id, {"status": "cancelled"})
-        return {"ok": True}
+            return {"ok": True, "cancelled_tasks": []}
+        ids = _backend.cancel_mission_tasks(mission_id, reason="mission cancelled")
+        return {"ok": True, "cancelled_tasks": ids}
 
     @app.get("/missions/{mission_id}/context")
     def get_mission_context_endpoint(mission_id: str):

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -517,6 +517,10 @@ class Soldier:
             if is_infra_task(task):
                 continue
             task_id = task.get("id", "")
+            # Skip cancelled tasks — they were purged by cancel_mission_tasks
+            if task.get("cancelled_at"):
+                _emit("merge_skipped", task_id, "reason=cancelled")
+                continue
             # Skip already-merged tasks
             if self._has_merged_attempt(task):
                 _emit("merge_skipped", task_id, "reason=already_merged")

--- a/antfarm/core/tui.py
+++ b/antfarm/core/tui.py
@@ -326,6 +326,9 @@ class AntfarmTUI:
                     snap.waiting_new.append(task)
 
             elif status == "done":
+                if task.get("cancelled_at"):
+                    snap.review_tasks[task_id] = task
+                    continue
                 if self._has_merged_attempt(task):
                     if not is_infra_task(task):  # only show impl tasks in merged
                         snap.recently_merged.append(task)

--- a/tests/test_e2e_mission.py
+++ b/tests/test_e2e_mission.py
@@ -401,10 +401,11 @@ def test_e2e_mission_cancel_stops_spawning(mission_env):
     mission = client.get(f"/missions/{mission_id}").json()
     assert mission["status"] == "cancelled"
 
-    # Child tasks still exist but are not processed further by Queen
+    # Child tasks are moved to done/ with cancellation metadata
     for cid in child_ids:
         task = client.get(f"/tasks/{cid}").json()
-        assert task["status"] == "ready"  # never foraged
+        assert task["status"] == "done"  # purged to done/ by cancel
+        assert task.get("cancelled_at") is not None
 
 
 def test_e2e_mission_blocked_task(mission_env):

--- a/tests/test_mission_serve.py
+++ b/tests/test_mission_serve.py
@@ -128,7 +128,9 @@ def test_cancel_mission_terminal_state(client):
     _create_mission(client)
     r = client.post("/missions/mission-001/cancel")
     assert r.status_code == 200
-    assert r.json() == {"ok": True}
+    data = r.json()
+    assert data["ok"] is True
+    assert "cancelled_tasks" in data
 
     mission = client.get("/missions/mission-001").json()
     assert mission["status"] == "cancelled"
@@ -142,7 +144,7 @@ def test_cancel_mission_idempotent(client):
 
     r2 = client.post("/missions/mission-001/cancel")
     assert r2.status_code == 200
-    assert r2.json() == {"ok": True}
+    assert r2.json() == {"ok": True, "cancelled_tasks": []}
 
 
 def test_carry_with_mission_id_appends_to_task_ids(client):
@@ -196,6 +198,188 @@ def test_get_mission_report_returns_report(client):
     data = r.json()
     assert data["mission_id"] == "mission-001"
     assert data["total_tasks"] == 5
+
+
+# ---------------------------------------------------------------------------
+# GitHubBackend preflight
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# cancel_mission purge tests (#265)
+# ---------------------------------------------------------------------------
+
+
+def _forage(client, worker_id: str = "worker-1"):
+    """Pull the next available task for a worker."""
+    return client.post("/tasks/pull", json={"worker_id": worker_id})
+
+
+def _register_worker(client, worker_id: str = "worker-1"):
+    client.post(
+        "/workers/register",
+        json={
+            "worker_id": worker_id,
+            "node_id": "node-1",
+            "agent_type": "generic",
+            "workspace_root": "/tmp/ws",
+            "registered_at": "2024-01-01T00:00:00+00:00",
+            "last_heartbeat": "2024-01-01T00:00:00+00:00",
+        },
+    )
+
+
+def test_cancel_mission_moves_ready_tasks_to_done(client, tmp_path):
+    """Cancelling a mission moves all ready tasks to done/ with cancellation metadata."""
+    _create_mission(client)
+    _carry(client, task_id="task-001", mission_id="mission-001")
+    _carry(client, task_id="task-002", mission_id="mission-001")
+
+    r = client.post("/missions/mission-001/cancel")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["ok"] is True
+    assert sorted(data["cancelled_tasks"]) == ["task-001", "task-002"]
+
+    for tid in ("task-001", "task-002"):
+        task = client.get(f"/tasks/{tid}").json()
+        assert task["status"] == "done", f"{tid} should be done"
+        assert task["cancelled_at"] is not None, f"{tid} missing cancelled_at"
+        assert task["cancelled_reason"] == "mission cancelled"
+        assert task["current_attempt"] is None
+        # Confirm trail entry with action_type=cancel
+        cancel_entries = [e for e in task.get("trail", []) if e.get("action_type") == "cancel"]
+        assert cancel_entries, f"{tid} has no cancel trail entry"
+
+
+def test_cancel_mission_moves_blocked_tasks_to_done(client):
+    """Cancelling a mission also moves blocked tasks to done/."""
+    _create_mission(client)
+    _carry(client, task_id="task-blocked", mission_id="mission-001")
+    # Block the task
+    client.post("/tasks/task-blocked/block", json={"reason": "external dep"})
+
+    r = client.post("/missions/mission-001/cancel")
+    assert r.status_code == 200
+    assert "task-blocked" in r.json()["cancelled_tasks"]
+
+    task = client.get("/tasks/task-blocked").json()
+    assert task["status"] == "done"
+    assert task["cancelled_at"] is not None
+
+
+def test_cancel_mission_supersedes_active_attempt(client):
+    """Cancelling a mission supersedes any active attempt on each task."""
+    _create_mission(client)
+    _carry(client, task_id="task-active", mission_id="mission-001")
+    _register_worker(client)
+    forage_r = _forage(client)
+    assert forage_r.status_code == 200
+    attempt_id = forage_r.json()["current_attempt"]
+    assert attempt_id is not None
+
+    r = client.post("/missions/mission-001/cancel")
+    assert r.status_code == 200
+    assert "task-active" in r.json()["cancelled_tasks"]
+
+    task = client.get("/tasks/task-active").json()
+    assert task["status"] == "done"
+    assert task["current_attempt"] is None
+    assert task["cancelled_at"] is not None
+
+    # The attempt should be SUPERSEDED
+    superseded = [a for a in task["attempts"] if a["attempt_id"] == attempt_id]
+    assert superseded, "original attempt not found"
+    assert superseded[0]["status"] == "superseded"
+    assert superseded[0]["completed_at"] is not None
+
+
+def test_cancel_mission_leaves_unrelated_mission_tasks_alone(client):
+    """Cancelling mission-A does not affect tasks belonging to mission-B."""
+    _create_mission(client, mission_id="mission-A")
+    _create_mission(client, mission_id="mission-B")
+    _carry(client, task_id="task-a", mission_id="mission-A")
+    _carry(client, task_id="task-b", mission_id="mission-B")
+
+    r = client.post("/missions/mission-A/cancel")
+    assert r.status_code == 200
+    assert "task-a" in r.json()["cancelled_tasks"]
+    assert "task-b" not in r.json()["cancelled_tasks"]
+
+    # mission-B task untouched
+    task_b = client.get("/tasks/task-b").json()
+    assert task_b["status"] == "ready"
+    assert task_b.get("cancelled_at") is None
+
+
+def test_cancel_mission_excludes_cancelled_task_from_merge_queue(tmp_path):
+    """After cancel, Soldier.get_merge_queue() returns empty list for cancelled tasks."""
+    from fastapi.testclient import TestClient
+
+    from antfarm.core.backends.file import FileBackend
+    from antfarm.core.colony_client import ColonyClient
+    from antfarm.core.serve import get_app
+    from antfarm.core.soldier import Soldier
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend)
+    http_client = TestClient(app, raise_server_exceptions=True)
+    colony_client = ColonyClient("http://testserver", client=http_client)
+
+    # Create mission + task
+    http_client.post("/missions", json={"mission_id": "mission-001", "spec": "test"})
+    http_client.post(
+        "/tasks",
+        json={"id": "task-001", "title": "t", "spec": "s", "mission_id": "mission-001"},
+    ).raise_for_status()
+
+    # Manually move task to done/ with a branch so it looks merge-eligible
+    colony_client.register_worker("w1", "node-1", "generic", "/tmp/ws")
+    task = colony_client.forage("w1")
+    assert task is not None
+    colony_client.harvest("task-001", task["current_attempt"], "http://pr/1", "feat/task-001")
+
+    # Confirm it looks merge-eligible before cancel
+    soldier = Soldier(
+        colony_url="http://testserver",
+        repo_path=str(tmp_path),
+        client=http_client,
+    )
+    queue_before = soldier.get_merge_queue()
+    assert any(t["id"] == "task-001" for t in queue_before)
+
+    # Cancel mission
+    http_client.post("/missions/mission-001/cancel")
+
+    # Now the task should be excluded from the merge queue
+    queue_after = soldier.get_merge_queue()
+    assert not any(t["id"] == "task-001" for t in queue_after)
+
+
+def test_cancel_mission_idempotent_on_already_cancelled(client):
+    """Second cancel call on an already-cancelled mission returns ok with empty list."""
+    _create_mission(client)
+    _carry(client, task_id="task-001", mission_id="mission-001")
+
+    r1 = client.post("/missions/mission-001/cancel")
+    assert r1.status_code == 200
+
+    r2 = client.post("/missions/mission-001/cancel")
+    assert r2.status_code == 200
+    assert r2.json() == {"ok": True, "cancelled_tasks": []}
+
+
+def test_cancel_mission_returns_payload_with_cancelled_task_count(client):
+    """Cancelling returns ok=True and the list of cancelled task IDs."""
+    _create_mission(client)
+    _carry(client, task_id="task-001", mission_id="mission-001")
+    _carry(client, task_id="task-002", mission_id="mission-001")
+
+    r = client.post("/missions/mission-001/cancel")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["ok"] is True
+    assert len(data["cancelled_tasks"]) == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `POST /missions/{id}/cancel` now moves every non-terminal task (ready, blocked, active, paused) belonging to the mission into `done/`, superseding any active attempt and stamping `cancelled_at`/`cancelled_reason` on the task dict.
- Already-done-but-unmerged tasks are also stamped with `cancelled_at` so the Soldier merge queue and TUI skip them automatically.
- `Soldier.get_merge_queue()` explicitly skips tasks with `cancelled_at` (emits `merge_skipped reason=cancelled`).
- TUI `_classify_tasks` early-guards on `cancelled_at` so cancelled tasks don't surface in `merge_ready` or `awaiting_review`.
- CLI `mission cancel` now prints the count of tasks moved to `done/`.
- `GitHubBackend` gets a matching `NotImplementedError` stub for `cancel_mission_tasks`.

Closes #265.

## Test plan

- [x] `test_cancel_mission_moves_ready_tasks_to_done` — two ready tasks → `done/` with `cancelled_at`, `cancelled_reason`, cancel trail entry, `current_attempt=None`
- [x] `test_cancel_mission_moves_blocked_tasks_to_done` — blocked task → `done/`
- [x] `test_cancel_mission_supersedes_active_attempt` — active task → attempt `superseded` + task `done/`
- [x] `test_cancel_mission_leaves_unrelated_mission_tasks_alone` — mission-B tasks unaffected
- [x] `test_cancel_mission_excludes_cancelled_task_from_merge_queue` — `Soldier.get_merge_queue()` returns `[]` for cancelled task
- [x] `test_cancel_mission_idempotent_on_already_cancelled` — second cancel returns `{"ok": True, "cancelled_tasks": []}`
- [x] `test_cancel_mission_returns_payload_with_cancelled_task_count` — response includes `cancelled_tasks` list
- [x] Updated `test_e2e_mission_cancel_stops_spawning` — child tasks now correctly asserted as `done/` with `cancelled_at`
- [x] `ruff check .` — clean
- [x] `pytest tests/ -x -q` — 1078 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)