### PR TITLE
fix(backend,soldier): mark_merged does not validate attempt currency — silent wrong-attempt MERGED under race

### DIFF
--- a/antfarm/core/backends/base.py
+++ b/antfarm/core/backends/base.py
@@ -155,6 +155,10 @@ class TaskBackend(ABC):
         Args:
             task_id: ID of the task.
             attempt_id: ID of the attempt that was merged.
+
+        Raises:
+            ValueError: If attempt_id is not the current attempt.
+            FileNotFoundError: If the task is not found in done/.
         """
         ...
 

--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -480,13 +480,25 @@ class FileBackend(TaskBackend):
             self._write_json(done_path, data)
 
     def mark_merged(self, task_id: str, attempt_id: str) -> None:
-        """Update attempt status to MERGED in done/ task file. Task stays DONE."""
+        """Update attempt status to MERGED in done/ task file. Task stays DONE.
+
+        Raises:
+            ValueError: If attempt_id is not the current attempt (or not found
+                on the task at all — defense against internal corruption).
+            FileNotFoundError: If the task is not found in done/.
+        """
         with self._lock:
             done_path = self._done_path(task_id)
             if not done_path.exists():
                 raise FileNotFoundError(f"Task '{task_id}' not found in done/")
 
             data = self._read_json(done_path)
+            current = data.get("current_attempt")
+            if current != attempt_id:
+                raise ValueError(
+                    f"attempt_id '{attempt_id}' is not the current attempt (got '{current}')"
+                )
+
             matched = False
             for a in data["attempts"]:
                 if a["attempt_id"] == attempt_id:
@@ -1160,6 +1172,4 @@ class FileBackend(TaskBackend):
 
     def _has_merged_attempt(self, task: dict) -> bool:
         """Return True if any attempt on the task has status=merged."""
-        return any(
-            a.get("status") == AttemptStatus.MERGED.value for a in task.get("attempts", [])
-        )
+        return any(a.get("status") == AttemptStatus.MERGED.value for a in task.get("attempts", []))

--- a/antfarm/core/backends/github.py
+++ b/antfarm/core/backends/github.py
@@ -607,11 +607,19 @@ class GitHubBackend(TaskBackend):
         """Close the issue, add antfarm:merged label.
 
         Raises:
-            ValueError: If attempt_id not found on task.
+            ValueError: If attempt_id is not the current attempt (or not found
+                on the task at all).
+            FileNotFoundError: If the task is not found in done.
         """
         task, issue_number = self._get_task_issue(task_id)
         if issue_number is None:
             raise FileNotFoundError(f"Task '{task_id}' not found in done")
+
+        current = task.get("current_attempt")
+        if current != attempt_id:
+            raise ValueError(
+                f"attempt_id '{attempt_id}' is not the current attempt (got '{current}')"
+            )
 
         matched = False
         for a in task["attempts"]:

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -70,27 +70,27 @@ WAKE_EVENT_TYPES: frozenset[str] = frozenset({"harvested", "kickback", "merged"}
 
 _MERGE_SKIP_REASONS = frozenset(
     {
-        "dep_unmerged",        # a dependency has not yet merged
-        "no_pr",               # current attempt has no branch/PR
-        "review_pending",      # review task was just created this tick
+        "dep_unmerged",  # a dependency has not yet merged
+        "no_pr",  # current attempt has no branch/PR
+        "review_pending",  # review task was just created this tick
         "review_in_progress",  # review task exists but is not done yet
-        "review_stale_sha",    # review verdict is for an older attempt SHA
-        "needs_changes",       # review verdict is not 'pass'
-        "already_merged",      # current_attempt is already MERGED
-        "superseded",          # current_attempt is None (post-kickback)
+        "review_stale_sha",  # review verdict is for an older attempt SHA
+        "needs_changes",  # review verdict is not 'pass'
+        "already_merged",  # current_attempt is already MERGED
+        "superseded",  # current_attempt is None (post-kickback)
     }
 )
 
 _MERGE_FAILED_REASONS = frozenset(
     {
-        "merge_conflict",   # git merge reported a conflict
-        "test_failed",      # test_command returned non-zero
-        "rebase_failed",    # rebase/fast-forward failed
-        "push_failed",      # git push origin failed
-        "no_pr",            # current attempt has no branch
-        "fetch_failed",     # git fetch origin failed
+        "merge_conflict",  # git merge reported a conflict
+        "test_failed",  # test_command returned non-zero
+        "rebase_failed",  # rebase/fast-forward failed
+        "push_failed",  # git push origin failed
+        "no_pr",  # current attempt has no branch
+        "fetch_failed",  # git fetch origin failed
         "checkout_failed",  # could not checkout integration branch / temp
-        "unknown",          # catch-all for unclassified failures
+        "unknown",  # catch-all for unclassified failures
     }
 )
 
@@ -113,9 +113,7 @@ def _emit(event_type: str, task_id: str, detail: str = "") -> None:
     try:
         _emit_event(event_type, task_id, detail, actor="soldier")
     except Exception:
-        logger.debug(
-            "soldier _emit: _emit_event(%s) raised", event_type, exc_info=True
-        )
+        logger.debug("soldier _emit: _emit_event(%s) raised", event_type, exc_info=True)
 
 
 class MergeResult(StrEnum):
@@ -187,7 +185,7 @@ class Soldier:
                 result = self.attempt_merge(task)
                 attempt_id = task["current_attempt"]
                 if result == MergeResult.MERGED:
-                    self.colony.mark_merged(task["id"], attempt_id)
+                    self._safe_mark_merged(task["id"], attempt_id)
                 else:
                     self.kickback_with_cascade(task["id"], self.last_failure_reason)
 
@@ -208,7 +206,7 @@ class Soldier:
             result = self.attempt_merge(task)
             attempt_id = task["current_attempt"]
             if result == MergeResult.MERGED:
-                self.colony.mark_merged(task["id"], attempt_id)
+                self._safe_mark_merged(task["id"], attempt_id)
             else:
                 self.kickback_with_cascade(task["id"], self.last_failure_reason)
             results.append((task["id"], result))
@@ -330,7 +328,7 @@ class Soldier:
                 if passed:
                     result = self.attempt_merge(task)
                     if result == MergeResult.MERGED:
-                        self.colony.mark_merged(task_id, attempt_id)
+                        self._safe_mark_merged(task_id, attempt_id)
                     else:
                         self.kickback_with_cascade(task_id, self.last_failure_reason)
                     results.append((task_id, result))
@@ -381,13 +379,10 @@ class Soldier:
                     carried = dict(prior_verdict)
                     carried["reviewed_commit_sha"] = current_sha
                     try:
-                        self.colony.store_review_verdict(
-                            task_id, attempt_id, carried
-                        )
+                        self.colony.store_review_verdict(task_id, attempt_id, carried)
                     except Exception:
                         logger.exception(
-                            "failed to carry forward verdict for %s; "
-                            "falling through to re-review",
+                            "failed to carry forward verdict for %s; falling through to re-review",
                             task_id,
                         )
                     else:
@@ -406,17 +401,13 @@ class Soldier:
                         if passed:
                             result = self.attempt_merge(task_updated)
                             if result == MergeResult.MERGED:
-                                self.colony.mark_merged(task_id, attempt_id)
+                                self._safe_mark_merged(task_id, attempt_id)
                             else:
-                                self.kickback_with_cascade(
-                                    task_id, self.last_failure_reason
-                                )
+                                self.kickback_with_cascade(task_id, self.last_failure_reason)
                             results.append((task_id, result))
                         else:
                             _emit("merge_skipped", task_id, "reason=needs_changes")
-                            self.kickback_with_cascade(
-                                task_id, f"review failed: {reason}"
-                            )
+                            self.kickback_with_cascade(task_id, f"review failed: {reason}")
                             results.append((task_id, MergeResult.FAILED))
                         continue
 
@@ -475,7 +466,7 @@ class Soldier:
             if passed:
                 result = self.attempt_merge(task_updated)
                 if result == MergeResult.MERGED:
-                    self.colony.mark_merged(task_id, attempt_id)
+                    self._safe_mark_merged(task_id, attempt_id)
                 else:
                     self.kickback_with_cascade(task_id, self.last_failure_reason)
                 results.append((task_id, result))
@@ -830,9 +821,7 @@ class Soldier:
                 # Stream closed cleanly (server-side timeout). Act as a tick.
                 return False
         except Exception as exc:
-            logger.warning(
-                "soldier event wait failed (%s); falling back to poll sleep", exc
-            )
+            logger.warning("soldier event wait failed (%s); falling back to poll sleep", exc)
             time.sleep(timeout)
             return False
 
@@ -969,9 +958,7 @@ class Soldier:
             check=False,
         )
         if r.returncode != 0:
-            self.last_failure_reason = (
-                f"rebase_retry_merge_failed: {r.stderr.decode().strip()}"
-            )
+            self.last_failure_reason = f"rebase_retry_merge_failed: {r.stderr.decode().strip()}"
             _emit("merge_failed", task_id, f"reason={self.last_failure_reason}")
             return MergeResult.FAILED
 
@@ -1154,6 +1141,35 @@ class Soldier:
             return False
         return None
 
+    def _safe_mark_merged(self, task_id: str, expected_attempt_id: str) -> bool:
+        """Re-fetch task and mark_merged only if expected_attempt_id is still current.
+
+        This guards against attempt drift — a concurrent doctor ``--fix``
+        kickback + worker re-harvest can rotate ``current_attempt`` to a new
+        ID between the moment Soldier captured the merge queue and the moment
+        it calls ``mark_merged``. Backend now validates currency, but we also
+        skip here with a diagnostic event so the drifted attempt's new cycle
+        can own its own merge decision.
+
+        Returns True on success; False if the attempt drifted (emits
+        ``merge_skipped`` with ``reason=attempt_drift``) or the task
+        disappeared.
+        """
+        fresh = self.colony.get_task(task_id)
+        current = (fresh or {}).get("current_attempt")
+        if current != expected_attempt_id:
+            logger.warning(
+                "skipping mark_merged for %s: attempt drift "
+                "(expected=%s current=%s); new attempt will own its merge cycle",
+                task_id,
+                expected_attempt_id,
+                current,
+            )
+            _emit("merge_skipped", task_id, "reason=attempt_drift")
+            return False
+        self.colony.mark_merged(task_id, expected_attempt_id)
+        return True
+
     def _reconcile_external_merge(self, task: dict) -> bool:
         """Mark the task as merged if its PR was merged on origin.
 
@@ -1171,9 +1187,13 @@ class Soldier:
             return False
         task_id = task["id"]
         attempt_id = task["current_attempt"]
-        # ValueError means already merged — idempotent no-op.
+        # ValueError means already merged or drifted — idempotent no-op.
+        # ``_safe_mark_merged`` already handles drift by emitting merge_skipped
+        # and returning False without raising; the suppress remains as defense
+        # for a rare case where the fresh task still has the current attempt
+        # but the backend write races with a kickback (very narrow window).
         with contextlib.suppress(ValueError):
-            self.colony.mark_merged(task_id, attempt_id)
+            self._safe_mark_merged(task_id, attempt_id)
         logger.info("reconciled externally-merged PR %s for %s", pr, task_id)
         _emit("reconciled_external", task_id, f"pr={pr}")
         return True

--- a/tests/test_file_backend.py
+++ b/tests/test_file_backend.py
@@ -475,7 +475,14 @@ def test_mark_harvested_idempotent_wrong_attempt_rejects(backend: FileBackend) -
 
 
 def test_mark_merged_unknown_attempt_rejects(backend: FileBackend) -> None:
-    """BUG 3 regression: mark_merged with unknown attempt_id must raise ValueError."""
+    """BUG 3 regression: mark_merged with unknown attempt_id must raise ValueError.
+
+    With the #305 currency check in place, an attempt_id that is both
+    non-existent AND not the current attempt trips the currency guard first
+    ("not the current attempt"); that is the expected behaviour. The
+    "not found on task" branch remains as defense-in-depth against internal
+    corruption — see ``test_mark_merged_rejects_stale_attempt_id`` below.
+    """
     backend.carry(_make_task("task-1"))
     pulled = backend.pull("worker-1")
     assert pulled is not None
@@ -483,7 +490,7 @@ def test_mark_merged_unknown_attempt_rejects(backend: FileBackend) -> None:
     attempt_id = pulled["current_attempt"]
     backend.mark_harvested("task-1", attempt_id, pr="pr", branch="branch")
 
-    with pytest.raises(ValueError, match="not found on task"):
+    with pytest.raises(ValueError, match="not the current attempt|not found on task"):
         backend.mark_merged("task-1", "nonexistent-attempt-id")
 
 
@@ -1359,3 +1366,62 @@ def test_kickback_does_not_hold_lock_during_pr_close(tmp_path: Path) -> None:
     backend.kickback("task-1", reason="tests failed")
 
     assert probe.acquired, "kickback held self._lock during PR close (deadlock risk)"
+
+
+# ---------------------------------------------------------------------------
+# Issue #305: mark_merged must validate attempt currency
+# ---------------------------------------------------------------------------
+
+
+def test_mark_merged_rejects_stale_attempt_id(backend: FileBackend) -> None:
+    """Issue #305: a stale attempt_id (from before a kickback) must raise.
+
+    Simulates the race where Soldier captured ``attempt_id = X`` from a merge
+    queue snapshot, then a concurrent doctor --fix kickback + worker re-harvest
+    rotated ``current_attempt`` to ``Y``. Calling ``mark_merged(task, X)`` at
+    that point must not silently flip the SUPERSEDED old attempt to MERGED.
+    """
+    backend.carry(_make_task("task-1"))
+
+    # First lifecycle: pull (creates attempt X), harvest.
+    pulled1 = backend.pull("worker-1")
+    assert pulled1 is not None
+    stale_attempt = pulled1["current_attempt"]
+    backend.mark_harvested("task-1", stale_attempt, pr="pr-1", branch="br-1")
+
+    # Concurrent doctor --fix would kick this back; we simulate that.
+    backend.kickback("task-1", reason="concurrent recovery")
+
+    # Worker re-harvests: new attempt Y becomes current.
+    pulled2 = backend.pull("worker-2")
+    assert pulled2 is not None
+    current_attempt = pulled2["current_attempt"]
+    assert current_attempt != stale_attempt
+    backend.mark_harvested("task-1", current_attempt, pr="pr-2", branch="br-2")
+
+    # Soldier now tries to mark the STALE attempt as merged — must be rejected.
+    with pytest.raises(ValueError, match="not the current attempt"):
+        backend.mark_merged("task-1", stale_attempt)
+
+    # The current attempt is untouched (still DONE, not MERGED).
+    data = backend.get_task("task-1")
+    assert data is not None
+    attempts_by_id = {a["attempt_id"]: a for a in data["attempts"]}
+    assert attempts_by_id[stale_attempt]["status"] == AttemptStatus.SUPERSEDED.value
+    assert attempts_by_id[current_attempt]["status"] == AttemptStatus.DONE.value
+
+
+def test_mark_merged_accepts_current_attempt(backend: FileBackend) -> None:
+    """Issue #305 happy path: mark_merged with the current attempt_id succeeds."""
+    backend.carry(_make_task("task-1"))
+    pulled = backend.pull("worker-1")
+    assert pulled is not None
+    attempt_id = pulled["current_attempt"]
+    backend.mark_harvested("task-1", attempt_id, pr="pr-1", branch="br-1")
+
+    backend.mark_merged("task-1", attempt_id)
+
+    data = backend.get_task("task-1")
+    assert data is not None
+    attempts_by_id = {a["attempt_id"]: a for a in data["attempts"]}
+    assert attempts_by_id[attempt_id]["status"] == AttemptStatus.MERGED.value

--- a/tests/test_soldier.py
+++ b/tests/test_soldier.py
@@ -1687,9 +1687,7 @@ def test_wait_for_event_wakes_on_harvested_under_one_second(monkeypatch):
     lines = [f"data: {json.dumps(wake)}", ""]
     fake_client = _FakeHttpxClient(lines=lines)
 
-    monkeypatch.setattr(
-        soldier_module.httpx, "Client", lambda *a, **kw: fake_client
-    )
+    monkeypatch.setattr(soldier_module.httpx, "Client", lambda *a, **kw: fake_client)
 
     # If sleep is called here we fail — wake path must not sleep.
     sleep_calls: list[float] = []
@@ -1721,9 +1719,7 @@ def test_wait_for_event_ignores_unrelated_events_until_timeout(monkeypatch):
     # simulating server-side timeout.
     lines = [f"data: {json.dumps(unrelated)}", ""]
     fake_client = _FakeHttpxClient(lines=lines)
-    monkeypatch.setattr(
-        soldier_module.httpx, "Client", lambda *a, **kw: fake_client
-    )
+    monkeypatch.setattr(soldier_module.httpx, "Client", lambda *a, **kw: fake_client)
 
     sleep_calls: list[float] = []
     monkeypatch.setattr(soldier_module.time, "sleep", lambda s: sleep_calls.append(s))
@@ -1742,9 +1738,7 @@ def test_wait_for_event_timeout_returns_false_without_crashing(monkeypatch):
     soldier = _make_soldier_for_event_tests(poll_interval=5.0)
 
     fake_client = _FakeHttpxClient(lines=[])
-    monkeypatch.setattr(
-        soldier_module.httpx, "Client", lambda *a, **kw: fake_client
-    )
+    monkeypatch.setattr(soldier_module.httpx, "Client", lambda *a, **kw: fake_client)
     monkeypatch.setattr(soldier_module.time, "sleep", lambda s: None)
 
     woken = soldier._wait_for_event(timeout=5.0)
@@ -1757,9 +1751,7 @@ def test_wait_for_event_connection_error_falls_back_to_sleep(monkeypatch):
     soldier = _make_soldier_for_event_tests(poll_interval=5.0)
 
     fake_client = _FakeHttpxClient(stream_exc=httpx.ConnectError("boom"))
-    monkeypatch.setattr(
-        soldier_module.httpx, "Client", lambda *a, **kw: fake_client
-    )
+    monkeypatch.setattr(soldier_module.httpx, "Client", lambda *a, **kw: fake_client)
 
     sleep_calls: list[float] = []
     monkeypatch.setattr(soldier_module.time, "sleep", lambda s: sleep_calls.append(s))
@@ -1777,9 +1769,7 @@ def test_wait_for_event_json_parse_error_falls_back_to_sleep(monkeypatch):
     # "data: not-json" will fail json.loads inside the helper.
     lines = ["data: not-json", ""]
     fake_client = _FakeHttpxClient(lines=lines)
-    monkeypatch.setattr(
-        soldier_module.httpx, "Client", lambda *a, **kw: fake_client
-    )
+    monkeypatch.setattr(soldier_module.httpx, "Client", lambda *a, **kw: fake_client)
 
     sleep_calls: list[float] = []
     monkeypatch.setattr(soldier_module.time, "sleep", lambda s: sleep_calls.append(s))
@@ -1821,9 +1811,7 @@ def test_wait_for_event_passes_cursor_and_timeout_to_server(monkeypatch):
     soldier._event_cursor = 42
 
     fake_client = _FakeHttpxClient(lines=[])
-    monkeypatch.setattr(
-        soldier_module.httpx, "Client", lambda *a, **kw: fake_client
-    )
+    monkeypatch.setattr(soldier_module.httpx, "Client", lambda *a, **kw: fake_client)
     monkeypatch.setattr(soldier_module.time, "sleep", lambda s: None)
 
     soldier._wait_for_event(timeout=4.0)
@@ -1907,9 +1895,7 @@ def test_get_merge_queue_emits_skipped_for_unmerged_dep(soldier_env, captured_em
 
     # Harvest task-a (not merged) and task-b which depends on task-a.
     _carry_and_harvest(cc, repo, "task-dep-a", "feat/task-dep-a")
-    _carry_and_harvest(
-        cc, repo, "task-dep-b", "feat/task-dep-b", depends_on=["task-dep-a"]
-    )
+    _carry_and_harvest(cc, repo, "task-dep-b", "feat/task-dep-b", depends_on=["task-dep-a"])
 
     # Clear emits from any prior steps, then invoke the filter path.
     captured_emits.clear()
@@ -1998,9 +1984,7 @@ def test_run_once_with_review_emits_skipped_needs_changes_before_kickback(
     # Filter emissions for this task.
     task_events = [c for c in captured_emits if c[1] == "task-nc-001"]
     types = [c[0] for c in task_events]
-    assert "merge_skipped" in types, (
-        f"expected merge_skipped before kickback, got {types}"
-    )
+    assert "merge_skipped" in types, f"expected merge_skipped before kickback, got {types}"
     # Ordering: merge_skipped (with needs_changes reason) must be emitted
     # BEFORE any subsequent kickback-related event. Kickback itself is
     # emitted by colony (actor=colony) not by soldier, so just assert that
@@ -2024,10 +2008,7 @@ def test_run_once_with_review_emits_skipped_review_in_progress(soldier_env, capt
         json={
             "id": "review-task-rip-001",
             "title": "Review: task-rip-001",
-            "spec": (
-                "Review task-rip-001\n"
-                "Attempt-SHA: feat/task-rip-001\n"
-            ),
+            "spec": ("Review task-rip-001\nAttempt-SHA: feat/task-rip-001\n"),
             "depends_on": [],
             "priority": 1,
             "capabilities_required": ["review"],
@@ -2047,9 +2028,7 @@ def test_run_once_with_review_emits_skipped_review_in_progress(soldier_env, capt
     captured_emits.clear()
     review_soldier.run_once_with_review()
 
-    skipped = [
-        c for c in captured_emits if c[0] == "merge_skipped" and c[1] == "task-rip-001"
-    ]
+    skipped = [c for c in captured_emits if c[0] == "merge_skipped" and c[1] == "task-rip-001"]
     assert any("reason=review_in_progress" in c[2] for c in skipped), (
         f"expected review_in_progress skip, got {skipped}"
     )
@@ -2195,9 +2174,7 @@ def test_rebase_retry_merges_when_rebase_resolves_drift(tmp_path, monkeypatch):
         if "merge" in args and "--no-ff" in args and "feat/task-rb" in args:
             merge_call_count["n"] += 1
             if merge_call_count["n"] == 1:
-                return _sp.CompletedProcess(
-                    args, 1, stdout=b"", stderr=b"CONFLICT (content)"
-                )
+                return _sp.CompletedProcess(args, 1, stdout=b"", stderr=b"CONFLICT (content)")
             return _sp.CompletedProcess(args, 0, stdout=b"", stderr=b"")
         if "rebase" in args and "origin/main" in joined and "--abort" not in args:
             return _sp.CompletedProcess(args, 0, stdout=b"", stderr=b"")
@@ -2232,9 +2209,7 @@ def test_rebase_conflict_kicks_back_with_rebase_failed_reason(tmp_path, monkeypa
             rebase_abort_called["n"] += 1
             return _sp.CompletedProcess(args, 0, stdout=b"", stderr=b"")
         if "rebase" in args and "origin/main" in joined:
-            return _sp.CompletedProcess(
-                args, 1, stdout=b"", stderr=b"CONFLICT during rebase"
-            )
+            return _sp.CompletedProcess(args, 1, stdout=b"", stderr=b"CONFLICT during rebase")
         return _sp.CompletedProcess(args, 0, stdout=b"", stderr=b"")
 
     import antfarm.core.soldier as soldier_mod
@@ -2260,9 +2235,7 @@ def test_rebase_retry_does_not_loop(tmp_path, monkeypatch):
 
         if "merge" in args and "--no-ff" in args and "feat/task-rb" in args:
             merge_calls["n"] += 1
-            return _sp.CompletedProcess(
-                args, 1, stdout=b"", stderr=b"CONFLICT (content)"
-            )
+            return _sp.CompletedProcess(args, 1, stdout=b"", stderr=b"CONFLICT (content)")
         if "rebase" in args and "--abort" not in args:
             rebase_calls["n"] += 1
             return _sp.CompletedProcess(args, 0, stdout=b"", stderr=b"")
@@ -2274,12 +2247,9 @@ def test_rebase_retry_does_not_loop(tmp_path, monkeypatch):
 
     result = soldier.attempt_merge(task)
     assert result == MergeResult.FAILED
-    assert rebase_calls["n"] == 1, (
-        f"expected exactly 1 rebase invocation, got {rebase_calls['n']}"
-    )
+    assert rebase_calls["n"] == 1, f"expected exactly 1 rebase invocation, got {rebase_calls['n']}"
     assert merge_calls["n"] == 2, (
-        f"expected exactly 2 merge invocations (initial + one retry), "
-        f"got {merge_calls['n']}"
+        f"expected exactly 2 merge invocations (initial + one retry), got {merge_calls['n']}"
     )
     assert "rebase_retry_merge_failed" in soldier.last_failure_reason
 
@@ -2313,9 +2283,7 @@ def test_rebase_uses_force_with_lease_never_plain_force(tmp_path, monkeypatch):
     pr_pushes = [a for a in push_args if "feat/task-rb" in a]
     assert pr_pushes, "expected a push to the PR branch after rebase"
     for p in pr_pushes:
-        assert "--force-with-lease" in p, (
-            f"PR-branch push must use --force-with-lease: {p}"
-        )
+        assert "--force-with-lease" in p, f"PR-branch push must use --force-with-lease: {p}"
 
     # No plain '--force' token anywhere in any push invocation
     # ('--force-with-lease' is a different token and is allowed).
@@ -2339,9 +2307,7 @@ def test_test_failure_does_not_trigger_rebase(tmp_path, monkeypatch):
             rebase_calls["n"] += 1
             return _sp.CompletedProcess(args, 0, stdout=b"", stderr=b"")
         if args and args[0] == "pytest-stub":
-            return _sp.CompletedProcess(
-                args, 1, stdout=b"1 failed", stderr=b"tests failed"
-            )
+            return _sp.CompletedProcess(args, 1, stdout=b"1 failed", stderr=b"tests failed")
         return _sp.CompletedProcess(args, 0, stdout=b"", stderr=b"")
 
     import antfarm.core.soldier as soldier_mod
@@ -2350,9 +2316,7 @@ def test_test_failure_does_not_trigger_rebase(tmp_path, monkeypatch):
 
     result = soldier.attempt_merge(task)
     assert result == MergeResult.FAILED
-    assert rebase_calls["n"] == 0, (
-        "test failure must NOT trigger the rebase retry path"
-    )
+    assert rebase_calls["n"] == 0, "test failure must NOT trigger the rebase retry path"
     assert "tests failed" in soldier.last_failure_reason
 
 
@@ -2377,9 +2341,7 @@ def test_run_once_with_review_kickbacks_on_needs_changes_verdict(tmp_path):
     _set_attempt_artifact_sha(backend, "task-nc-284", "a" * 40)
 
     # 2. Soldier with require_review=True creates the review task.
-    soldier = Soldier.from_backend(
-        backend, repo_path=str(tmp_path), require_review=True
-    )
+    soldier = Soldier.from_backend(backend, repo_path=str(tmp_path), require_review=True)
     assert soldier.require_review is True, (
         "pre-condition: Soldier.from_backend must default require_review=True"
     )
@@ -2482,8 +2444,7 @@ def test_start_soldier_thread_wires_require_review_true(tmp_path, monkeypatch):
 
     assert captured, "_start_soldier_thread did not build a Soldier instance"
     assert captured["kwargs"].get("require_review", False) is True, (
-        f"Soldier must be started with require_review=True, "
-        f"got kwargs={captured['kwargs']}"
+        f"Soldier must be started with require_review=True, got kwargs={captured['kwargs']}"
     )
 
 
@@ -2588,9 +2549,7 @@ def test_p3_identical_diff_carries_forward_pass_verdict(tmp_path, monkeypatch):
     soldier = Soldier.from_backend(backend, repo_path=str(tmp_path))
 
     # Force diffs equivalent; stub attempt_merge so no real git runs.
-    monkeypatch.setattr(
-        Soldier, "_diffs_equivalent_after_rebase", lambda *a, **kw: True
-    )
+    monkeypatch.setattr(Soldier, "_diffs_equivalent_after_rebase", lambda *a, **kw: True)
     merges: list[tuple[str, str]] = []
 
     def fake_attempt_merge(self, task):
@@ -2645,9 +2604,7 @@ def test_p3_code_change_falls_through_to_rereview(tmp_path, monkeypatch):
     )
 
     soldier = Soldier.from_backend(backend, repo_path=str(tmp_path))
-    monkeypatch.setattr(
-        Soldier, "_diffs_equivalent_after_rebase", lambda *a, **kw: False
-    )
+    monkeypatch.setattr(Soldier, "_diffs_equivalent_after_rebase", lambda *a, **kw: False)
 
     def fail_attempt_merge(self, task):  # pragma: no cover - sanity guard
         raise AssertionError("attempt_merge must NOT run when diffs differ")
@@ -2686,9 +2643,7 @@ def test_p3_needs_changes_verdict_always_rereviews(tmp_path, monkeypatch):
     soldier = Soldier.from_backend(backend, repo_path=str(tmp_path))
     # Diffs equivalent — carry-forward still must be skipped because verdict
     # is not 'pass'.
-    monkeypatch.setattr(
-        Soldier, "_diffs_equivalent_after_rebase", lambda *a, **kw: True
-    )
+    monkeypatch.setattr(Soldier, "_diffs_equivalent_after_rebase", lambda *a, **kw: True)
 
     def fail_attempt_merge(self, task):  # pragma: no cover - sanity guard
         raise AssertionError("attempt_merge must NOT run on needs_changes")
@@ -2786,9 +2741,15 @@ def test_p3_git_failure_falls_through_safely(tmp_path, monkeypatch):
     def fake_subprocess_run(*args, **kwargs):
         # Only intercept git merge-base / git diff calls from the P3 helper.
         cmd = args[0] if args else kwargs.get("args", [])
-        if isinstance(cmd, list) and len(cmd) >= 2 and cmd[0] == "git" and cmd[1] in (
-            "merge-base",
-            "diff",
+        if (
+            isinstance(cmd, list)
+            and len(cmd) >= 2
+            and cmd[0] == "git"
+            and cmd[1]
+            in (
+                "merge-base",
+                "diff",
+            )
         ):
             return _FakeCompleted(returncode=128, stderr="fatal: bad object")
         # Fallback: raise to ensure nothing else unexpectedly shells out.
@@ -2832,9 +2793,7 @@ def test_p3_carry_forward_is_idempotent(tmp_path, monkeypatch):
     )
 
     soldier = Soldier.from_backend(backend, repo_path=str(tmp_path))
-    monkeypatch.setattr(
-        Soldier, "_diffs_equivalent_after_rebase", lambda *a, **kw: True
-    )
+    monkeypatch.setattr(Soldier, "_diffs_equivalent_after_rebase", lambda *a, **kw: True)
 
     merge_calls: list[str] = []
 
@@ -2865,3 +2824,74 @@ def test_p3_carry_forward_is_idempotent(tmp_path, monkeypatch):
     assert results2 == []
     # attempt_merge must not be called a second time for this task.
     assert merge_calls == [new_attempt_id]
+
+
+# ---------------------------------------------------------------------------
+# Issue #305: _safe_mark_merged re-fetches and skips on attempt drift
+# ---------------------------------------------------------------------------
+
+
+def test_safe_mark_merged_skips_on_attempt_drift(soldier_env, captured_emits):
+    """Issue #305: Soldier must re-fetch task before mark_merged and skip on
+    attempt drift (concurrent kickback + re-harvest).
+
+    Simulates the race: Soldier captured ``attempt_id = X`` from a stale
+    queue snapshot, but ``colony.get_task`` now returns a task whose
+    ``current_attempt`` is ``Y``. ``_safe_mark_merged`` must return False,
+    must NOT call ``colony.mark_merged``, and must emit merge_skipped with
+    reason=attempt_drift.
+    """
+    soldier = soldier_env["soldier"]
+
+    mark_merged_calls: list[tuple[str, str]] = []
+
+    def fake_get_task(task_id: str):
+        # Pretend the task's current attempt has rotated.
+        return {
+            "id": task_id,
+            "current_attempt": "att-002-new",
+            "attempts": [
+                {"attempt_id": "att-001-stale", "status": "superseded"},
+                {"attempt_id": "att-002-new", "status": "done"},
+            ],
+        }
+
+    def fake_mark_merged(task_id: str, attempt_id: str) -> None:
+        mark_merged_calls.append((task_id, attempt_id))
+
+    soldier.colony.get_task = fake_get_task  # type: ignore[method-assign]
+    soldier.colony.mark_merged = fake_mark_merged  # type: ignore[method-assign]
+
+    result = soldier._safe_mark_merged("task-drift", "att-001-stale")
+
+    assert result is False
+    assert mark_merged_calls == [], "mark_merged must not be called on drift"
+    drift_emits = [c for c in captured_emits if c[0] == "merge_skipped" and c[1] == "task-drift"]
+    assert any("reason=attempt_drift" in c[2] for c in drift_emits), (
+        f"expected merge_skipped with reason=attempt_drift, got {captured_emits}"
+    )
+
+
+def test_safe_mark_merged_proceeds_when_attempt_still_current(soldier_env):
+    """Issue #305 happy path: when current_attempt matches, call through."""
+    soldier = soldier_env["soldier"]
+
+    mark_merged_calls: list[tuple[str, str]] = []
+
+    def fake_get_task(task_id: str):
+        return {
+            "id": task_id,
+            "current_attempt": "att-001",
+            "attempts": [{"attempt_id": "att-001", "status": "done"}],
+        }
+
+    def fake_mark_merged(task_id: str, attempt_id: str) -> None:
+        mark_merged_calls.append((task_id, attempt_id))
+
+    soldier.colony.get_task = fake_get_task  # type: ignore[method-assign]
+    soldier.colony.mark_merged = fake_mark_merged  # type: ignore[method-assign]
+
+    result = soldier._safe_mark_merged("task-ok", "att-001")
+
+    assert result is True
+    assert mark_merged_calls == [("task-ok", "att-001")]


### PR DESCRIPTION
## Summary

- `FileBackend.mark_merged` and `GitHubBackend.mark_merged` only verified that `attempt_id` existed somewhere in `task.attempts`, not that it matched `current_attempt`. Under a concurrent `doctor --fix` kickback + worker re-harvest, Soldier captured `attempt_id` from a stale queue snapshot and silently flipped the old (SUPERSEDED) attempt to MERGED while the actually-merged new attempt stayed DONE.
- Both backends now raise `ValueError("… not the current attempt …")` when `attempt_id != current_attempt`, matching the existing `mark_harvested` / `store_review_verdict` guard. ABC docstring declares the contract.
- New Soldier helper `_safe_mark_merged` re-fetches the task immediately before `mark_merged`, skips with a `merge_skipped(reason=attempt_drift)` event on drift, and lets the new attempt own its own merge cycle. All six success-path call sites in `soldier.py` route through the helper. The `kickback_with_cascade` FAILED paths are untouched.

## Changes

| File | Change |
|---|---|
| `antfarm/core/backends/base.py` | ABC docstring declares `ValueError` / `FileNotFoundError` |
| `antfarm/core/backends/file.py` | `mark_merged` validates `current_attempt == attempt_id` |
| `antfarm/core/backends/github.py` | Same validation |
| `antfarm/core/soldier.py` | New `_safe_mark_merged` helper; 6 call sites updated |
| `tests/test_file_backend.py` | +2 tests for currency; existing unknown-attempt test regex widened |
| `tests/test_soldier.py` | +2 tests for drift-skip / happy path |

## Test plan

- [x] New currency-reject test passes: `test_mark_merged_rejects_stale_attempt_id`
- [x] New currency-accept test passes: `test_mark_merged_accepts_current_attempt`
- [x] New soldier drift-skip test passes: `test_safe_mark_merged_skips_on_attempt_drift`
- [x] New soldier happy-path test passes: `test_safe_mark_merged_proceeds_when_attempt_still_current`
- [x] Full suite green: `pytest tests/ -x -q` — 1088 passed (baseline was 1084)
- [x] Ruff clean: `ruff check antfarm/ tests/`
- [x] `git grep 'self\.colony\.mark_merged(' antfarm/core/soldier.py` returns only the single call inside `_safe_mark_merged` itself (no top-level call sites remain)
- [x] Both `FileBackend.mark_merged` and `GitHubBackend.mark_merged` carry the currency check

## Notes / deviations

- The plan called for literally zero hits on `self.colony.mark_merged(` in `soldier.py`, but the helper must call it somewhere — the single remaining hit is inside `_safe_mark_merged` and is load-bearing. All top-level success-path call sites were replaced.
- Plan-referenced line numbers matched the current codebase exactly (190, 211, 333, 409, 478, 1176 — though shifted slightly after edits).
- `ruff format` touched the soldier file (aligned comments in `_MERGE_SKIP_REASONS` / `_MERGE_FAILED_REASONS` became single-space). These are cosmetic and don't affect logic. Scoped format to the four edited files to keep the diff minimal; the rest of the repo has pre-existing format drift the CI doesn't enforce.

Closes #305