### PR TITLE
docs(readme): sharpen prior-art framing and add multi-node transcript

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Not a framework. Not AGI. Not a cloud service.
 
 A self-hosted coordinator that fans coding tasks across multiple AI agent sessions — on one machine or many — and merges the results through a deterministic gate.
 
-Closest neighbor is tmux-orchestrator; unlike CrewAI or AutoGen, antfarm is not a meta-agent framework — the agents are real Claude Code (or Codex/Aider) sessions.
+Antfarm is not a multi-agent framework like CrewAI or AutoGen — there is no agent-to-agent conversation. It is closer to a CI runner pool: each task is sealed (one AI session, one git worktree, one PR), a deterministic gate merges the results, and coordination happens through specs and code review, not chat.
 
 ---
 
@@ -52,6 +52,23 @@ $ antfarm scout --watch
 No manual intervention between `mission create` and `mission complete`. The kickback at 14:13 is the Soldier refusing to merge a reviewer `needs_changes`; the builder re-tries attempt 2.
 
 <!-- asciicast: record after rewrite lands, link here -->
+
+### Adding a second machine
+
+```
+# on machine-2 (same trusted network, same repo cloned)
+$ antfarm runner --colony-url http://lead:7433 --repo-path ~/projects/rate-limiter
+[runner] node=machine-2  listening on 127.0.0.1:7434  max-workers=4
+[runner] registered with colony a4f2c1e8
+
+# back on the lead, scout --watch picks it up:
+14:21:03  colony      node registered: machine-2  (capacity=4)
+14:21:04  autoscaler  scaling builders 3 -> 5  (2 placed on machine-2)
+14:21:11  worker      machine-2/builder-1 claimed task-004
+14:21:11  worker      machine-2/builder-2 claimed task-005
+```
+
+Same mission, two machines. The autoscaler sees the new runner's capacity and places additional builders there; workers draw from the shared queue over HTTP.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replace the shaky tmux-orchestrator "closest neighbor" claim with a CI-runner-pool framing and a sharper coordination-medium contrast against CrewAI/AutoGen.
- Add a compact \"Adding a second machine\" subsection to *What it looks like* so multi-node (the actual differentiator) is visible above the fold, not buried in a single FAQ line.

## Why

After #298 landed we re-read the prior-art line at 180-IQ and three problems surfaced:

1. tmux-orchestrator is single-machine, manual, no merge gate — not actually the closest neighbor. A reader arriving with that mental model gets confused by the Soldier, autoscaler, and multi-machine story.
2. \"Not a meta-agent framework\" self-contradicts on inspection — the Queen is an AI session spawning other AI sessions, the Reviewer is an AI judging another AI. That *is* a meta-agent system. The distinction we actually want is the coordination *medium* (tickets + git vs. LLM-to-LLM messages).
3. Multi-machine is antfarm's actual differentiator vs. CrewAI / AutoGen / tmux-orchestrator — burying it in one FAQ answer undersells it.

## Changes

- One-line rewrite of the prior-art paragraph (line 13).
- New `### Adding a second machine` subsection under *What it looks like* showing `antfarm runner --colony-url` on a second machine and the scout feed on the lead picking up the new capacity.

## Verification

- `wc -l README.md` → 211 (under the 220 cap).
- Voice-check greps (marketing words, AI-powered/leverage/etc., emoji, \"just works/add/run\") all zero hits.
- `ruff check .` clean; docs-only change.