### PR TITLE
fix(doctor): warn when ready review tasks have no reviewer capacity

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -588,6 +588,9 @@ _WATCHED_FIELDS = (
 
 def _render_scout(status: dict, prev: dict | None) -> None:
     """Render a status table, highlighting changes vs prev snapshot."""
+    # Pop warnings before the table loop so they don't render as rows.
+    warnings = status.pop("warnings", [])
+
     click.echo(f"{'Field':<25} {'Value'}")
     click.echo("-" * 40)
     for key, value in status.items():
@@ -600,6 +603,13 @@ def _render_scout(status: dict, prev: dict | None) -> None:
                 elif value < prev_val:
                     value_str = click.style(value_str, fg="red")
         click.echo(f"{key:<25} {value_str}")
+
+    if warnings:
+        click.echo("")
+        for w in warnings:
+            msg = w.get("message", "")
+            hint = w.get("hint", "")
+            click.secho(f"\u26a0  {msg} \u2014 {hint}", fg="red")
 
 
 def _format_event(event: dict) -> str:

--- a/antfarm/core/doctor.py
+++ b/antfarm/core/doctor.py
@@ -76,6 +76,7 @@ def run_doctor(
     findings.extend(check_stale_workers(backend, config, fix))
     findings.extend(check_stuck_workers(backend, config, fix))
     findings.extend(check_stale_tasks(backend, config, fix))
+    findings.extend(check_no_reviewer_capacity(backend, config))
     findings.extend(check_stale_guards(backend, config, fix))
     findings.extend(check_workspace_conflicts(backend))
     findings.extend(check_orphan_workspaces(config, fix))
@@ -541,6 +542,49 @@ def _recover_stale_task(
     tmp_path.write_text(json.dumps(data, indent=2))
     tmp_path.replace(ready_path)
     task_file.unlink()
+
+
+# ---------------------------------------------------------------------------
+# Check 5b: No reviewer capacity
+# ---------------------------------------------------------------------------
+
+
+def check_no_reviewer_capacity(backend, config: dict) -> list[Finding]:  # noqa: ARG001
+    """Warn when ready review tasks exist but no registered worker has the review capability.
+
+    This detects the common operator error where doctor requeued a review task
+    but no reviewer worker is running (e.g. autoscaler off, no standalone
+    reviewer started). The task silently sits in ready forever without this check.
+
+    No auto-fix: Antfarm never spawns workers on the operator's behalf.
+
+    Args:
+        backend: TaskBackend instance.
+        config: Doctor config dict (unused; kept for consistent signature).
+
+    Returns:
+        List of findings (at most one).
+    """
+    from antfarm.core.warnings import detect_no_reviewer_capacity
+
+    try:
+        tasks = backend.list_tasks()
+        workers = backend.list_workers() if hasattr(backend, "list_workers") else []
+    except Exception:
+        return []
+
+    warning = detect_no_reviewer_capacity(tasks, workers)
+    if warning is None:
+        return []
+
+    return [
+        Finding(
+            severity="warning",
+            check="no_reviewer_capacity",
+            message=warning["message"],
+            auto_fixable=False,
+        )
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -1040,6 +1040,26 @@ def get_app(
     # Status
     # ------------------------------------------------------------------
 
+    def _compute_status_warnings(backend: TaskBackend) -> list[dict]:
+        """Collect all colony-level warnings for the /status response.
+
+        Each warning dict has keys: code, message, hint, count.
+        Pure read — never mutates state.
+        """
+        from antfarm.core.warnings import detect_no_reviewer_capacity
+
+        try:
+            tasks = backend.list_tasks()
+            workers = backend.list_workers() if hasattr(backend, "list_workers") else []
+        except Exception:
+            return []
+
+        warnings: list[dict] = []
+        w = detect_no_reviewer_capacity(tasks, workers)
+        if w is not None:
+            warnings.append(w)
+        return warnings
+
     @app.get("/status", status_code=200)
     def colony_status():
         """Return colony status summary."""
@@ -1048,6 +1068,7 @@ def get_app(
         result["doctor"] = _doctor_status
         result["queen"] = _queen_status
         result["autoscaler"] = _autoscaler_status
+        result["warnings"] = _compute_status_warnings(_backend)
         return result
 
     @app.get("/status/full", status_code=200)
@@ -1067,6 +1088,7 @@ def get_app(
             "doctor": _doctor_status,
             "queen": _queen_status,
             "autoscaler": _autoscaler_status,
+            "warnings": _compute_status_warnings(_backend),
         }
 
     # ------------------------------------------------------------------

--- a/antfarm/core/tui.py
+++ b/antfarm/core/tui.py
@@ -39,6 +39,7 @@ class PipelineSnapshot:
     merge_ready: list[dict] = field(default_factory=list)
     recently_merged: list[dict] = field(default_factory=list)
     review_tasks: dict = field(default_factory=dict)
+    warnings: list[dict] = field(default_factory=list)
 
 
 class AntfarmTUI:
@@ -155,10 +156,12 @@ class AntfarmTUI:
             missions = []
 
         snap = self._classify_tasks(tasks)
+        snap.warnings = full.get("warnings", [])
 
         layout = Layout()
         missions_size = max(5, min(len(missions) + 4, 10)) if missions else 5
-        layout.split_column(
+        warnings_size = len(snap.warnings) + 2 if snap.warnings else 0
+        column_slices = [
             Layout(name="header", size=10),
             Layout(name="missions", size=missions_size),
             Layout(name="workers", size=max(5, len(workers) + 5)),
@@ -169,7 +172,16 @@ class AntfarmTUI:
             Layout(name="merge_ready", size=6),
             Layout(name="merged", size=6),
             Layout(name="activity", size=8),
-        )
+        ]
+        if snap.warnings:
+            column_slices.insert(0, Layout(name="warnings", size=warnings_size))
+        layout.split_column(*column_slices)
+
+        # Warnings panel — only present when there are warnings
+        if snap.warnings:
+            layout["warnings"].update(
+                self._render_warnings(snap.warnings)
+            )
 
         # Header: banner (left) + colony summary (right) side by side
         layout["header"].split_row(
@@ -895,6 +907,19 @@ class AntfarmTUI:
         self._add_overflow_hint(table, len(tasks), max_shown)
 
         return table
+
+    def _render_warnings(self, warnings: list[dict]) -> Panel:
+        """Render a red panel listing all colony-level warnings with hints."""
+        text = Text()
+        for i, w in enumerate(warnings):
+            message = w.get("message", "")
+            hint = w.get("hint", "")
+            text.append(message, style="bold red")
+            if hint:
+                text.append(f"\n  \u2192 {hint}", style="red")
+            if i < len(warnings) - 1:
+                text.append("\n")
+        return Panel(text, title="[bold red]\u26a0 Warnings[/bold red]", border_style="red")
 
     def _get_worker_type(self, worker: dict) -> str:
         """Determine worker type (builder/reviewer) from agent_type or touches."""

--- a/antfarm/core/warnings.py
+++ b/antfarm/core/warnings.py
@@ -1,0 +1,41 @@
+"""Colony-level warning detection for Antfarm.
+
+Pure-function module. No side effects, no I/O. Receives pre-fetched lists of
+tasks and workers and returns structured warning dicts suitable for the
+/status response and operator-facing UIs.
+"""
+
+from __future__ import annotations
+
+
+def detect_no_reviewer_capacity(tasks: list[dict], workers: list[dict]) -> dict | None:
+    """Return a warning dict if ready review tasks exist but no worker has the review capability.
+
+    Args:
+        tasks: List of task dicts (as returned by backend.list_tasks()).
+        workers: List of worker dicts (as returned by backend.list_workers()).
+
+    Returns:
+        Dict with keys ``code``, ``message``, ``hint``, ``count`` if the
+        condition is detected, or ``None`` when capacity is fine.
+    """
+    ready_review_count = sum(
+        1
+        for t in tasks
+        if t.get("status") == "ready" and "review" in t.get("capabilities_required", [])
+    )
+    if ready_review_count == 0:
+        return None
+
+    reviewer_count = sum(1 for w in workers if "review" in w.get("capabilities", []))
+    if reviewer_count > 0:
+        return None
+
+    return {
+        "code": "no_reviewer_capacity",
+        "message": (
+            f"{ready_review_count} review task(s) ready but no worker has 'review' capability"
+        ),
+        "hint": "Start one: antfarm worker start --agent reviewer",
+        "count": ready_review_count,
+    }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1057,3 +1057,63 @@ def test_plan_carry_resolves_index_deps():
     # Task B's depends_on should reference Task A's actual ID
     task_a_id = carried_payloads[0]["id"]
     assert carried_payloads[1]["depends_on"] == [task_a_id]
+
+
+# ---------------------------------------------------------------------------
+# _render_scout warnings
+# ---------------------------------------------------------------------------
+
+
+def test_render_scout_prints_warnings():
+    """_render_scout emits warning lines in red when warnings are present in the status dict."""
+    from antfarm.core.cli import _render_scout
+
+    status = {
+        "tasks": {"ready": 1, "active": 0, "done": 0},
+        "workers": 0,
+        "nodes": 0,
+        "soldier": "not started",
+        "warnings": [
+            {
+                "code": "no_reviewer_capacity",
+                "message": "1 review task(s) ready but no worker has 'review' capability",
+                "hint": "Start one: antfarm worker start --agent reviewer",
+                "count": 1,
+            }
+        ],
+    }
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with runner.isolation(input=None, color=False):
+            _render_scout(status, None)
+        # After the call, 'warnings' should have been popped from status
+        assert "warnings" not in status
+
+    # Invoke via CLI echo captures — simplest is to capture via a Click echo wrapper
+    # by calling the function inside a runner context that captures output.
+    output_lines: list[str] = []
+
+    def capturing_echo(*args, **kwargs):
+        msg = args[0] if args else ""
+        output_lines.append(str(msg))
+
+    with patch("antfarm.core.cli.click.echo", side_effect=capturing_echo), patch(
+        "antfarm.core.cli.click.secho", side_effect=capturing_echo
+    ):
+        status2 = {
+            "tasks": {"ready": 1, "active": 0, "done": 0},
+            "warnings": [
+                {
+                    "code": "no_reviewer_capacity",
+                    "message": "m",
+                    "hint": "h",
+                    "count": 1,
+                }
+            ],
+        }
+        _render_scout(status2, None)
+
+    combined = "\n".join(output_lines)
+    assert "h" in combined
+    assert "m" in combined

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1615,3 +1615,80 @@ def test_doctor_dry_run_does_not_emit_stale_guard_event(setup, clear_events):
     run_doctor(backend, config, fix=False)
 
     assert _find_event(clear_events, "stale_guard_cleared") is None
+
+
+# ---------------------------------------------------------------------------
+# check_no_reviewer_capacity tests
+# ---------------------------------------------------------------------------
+
+
+def _make_review_task(task_id: str = "review-1") -> dict:
+    """Make a task that requires the 'review' capability."""
+    now = datetime.now(UTC).isoformat()
+    return {
+        "id": task_id,
+        "title": f"Review {task_id}",
+        "spec": "Review this PR",
+        "complexity": "S",
+        "priority": 5,
+        "depends_on": [],
+        "touches": [],
+        "capabilities_required": ["review"],
+        "created_at": now,
+        "updated_at": now,
+        "created_by": "test",
+    }
+
+
+def _make_reviewer_worker(worker_id: str = "reviewer-1") -> dict:
+    """Make a worker dict with the 'review' capability."""
+    now = datetime.now(UTC).isoformat()
+    return {
+        "worker_id": worker_id,
+        "node_id": "node-1",
+        "agent_type": "reviewer",
+        "workspace_root": "/tmp/ws-review",
+        "capabilities": ["review"],
+        "status": "idle",
+        "registered_at": now,
+        "last_heartbeat": now,
+    }
+
+
+def test_check_no_reviewer_capacity_fires(setup):
+    """Ready review task + zero reviewer workers → one warning finding."""
+    backend, config = setup
+    backend.carry(_make_review_task("review-001"))
+
+    findings = run_doctor(backend, config)
+
+    capacity_findings = [f for f in findings if f.check == "no_reviewer_capacity"]
+    assert len(capacity_findings) == 1
+    f = capacity_findings[0]
+    assert f.severity == "warning"
+    assert f.auto_fixable is False
+    assert "review" in f.message.lower()
+
+
+def test_check_no_reviewer_capacity_silent_when_reviewer_present(setup):
+    """Ready review task + a registered reviewer worker → no capacity finding."""
+    backend, config = setup
+    backend.carry(_make_review_task("review-001"))
+    backend.register_worker(_make_reviewer_worker("local/reviewer-1"))
+
+    findings = run_doctor(backend, config)
+
+    capacity_findings = [f for f in findings if f.check == "no_reviewer_capacity"]
+    assert len(capacity_findings) == 0
+
+
+def test_check_no_reviewer_capacity_silent_when_no_ready_review_tasks(setup):
+    """No ready review tasks → no capacity finding, even without reviewer workers."""
+    backend, config = setup
+    # Regular task (no capabilities_required) and no workers
+    backend.carry(_make_task("task-regular"))
+
+    findings = run_doctor(backend, config)
+
+    capacity_findings = [f for f in findings if f.check == "no_reviewer_capacity"]
+    assert len(capacity_findings) == 0

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1026,3 +1026,75 @@ def test_get_app_does_not_log_colony_hash(tmp_path, caplog):
     assert not noisy, (
         f"get_app() must not log colony id, but got: {[r.getMessage() for r in noisy]}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Warnings in /status and /status/full
+# ---------------------------------------------------------------------------
+
+
+def _carry_review_task(client, task_id="review-001"):
+    """Carry a task with capabilities_required=['review']."""
+    return client.post(
+        "/tasks",
+        json={
+            "id": task_id,
+            "title": "Review this",
+            "spec": "Review the PR",
+            "capabilities_required": ["review"],
+        },
+    )
+
+
+def test_status_includes_warnings_when_no_reviewer_capacity(tmp_path):
+    """GET /status and GET /status/full both surface no_reviewer_capacity warning."""
+    from antfarm.core.backends.file import FileBackend
+    from antfarm.core.serve import get_app
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend)
+    test_client = TestClient(app)
+
+    _carry_review_task(test_client)
+
+    r = test_client.get("/status")
+    assert r.status_code == 200
+    data = r.json()
+    assert "warnings" in data
+    codes = [w["code"] for w in data["warnings"]]
+    assert "no_reviewer_capacity" in codes
+
+    r = test_client.get("/status/full")
+    assert r.status_code == 200
+    data = r.json()
+    assert "warnings" in data
+    codes = [w["code"] for w in data["warnings"]]
+    assert "no_reviewer_capacity" in codes
+
+
+def test_status_warnings_empty_when_reviewer_present(tmp_path):
+    """When a reviewer worker is registered, no_reviewer_capacity warning is absent."""
+    from antfarm.core.backends.file import FileBackend
+    from antfarm.core.serve import get_app
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend)
+    test_client = TestClient(app)
+
+    _carry_review_task(test_client)
+    test_client.post(
+        "/workers/register",
+        json={
+            "worker_id": "local/reviewer-1",
+            "node_id": "local",
+            "agent_type": "reviewer",
+            "workspace_root": "/tmp/ws",
+            "capabilities": ["review"],
+        },
+    )
+
+    r = test_client.get("/status")
+    assert r.status_code == 200
+    data = r.json()
+    codes = [w.get("code") for w in data.get("warnings", [])]
+    assert "no_reviewer_capacity" not in codes


### PR DESCRIPTION
## Summary

- Adds `antfarm/core/warnings.py` with `detect_no_reviewer_capacity()` — pure function, no I/O.
- Adds `check_no_reviewer_capacity` doctor check that fires when ready review tasks exist but no worker has the `review` capability; registered in `run_doctor` after `check_stale_tasks`.
- Surfaces the warning via `/status` and `/status/full` `warnings[]` array in the colony API.
- Renders an actionable red `⚠ Warnings` panel at the top of the TUI when warnings are non-empty.
- Prints red warning lines with hint at the bottom of `antfarm scout` output.

## Test plan

- [x] `test_check_no_reviewer_capacity_fires` — ready review task + no reviewer → one warning finding
- [x] `test_check_no_reviewer_capacity_silent_when_reviewer_present` — reviewer worker registered → no finding
- [x] `test_check_no_reviewer_capacity_silent_when_no_ready_review_tasks` — no review tasks → no finding
- [x] `test_status_includes_warnings_when_no_reviewer_capacity` — GET `/status` and `/status/full` both include `code=="no_reviewer_capacity"` when condition is met
- [x] `test_status_warnings_empty_when_reviewer_present` — no warning when reviewer registered
- [x] `test_render_scout_prints_warnings` — hint text appears in scout output; `warnings` key popped before table render
- [x] Full test suite: 1084 passed, 0 failures
- [x] `ruff check .` clean

Closes #266.

🤖 Generated with [Claude Code](https://claude.com/claude-code)