### PR TITLE
fix(backend,doctor): close doctor --fix TOCTTOU races

### DIFF
--- a/antfarm/core/backends/base.py
+++ b/antfarm/core/backends/base.py
@@ -96,6 +96,43 @@ class TaskBackend(ABC):
         ...
 
     @abstractmethod
+    def recover_stale_task_if_worker_dead(self, task_id: str, current_attempt_id: str) -> bool:
+        """Atomically recover a stale active task only if its worker is dead.
+
+        Under the backend lock, verify that the task is still in the active
+        state, the current attempt still matches ``current_attempt_id``, and
+        the attempt's worker has no live worker record. If any of those drift
+        conditions fire, return False without mutating — the caller's
+        observation was stale and another actor has already moved state
+        forward.
+
+        When the conditions hold, supersede the current attempt, reset the
+        task to READY with ``current_attempt=None``, append a doctor trail
+        entry ("recovered by doctor"), and move the JSON from ``active/`` to
+        ``ready/``.
+
+        Drift conditions that trigger a False return:
+
+        - Task is no longer in ``active/`` (already moved by another actor).
+        - ``current_attempt`` differs from ``current_attempt_id`` (another
+          actor rotated the attempt).
+        - The attempt's worker record exists (worker recovered between the
+          caller's check and our mutation).
+
+        Scope is within-process only; cross-process callers must rely on
+        filesystem atomicity primitives.
+
+        Args:
+            task_id: ID of the task suspected to be stale.
+            current_attempt_id: The attempt ID the caller observed as current.
+
+        Returns:
+            True if the task was recovered to READY.
+            False if any drift condition prevented the recovery.
+        """
+        ...
+
+    @abstractmethod
     def kickback(self, task_id: str, reason: str, max_attempts: int = 3) -> None:
         """Transition task to READY (or BLOCKED if attempts exhausted).
 
@@ -356,6 +393,26 @@ class TaskBackend(ABC):
         """
         ...
 
+    @abstractmethod
+    def release_guard_if_owner_dead(self, resource: str) -> bool:
+        """Atomically release a guard only if its recorded owner is no longer alive.
+
+        Reads the guard's owner under the backend lock, verifies the owner has
+        no registered worker record, and re-checks that the guard has not been
+        replaced (re-acquired) before releasing. Scope is within-process only;
+        cross-process races (a peer process re-acquires between our check and
+        our release) are out of scope.
+
+        Args:
+            resource: Resource identifier whose guard may be stale.
+
+        Returns:
+            True if the guard existed with a dead owner and was released.
+            False if the guard was missing, unreadable, owned by a live worker,
+            or re-acquired concurrently (state changed — not an error).
+        """
+        ...
+
     # --- Nodes ---
 
     @abstractmethod
@@ -411,6 +468,29 @@ class TaskBackend(ABC):
 
         Args:
             worker_id: ID of the worker to deregister.
+        """
+        ...
+
+    @abstractmethod
+    def deregister_worker_if_stale(self, worker_id: str, max_age: float) -> bool:
+        """Atomically deregister a worker only if its heartbeat is older than ``max_age``.
+
+        The staleness check and the delete are performed under the backend's
+        internal lock so a concurrent heartbeat inside the same process cannot
+        slip between the check and the delete. Scope is within-process only;
+        cross-process callers must rely on ``os.unlink`` atomicity and accept
+        that a peer process may re-register between our check and our unlink.
+
+        Args:
+            worker_id: ID of the worker to deregister.
+            max_age: Minimum age (seconds) a heartbeat must have before the
+                worker is considered stale. Age is measured against the
+                backend's persisted heartbeat timestamp.
+
+        Returns:
+            True if the worker was stale and removed.
+            False if the worker file was missing or had a fresh heartbeat
+            (i.e. state changed before mutation — not an error).
         """
         ...
 

--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -435,6 +435,55 @@ class FileBackend(TaskBackend):
         # stall every other worker for its duration.
         self._close_superseded_pr(superseded_attempt, reason)
 
+    def recover_stale_task_if_worker_dead(self, task_id: str, current_attempt_id: str) -> bool:
+        """Atomically recover a stale active task iff its worker is dead.
+
+        Re-validates all drift conditions under ``self._lock`` before moving
+        state forward. See the ABC docstring for the full contract.
+
+        Within-process only; cross-process racers are out of scope.
+        """
+        with self._lock:
+            active_path = self._active_path(task_id)
+            if not active_path.exists():
+                return False
+            try:
+                data = self._read_json(active_path)
+            except (json.JSONDecodeError, OSError):
+                return False
+            if data.get("current_attempt") != current_attempt_id:
+                return False
+
+            worker_id = next(
+                (
+                    a.get("worker_id")
+                    for a in data.get("attempts", [])
+                    if a.get("attempt_id") == current_attempt_id
+                ),
+                None,
+            )
+            if worker_id and self._worker_path(worker_id).exists():
+                return False
+
+            now = _now_iso()
+            for a in data.get("attempts", []):
+                if a.get("attempt_id") == current_attempt_id:
+                    a["status"] = AttemptStatus.SUPERSEDED.value
+                    a["completed_at"] = now
+                    break
+
+            data["status"] = TaskStatus.READY.value
+            data["current_attempt"] = None
+            data["updated_at"] = now
+            data.setdefault("trail", []).append(
+                {"ts": now, "worker_id": "doctor", "message": "recovered by doctor"}
+            )
+
+            ready_path = self._ready_path(task_id)
+            self._write_json(ready_path, data)
+            active_path.unlink()
+            return True
+
     def mark_harvest_pending(self, task_id: str, attempt_id: str) -> None:
         """Transition task from ACTIVE to HARVEST_PENDING.
 
@@ -858,6 +907,45 @@ class FileBackend(TaskBackend):
             )
         guard_path.unlink()
 
+    def release_guard_if_owner_dead(self, resource: str) -> bool:
+        """Atomically release the guard only if its owner is no longer alive.
+
+        Reads the guard under ``self._lock``, records the owner and mtime,
+        verifies no worker file exists for that owner, re-stats the guard
+        under the same lock to defend against a release+re-acquire race,
+        then unlinks. Within-process only.
+
+        Returns:
+            True if the guard existed with a dead owner and was removed.
+            False if the guard was missing, unreadable, owned by a live
+            worker, or re-acquired concurrently (state changed — not an
+            error).
+        """
+        guard_path = self._guard_path(resource)
+        with self._lock:
+            try:
+                data = json.loads(guard_path.read_text())
+                stat_before = os.stat(str(guard_path))
+            except (FileNotFoundError, json.JSONDecodeError, OSError):
+                return False
+            owner = data.get("owner", "")
+            if not owner:
+                return False
+            if self._worker_path(owner).exists():
+                return False
+            # Re-stat under lock: belt-and-suspenders against release+re-acquire.
+            # Holding self._lock already prevents that inside this process, but
+            # the comparison stays as a safety net if future code paths widen
+            # guard mutations outside the lock.
+            try:
+                stat_now = os.stat(str(guard_path))
+            except FileNotFoundError:
+                return False
+            if stat_now.st_mtime != stat_before.st_mtime:
+                return False
+            guard_path.unlink(missing_ok=True)
+            return True
+
     # ------------------------------------------------------------------
     # Nodes
     # ------------------------------------------------------------------
@@ -927,6 +1015,30 @@ class FileBackend(TaskBackend):
         """Deregister a worker. No-op if not found (idempotent)."""
         worker_path = self._worker_path(worker_id)
         worker_path.unlink(missing_ok=True)
+
+    def deregister_worker_if_stale(self, worker_id: str, max_age: float) -> bool:
+        """Atomically delete the worker file only if its mtime is older than ``max_age``.
+
+        Re-checks the file's mtime under ``self._lock`` to close the TOCTOU
+        window between the doctor's initial stale detection and the delete.
+        Within-process only; an external process that writes between our stat
+        and our unlink can still race — but such peers are not expected in v0.1.
+
+        Returns:
+            True if the file was stale and removed. False if the file was
+            missing or fresh (state changed — not an error).
+        """
+        worker_path = self._worker_path(worker_id)
+        with self._lock:
+            try:
+                stat = os.stat(str(worker_path))
+            except FileNotFoundError:
+                return False
+            age = datetime.now(UTC).timestamp() - stat.st_mtime
+            if age <= max_age:
+                return False
+            worker_path.unlink(missing_ok=True)
+            return True
 
     def heartbeat(self, worker_id: str, status: dict) -> None:
         """Write/update worker file in workers/. mtime = heartbeat timestamp."""

--- a/antfarm/core/backends/github.py
+++ b/antfarm/core/backends/github.py
@@ -589,6 +589,26 @@ class GitHubBackend(TaskBackend):
 
         self._close_superseded_pr(superseded_attempt, reason)
 
+    def recover_stale_task_if_worker_dead(self, task_id: str, current_attempt_id: str) -> bool:
+        """Not supported on GitHubBackend — logs a warning and returns False.
+
+        Task recovery requires a file-based state machine. GitHub Issues
+        labels and body JSON do not support the same atomic rename semantics
+        that the doctor's stale-task fixer relies on, and the doctor's
+        ``check_stale_tasks`` only inspects FileBackend directories. This
+        method exists to satisfy the ABC; operators running a GitHub-backed
+        colony should rely on manual intervention or a parallel FileBackend
+        for task recovery.
+        """
+        import logging
+
+        del task_id, current_attempt_id  # unused — no-op implementation
+        logging.getLogger(__name__).warning(
+            "recover_stale_task_if_worker_dead is not supported for GitHubBackend; "
+            "task recovery is a filesystem-only operation in v0.1."
+        )
+        return False
+
     def mark_harvest_pending(self, task_id: str, attempt_id: str) -> None:
         """Mark task as harvest_pending. Updates status in issue body."""
         task, issue_number = self._get_task_issue(task_id)
@@ -881,6 +901,28 @@ class GitHubBackend(TaskBackend):
                 )
             del self._guards[resource]
 
+    def release_guard_if_owner_dead(self, resource: str) -> bool:
+        """Atomically release a guard iff its owner has no live worker record.
+
+        Within-process only. Checks ``self._workers`` under ``self._lock``.
+
+        Returns:
+            True if the guard existed with a dead owner and was removed.
+            False if the guard was missing, had no owner, or the owner was
+            still alive (state unchanged — not an error).
+        """
+        with self._lock:
+            existing = self._guards.get(resource)
+            if existing is None:
+                return False
+            owner = existing.get("owner", "")
+            if not owner:
+                return False
+            if owner in self._workers:
+                return False
+            del self._guards[resource]
+            return True
+
     # ------------------------------------------------------------------
     # Nodes
     # ------------------------------------------------------------------
@@ -929,6 +971,32 @@ class GitHubBackend(TaskBackend):
     def deregister_worker(self, worker_id: str) -> None:
         """Deregister a worker. No-op if not found."""
         self._workers.pop(worker_id, None)
+
+    def deregister_worker_if_stale(self, worker_id: str, max_age: float) -> bool:
+        """Atomically remove a worker iff its last heartbeat is older than ``max_age``.
+
+        Within-process only. Re-checks the heartbeat under ``self._lock`` so a
+        concurrent heartbeat between the doctor's detection and the delete is
+        honored.
+
+        Returns:
+            True if the worker was stale and removed.
+            False if the record was missing, malformed, or fresh.
+        """
+        with self._lock:
+            worker = self._workers.get(worker_id)
+            if worker is None:
+                return False
+            last_hb = worker.get("last_heartbeat", "")
+            try:
+                hb_dt = datetime.fromisoformat(last_hb)
+                age = (datetime.now(UTC) - hb_dt).total_seconds()
+            except (ValueError, TypeError):
+                return False
+            if age <= max_age:
+                return False
+            del self._workers[worker_id]
+            return True
 
     def heartbeat(self, worker_id: str, status: dict) -> None:
         """Update worker in-memory state with heartbeat."""

--- a/antfarm/core/doctor.py
+++ b/antfarm/core/doctor.py
@@ -318,14 +318,19 @@ def check_stale_workers(backend, config: dict, fix: bool = False) -> list[Findin
                     auto_fixable=True,
                 )
                 if fix:
-                    backend.deregister_worker(worker_id)
-                    f.fixed = True
-                    _emit_event(
-                        "stale_worker_recovered",
-                        "",
-                        f"worker={worker_id}",
-                        actor="doctor",
-                    )
+                    # Atomic re-check-and-delete under the backend lock so a
+                    # late heartbeat between our stat and deregister cannot
+                    # silently evict a live worker (issue #310).
+                    if backend.deregister_worker_if_stale(worker_id, worker_ttl):
+                        f.fixed = True
+                        _emit_event(
+                            "stale_worker_recovered",
+                            "",
+                            f"worker={worker_id}",
+                            actor="doctor",
+                        )
+                    else:
+                        f.message += " (worker recovered before fix)"
                 findings.append(f)
         except FileNotFoundError:
             # File disappeared between glob and stat
@@ -482,66 +487,25 @@ def check_stale_tasks(backend, config: dict, fix: bool = False) -> list[Finding]
                 auto_fixable=True,
             )
             if fix:
-                _recover_stale_task(data_dir, task_file, data, current_attempt_id)
-                f.fixed = True
-                _emit_event(
-                    "stale_task_recovered",
-                    task_id,
-                    f"worker={worker_id}",
-                    actor="doctor",
-                )
+                # Atomic re-check-and-recover under the backend lock. We pass
+                # the UNENCODED worker_id (backend's _worker_path handles the
+                # %2F encoding). If the worker's heartbeat returned, or the
+                # attempt rotated between this check and the mutation, the
+                # backend returns False and we leave the finding as unfixed
+                # (issue #310).
+                if backend.recover_stale_task_if_worker_dead(task_id, current_attempt_id):
+                    f.fixed = True
+                    _emit_event(
+                        "stale_task_recovered",
+                        task_id,
+                        f"worker={worker_id}",
+                        actor="doctor",
+                    )
+                else:
+                    f.message += " (worker recovered or task drifted; no action taken)"
             findings.append(f)
 
     return findings
-
-
-def _recover_stale_task(
-    data_dir: Path,
-    task_file: Path,
-    data: dict,
-    current_attempt_id: str,
-) -> None:
-    """Raw file recovery for a stale active task.
-
-    Supersedes the current attempt, resets status to ready, adds a trail
-    entry, writes to ready/, and deletes from active/.
-
-    Args:
-        data_dir: Root .antfarm directory.
-        task_file: Path to the active task JSON file.
-        data: Parsed task dict.
-        current_attempt_id: The attempt ID to supersede.
-    """
-    now = datetime.now(UTC).isoformat()
-
-    # Supersede the current attempt
-    for attempt in data.get("attempts", []):
-        if attempt.get("attempt_id") == current_attempt_id:
-            attempt["status"] = "superseded"
-            attempt["completed_at"] = now
-            break
-
-    # Reset task to ready
-    data["status"] = "ready"
-    data["current_attempt"] = None
-    data["updated_at"] = now
-
-    # Add trail entry
-    data.setdefault("trail", [])
-    data["trail"].append(
-        {
-            "ts": now,
-            "worker_id": "doctor",
-            "message": "recovered by doctor",
-        }
-    )
-
-    # Write to ready/ atomically, then delete from active/
-    ready_path = data_dir / "tasks" / "ready" / task_file.name
-    tmp_path = ready_path.with_suffix(".tmp")
-    tmp_path.write_text(json.dumps(data, indent=2))
-    tmp_path.replace(ready_path)
-    task_file.unlink()
 
 
 # ---------------------------------------------------------------------------
@@ -649,14 +613,20 @@ def check_stale_guards(backend, config: dict, fix: bool = False) -> list[Finding
             auto_fixable=True,
         )
         if fix:
-            guard_file.unlink(missing_ok=True)
-            f.fixed = True
-            _emit_event(
-                "stale_guard_cleared",
-                "",
-                f"resource={resource}",
-                actor="doctor",
-            )
+            # Atomic re-check-and-release under the backend lock. If the owner
+            # reappeared or the guard was re-acquired by another worker between
+            # our observation and the mutation, the backend returns False and
+            # we leave the finding unfixed (issue #310).
+            if backend.release_guard_if_owner_dead(resource):
+                f.fixed = True
+                _emit_event(
+                    "stale_guard_cleared",
+                    "",
+                    f"resource={resource}",
+                    actor="doctor",
+                )
+            else:
+                f.message += " (owner recovered before fix)"
         findings.append(f)
 
     return findings

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1692,3 +1692,88 @@ def test_check_no_reviewer_capacity_silent_when_no_ready_review_tasks(setup):
 
     capacity_findings = [f for f in findings if f.check == "no_reviewer_capacity"]
     assert len(capacity_findings) == 0
+
+
+# ---------------------------------------------------------------------------
+# Issue #310: doctor --fix must re-check state atomically before mutating.
+# Simulate a late heartbeat arriving between the doctor's stale detection and
+# the backend-side mutation by monkeypatching each *_if_* helper.
+# ---------------------------------------------------------------------------
+
+
+def test_check_stale_workers_fix_respects_late_heartbeat(setup, monkeypatch):
+    """Late heartbeat → backend refuses to deregister → finding reports unfixed."""
+    backend, config = setup
+    backend.register_worker(_make_worker("worker-late"))
+    _backdate(Path(config["data_dir"]) / "workers" / "worker-late.json", seconds=600)
+
+    real = backend.deregister_worker_if_stale
+
+    def wrapped(wid: str, max_age: float) -> bool:
+        # Simulate a concurrent heartbeat landing just before the backend
+        # re-checks staleness under its lock.
+        backend.heartbeat(wid, {})
+        return real(wid, max_age)
+
+    monkeypatch.setattr(backend, "deregister_worker_if_stale", wrapped)
+
+    findings = run_doctor(backend, config, fix=True)
+    stale = [f for f in findings if f.check == "stale_worker"]
+    assert len(stale) == 1
+    assert stale[0].fixed is False
+    assert "recovered" in stale[0].message
+    # Worker file must still exist — the late heartbeat kept it alive.
+    assert (Path(config["data_dir"]) / "workers" / "worker-late.json").exists()
+
+
+def test_check_stale_tasks_fix_respects_late_heartbeat(setup, monkeypatch):
+    """Late worker re-registration → backend refuses recovery → finding reports unfixed."""
+    backend, config = setup
+    backend.register_worker(_make_worker("worker-late"))
+    backend.carry(_make_task("task-racey"))
+    backend.pull("worker-late")
+
+    # Kill the worker so the doctor detects the stale task.
+    backend.deregister_worker("worker-late")
+
+    real = backend.recover_stale_task_if_worker_dead
+
+    def wrapped(task_id: str, attempt_id: str) -> bool:
+        # Simulate the worker reviving between detection and mutation.
+        backend.register_worker(_make_worker("worker-late"))
+        return real(task_id, attempt_id)
+
+    monkeypatch.setattr(backend, "recover_stale_task_if_worker_dead", wrapped)
+
+    findings = run_doctor(backend, config, fix=True)
+    stale = [f for f in findings if f.check == "stale_task"]
+    assert len(stale) == 1
+    assert stale[0].fixed is False
+    assert "no action taken" in stale[0].message
+    # Task must still be in active/ since recovery was refused.
+    assert (Path(config["data_dir"]) / "tasks" / "active" / "task-racey.json").exists()
+    assert not (Path(config["data_dir"]) / "tasks" / "ready" / "task-racey.json").exists()
+
+
+def test_check_stale_guards_fix_respects_owner_revival(setup, monkeypatch):
+    """Owner revives between detection and release → backend refuses → finding unfixed."""
+    backend, config = setup
+    backend.guard("resource/lock", "owner-gone")
+    guard_file = Path(config["data_dir"]) / "guards" / "resource__lock.lock"
+    _backdate(guard_file, seconds=600)
+
+    real = backend.release_guard_if_owner_dead
+
+    def wrapped(resource: str) -> bool:
+        # Simulate owner coming back online right as doctor --fix acts.
+        backend.register_worker(_make_worker("owner-gone"))
+        return real(resource)
+
+    monkeypatch.setattr(backend, "release_guard_if_owner_dead", wrapped)
+
+    findings = run_doctor(backend, config, fix=True)
+    stale = [f for f in findings if f.check == "stale_guard"]
+    assert len(stale) == 1
+    assert stale[0].fixed is False
+    assert "recovered" in stale[0].message
+    assert guard_file.exists()

--- a/tests/test_file_backend.py
+++ b/tests/test_file_backend.py
@@ -1425,3 +1425,109 @@ def test_mark_merged_accepts_current_attempt(backend: FileBackend) -> None:
     assert data is not None
     attempts_by_id = {a["attempt_id"]: a for a in data["attempts"]}
     assert attempts_by_id[attempt_id]["status"] == AttemptStatus.MERGED.value
+
+
+# ---------------------------------------------------------------------------
+# Issue #310: doctor --fix TOCTTOU-safe backend helpers
+# ---------------------------------------------------------------------------
+
+
+def _backdate(path: Path, seconds: int = 600) -> None:
+    """Rewind a file's mtime by ``seconds`` seconds."""
+    old_time = time.time() - seconds
+    os.utime(str(path), (old_time, old_time))
+
+
+def test_deregister_worker_if_stale_skips_fresh(backend: FileBackend) -> None:
+    """Fresh heartbeat must not be evicted — returns False and leaves file intact."""
+    backend.register_worker(_make_worker("w1"))
+    assert backend.deregister_worker_if_stale("w1", max_age=300) is False
+    assert backend._worker_path("w1").exists()
+
+
+def test_deregister_worker_if_stale_removes_old(backend: FileBackend) -> None:
+    """Stale heartbeat is evicted and returns True."""
+    backend.register_worker(_make_worker("w1"))
+    _backdate(backend._worker_path("w1"), seconds=600)
+    assert backend.deregister_worker_if_stale("w1", max_age=300) is True
+    assert not backend._worker_path("w1").exists()
+
+
+def test_deregister_worker_if_stale_missing_returns_false(backend: FileBackend) -> None:
+    """A missing worker file returns False (no error)."""
+    assert backend.deregister_worker_if_stale("never-registered", max_age=300) is False
+
+
+def test_recover_stale_task_skips_when_worker_alive(backend: FileBackend) -> None:
+    """A live worker record must block recovery — caller observation was stale."""
+    backend.register_worker(_make_worker("w1"))
+    backend.carry(_make_task("task-1"))
+    pulled = backend.pull("w1")
+    assert pulled is not None
+    attempt_id = pulled["current_attempt"]
+
+    # Worker is still registered (alive). Recovery must be a no-op.
+    assert backend.recover_stale_task_if_worker_dead("task-1", attempt_id) is False
+    # Task stays in active/
+    assert backend._active_path("task-1").exists()
+    assert not backend._ready_path("task-1").exists()
+
+
+def test_recover_stale_task_skips_when_attempt_drifted(backend: FileBackend) -> None:
+    """If current_attempt no longer matches the caller's observation, no action."""
+    backend.register_worker(_make_worker("w1"))
+    backend.carry(_make_task("task-1"))
+    pulled = backend.pull("w1")
+    assert pulled is not None
+    stale_attempt = "att-does-not-match"
+
+    # Caller's observation is wrong (different attempt_id).
+    assert backend.recover_stale_task_if_worker_dead("task-1", stale_attempt) is False
+    assert backend._active_path("task-1").exists()
+
+
+def test_recover_stale_task_succeeds_when_worker_dead(backend: FileBackend) -> None:
+    """Worker file gone → task is recovered to ready/ with trail entry."""
+    backend.register_worker(_make_worker("w1"))
+    backend.carry(_make_task("task-1"))
+    pulled = backend.pull("w1")
+    assert pulled is not None
+    attempt_id = pulled["current_attempt"]
+
+    # Kill the worker
+    backend.deregister_worker("w1")
+
+    assert backend.recover_stale_task_if_worker_dead("task-1", attempt_id) is True
+    assert not backend._active_path("task-1").exists()
+    assert backend._ready_path("task-1").exists()
+
+    data = json.loads(backend._ready_path("task-1").read_text())
+    assert data["status"] == "ready"
+    assert data["current_attempt"] is None
+    superseded = [a for a in data["attempts"] if a["attempt_id"] == attempt_id]
+    assert len(superseded) == 1
+    assert superseded[0]["status"] == AttemptStatus.SUPERSEDED.value
+    assert any("recovered by doctor" in t["message"] for t in data.get("trail", []))
+
+
+def test_release_guard_if_owner_dead_skips_when_owner_alive(backend: FileBackend) -> None:
+    """A live owner's guard must not be released — returns False."""
+    backend.register_worker(_make_worker("w1"))
+    backend.guard("resource-a", "w1")
+
+    assert backend.release_guard_if_owner_dead("resource-a") is False
+    assert backend._guard_path("resource-a").exists()
+
+
+def test_release_guard_if_owner_dead_unlinks_when_owner_gone(backend: FileBackend) -> None:
+    """An owner with no worker file → guard is released, returns True."""
+    backend.guard("resource-b", "worker-gone")
+    assert backend._guard_path("resource-b").exists()
+
+    assert backend.release_guard_if_owner_dead("resource-b") is True
+    assert not backend._guard_path("resource-b").exists()
+
+
+def test_release_guard_if_owner_dead_missing_returns_false(backend: FileBackend) -> None:
+    """A guard that does not exist returns False (no error)."""
+    assert backend.release_guard_if_owner_dead("never-locked") is False


### PR DESCRIPTION
## Summary

Closes #310.

Three `doctor --fix` checks (`check_stale_workers`, `check_stale_tasks`, `check_stale_guards`) had a classic check-then-mutate TOCTTOU race: doctor observed stale state, then mutated based on that observation — even if a concurrent heartbeat / re-registration / guard re-acquire had invalidated the observation in between.

This PR moves the decide-and-mutate into three new `TaskBackend` methods that re-check state under `self._lock` in `FileBackend` before acting:

- `deregister_worker_if_stale(worker_id, max_age)` — atomic mtime re-check + unlink
- `recover_stale_task_if_worker_dead(task_id, current_attempt_id)` — atomic drift check (active/, attempt_id match, worker liveness) + move to ready/
- `release_guard_if_owner_dead(resource)` — atomic owner-liveness + re-stat guard under the same lock before unlinking

When the mutation is skipped because state drifted, the finding is reported with `fixed=False` and an explanatory message appended to `Finding.message` ("worker recovered before fix", "worker recovered or task drifted; no action taken", "owner recovered before fix").

**Scope:** within-process only. Cross-process races (a peer process writing between our stat and unlink) are out of scope and acknowledged in each ABC docstring.

The `GitHubBackend` implements the two worker/guard helpers against its in-memory dicts. Its `recover_stale_task_if_worker_dead` logs a warning and returns False — the doctor's `check_stale_tasks` only inspects FileBackend directories, so task recovery is a filesystem-only operation in v0.1.

The obsolete `_recover_stale_task` raw-file helper in `doctor.py` is removed.

## Test Plan

- [x] 9 new FileBackend unit tests (fresh/stale/missing per helper, plus drift variants for task recovery)
- [x] 3 new race tests in `test_doctor.py` that monkeypatch each helper to fire a concurrent mutation (late heartbeat, worker revival, owner re-register) before delegating to the real backend method
- [x] Existing positive-path tests still green (`test_stale_worker_fixed`, `test_stale_task_fixed`, `test_stale_guard_fixed`)
- [x] `pytest tests/ -x -q` — 1100 passed (was 1088; +12 new)
- [x] `ruff check .` — clean

## Acceptance Checks Verified

- `git grep 'backend\.deregister_worker\b' antfarm/core/doctor.py` — zero hits (replaced by `_if_stale`)
- `git grep '_recover_stale_task' antfarm/core/doctor.py` — zero hits (helper removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)