### PR TITLE
fix(server,tui): epoch-tagged SSE events + backoff in TUI consumer

### DIFF
--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -16,6 +16,7 @@ import logging
 import os
 import threading
 import time
+import uuid
 from datetime import UTC, datetime
 
 from fastapi import FastAPI, HTTPException, Query, Response
@@ -42,15 +43,16 @@ _autoscaler_instance = None
 # SSE event bus
 _event_queue: collections.deque = collections.deque(maxlen=1000)
 _event_counter: int = 0
+# UUID regenerated every time get_app() runs. Tags every emitted event so the
+# TUI can detect a colony restart and reset its cursor — see #306.
+_server_epoch: str = str(uuid.uuid4())
 
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def _emit_event(
-    event_type: str, task_id: str, detail: str = "", actor: str = "colony"
-) -> None:
+def _emit_event(event_type: str, task_id: str, detail: str = "", actor: str = "colony") -> None:
     """Append an event to the SSE event bus.
 
     Args:
@@ -66,6 +68,7 @@ def _emit_event(
     _event_queue.append(
         {
             "id": _event_counter,
+            "epoch": _server_epoch,
             "actor": actor,
             "type": event_type,
             "task_id": task_id,
@@ -372,7 +375,11 @@ def get_app(
     Returns:
         Configured FastAPI application.
     """
-    global _backend, _max_attempts
+    global _backend, _max_attempts, _server_epoch
+
+    # Fresh epoch per app instance — ensures tests and real colony restarts
+    # both present a new server identity to SSE clients (#306).
+    _server_epoch = str(uuid.uuid4())
 
     # Ensure a persisted colony id exists BEFORE any other code (including
     # the config.json read below) touches the file. colony_id() serializes
@@ -1014,12 +1021,23 @@ def get_app(
     @app.get("/events")
     def event_stream(
         after: int = Query(default=0, description="Cursor: return events with id > after"),
+        epoch: str = Query(
+            default="",
+            description=(
+                "Server epoch seen by the client. If non-empty and differs from the "
+                "current epoch, the cursor is reset to 0 (colony restart recovery)."
+            ),
+        ),
         timeout: float = Query(default=30.0, description="Max seconds to hold connection"),
     ):
         """Stream colony events (harvest, kickback, merge) as SSE."""
 
         def _generate():
-            cursor = after
+            # If client supplies a non-empty epoch that differs from ours, the
+            # client was talking to a prior server instance. Reset its cursor.
+            # Empty epoch = first connect; use `after` literally for backward
+            # compat with old TUIs that don't send the epoch parameter.
+            cursor = 0 if epoch and epoch != _server_epoch else after
             start = time.monotonic()
             try:
                 while True:
@@ -1035,6 +1053,16 @@ def get_app(
                 pass
 
         return StreamingResponse(_generate(), media_type="text/event-stream")
+
+    @app.get("/events/epoch")
+    def event_epoch():
+        """Return the server's current SSE epoch.
+
+        Used by clients (e.g. TUI) to learn the server identity without waiting
+        for the first event. If the epoch changes between two reads, the colony
+        restarted.
+        """
+        return {"epoch": _server_epoch}
 
     # ------------------------------------------------------------------
     # Status

--- a/antfarm/core/tui.py
+++ b/antfarm/core/tui.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import collections
 import json
+import logging
 import threading
 import time
 from dataclasses import dataclass, field
@@ -26,6 +27,8 @@ from rich.table import Table
 from rich.text import Text
 
 from antfarm.core.missions import is_infra_task
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -64,6 +67,8 @@ class AntfarmTUI:
 
         self._activity_events: collections.deque = collections.deque(maxlen=1000)
         self._activity_cursor: int = 0
+        self._activity_epoch: str = ""
+        self._activity_status: str = "connected"
         self._activity_lock = threading.Lock()
         self._activity_thread: threading.Thread | None = None
         if autostart_activity:
@@ -82,12 +87,51 @@ class AntfarmTUI:
         t.start()
 
     def _activity_loop(self) -> None:
-        """Consume the colony /events SSE stream, retrying silently on error."""
+        """Consume the colony /events SSE stream with exponential backoff.
+
+        Classifies errors and surfaces a human-readable status string to the
+        TUI header. Auth errors (401/403) are terminal; transport errors and
+        HTTP 5xx bump the backoff up to 30s. Successful polls reset backoff.
+        """
+        backoff = 1.0
+        max_backoff = 30.0
         while True:
             try:
                 self._poll_events_once()
-            except Exception:
-                time.sleep(1)
+            except httpx.HTTPStatusError as e:
+                status = e.response.status_code
+                if status in (401, 403):
+                    with self._activity_lock:
+                        self._activity_status = f"auth error ({status})"
+                    return
+                with self._activity_lock:
+                    self._activity_status = f"http {status} — retry in {backoff:.0f}s"
+                time.sleep(backoff)
+                backoff = min(backoff * 2, max_backoff)
+                continue
+            except (
+                httpx.ConnectError,
+                httpx.ReadTimeout,
+                httpx.ReadError,
+                httpx.RemoteProtocolError,
+                httpx.ConnectTimeout,
+            ):
+                with self._activity_lock:
+                    self._activity_status = f"reconnecting in {backoff:.0f}s"
+                time.sleep(backoff)
+                backoff = min(backoff * 2, max_backoff)
+                continue
+            except Exception as e:
+                with self._activity_lock:
+                    self._activity_status = f"error: {type(e).__name__}"
+                time.sleep(backoff)
+                backoff = min(backoff * 2, max_backoff)
+                continue
+            # Healthy return — stream closed at server timeout with no error.
+            with self._activity_lock:
+                self._activity_status = "connected"
+            backoff = 1.0
+            time.sleep(0.5)  # rate-limit empty-stream reconnects
 
     def _poll_events_once(self) -> None:
         """Open one streaming request to /events and ingest each event."""
@@ -95,7 +139,11 @@ class AntfarmTUI:
         with httpx.stream(
             "GET",
             f"{self.colony_url}/events",
-            params={"after": self._activity_cursor, "timeout": 5},
+            params={
+                "after": self._activity_cursor,
+                "epoch": self._activity_epoch,
+                "timeout": 5,
+            },
             headers=headers,
             timeout=30.0,
         ) as response:
@@ -109,8 +157,23 @@ class AntfarmTUI:
                 self._ingest_event(event)
 
     def _ingest_event(self, event: dict) -> None:
-        """Append an event to the activity deque and advance the cursor."""
+        """Append an event to the activity deque and advance the cursor.
+
+        If the event carries an epoch that differs from the one we've been
+        tracking, the colony restarted — zero the cursor so we replay events
+        from the new server's id=1 onward (#306).
+        """
         with self._activity_lock:
+            incoming_epoch = event.get("epoch", "")
+            if incoming_epoch and incoming_epoch != self._activity_epoch:
+                if self._activity_epoch:
+                    logger.info(
+                        "colony epoch changed %s -> %s; resetting cursor",
+                        self._activity_epoch,
+                        incoming_epoch,
+                    )
+                self._activity_epoch = incoming_epoch
+                self._activity_cursor = 0
             self._activity_events.append(event)
             eid = event.get("id", 0)
             if isinstance(eid, int) and eid > self._activity_cursor:
@@ -179,9 +242,7 @@ class AntfarmTUI:
 
         # Warnings panel — only present when there are warnings
         if snap.warnings:
-            layout["warnings"].update(
-                self._render_warnings(snap.warnings)
-            )
+            layout["warnings"].update(self._render_warnings(snap.warnings))
 
         # Header: banner (left) + colony summary (right) side by side
         layout["header"].split_row(
@@ -202,6 +263,14 @@ class AntfarmTUI:
         from antfarm.core import __version__
 
         banner.append(f"\n v{__version__}", style="bold bright_white")
+
+        # SSE consumer status — visible signal that the event stream is healthy
+        # or in backoff (#307). Read once under the lock to avoid torn strings.
+        with self._activity_lock:
+            stream_status = self._activity_status
+        if len(stream_status) > 60:
+            stream_status = stream_status[:59] + "…"
+        banner.append(f"\n stream: {stream_status}", style="dim")
         layout["header"]["banner"].update(Panel(banner))
 
         layout["header"]["summary"].update(

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1098,3 +1098,134 @@ def test_status_warnings_empty_when_reviewer_present(tmp_path):
     data = r.json()
     codes = [w.get("code") for w in data.get("warnings", [])]
     assert "no_reviewer_capacity" not in codes
+
+
+# ---------------------------------------------------------------------------
+# SSE epoch (#306) — server tags events + client can detect restarts
+# ---------------------------------------------------------------------------
+
+
+def _harvest_one_task(client, task_id="task-001"):
+    """Carry, forage, and harvest a task so _emit_event appends a harvested event."""
+    _carry(client, task_id=task_id)
+    task = _forage(client).json()
+    attempt_id = task["current_attempt"]
+    client.post(
+        f"/tasks/{task['id']}/harvest",
+        json={"attempt_id": attempt_id, "pr": "pr-1", "branch": "feat/x"},
+    )
+
+
+def _read_sse_events(client, query: str) -> list[dict]:
+    import json as json_mod
+
+    events: list[dict] = []
+    with client.stream("GET", f"/events{query}") as r:
+        assert r.status_code == 200
+        for line in r.iter_lines():
+            if line.startswith("data: "):
+                events.append(json_mod.loads(line[len("data: ") :]))
+    return events
+
+
+def test_events_include_epoch(tmp_path):
+    """Every streamed event carries a non-empty `epoch` field."""
+    from antfarm.core.backends.file import FileBackend
+
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend, enable_soldier=False)
+    client = TestClient(app)
+
+    _harvest_one_task(client)
+    events = _read_sse_events(client, "?after=0&timeout=0.2")
+
+    assert len(events) >= 1
+    for ev in events:
+        assert "epoch" in ev
+        assert ev["epoch"] == serve_mod._server_epoch
+        assert ev["epoch"]  # non-empty
+
+
+def test_events_epoch_match_filters_by_cursor(tmp_path):
+    """When epoch matches, `after` filters out already-seen events."""
+    from antfarm.core.backends.file import FileBackend
+
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend, enable_soldier=False)
+    client = TestClient(app)
+
+    # Emit 3 events so ids 1, 2, 3 exist
+    for i in range(3):
+        serve_mod._emit_event("harvested", f"task-{i}", "d")
+
+    current_epoch = serve_mod._server_epoch
+    events = _read_sse_events(client, f"?after=1&epoch={current_epoch}&timeout=0.3")
+
+    ids = [ev["id"] for ev in events]
+    assert ids == [2, 3]
+
+
+def test_events_epoch_mismatch_resets_cursor(tmp_path):
+    """Stale epoch signals a colony restart — cursor resets to 0."""
+    from antfarm.core.backends.file import FileBackend
+
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend, enable_soldier=False)
+    client = TestClient(app)
+
+    for i in range(3):
+        serve_mod._emit_event("harvested", f"task-{i}", "d")
+
+    events = _read_sse_events(client, "?after=2&epoch=stale-uuid&timeout=0.3")
+    ids = [ev["id"] for ev in events]
+    assert ids == [1, 2, 3]
+
+
+def test_events_empty_epoch_uses_after_literally(tmp_path):
+    """Empty epoch = old TUI or first connect — `after` is obeyed as-is."""
+    from antfarm.core.backends.file import FileBackend
+
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend, enable_soldier=False)
+    client = TestClient(app)
+
+    for i in range(3):
+        serve_mod._emit_event("harvested", f"task-{i}", "d")
+
+    events = _read_sse_events(client, "?epoch=&after=2&timeout=0.3")
+    ids = [ev["id"] for ev in events]
+    assert ids == [3]
+
+
+def test_events_epoch_endpoint(tmp_path):
+    """GET /events/epoch returns a parseable UUID under the `epoch` key."""
+    import uuid as _uuid
+
+    from antfarm.core.backends.file import FileBackend
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend, enable_soldier=False)
+    client = TestClient(app)
+
+    r = client.get("/events/epoch")
+    assert r.status_code == 200
+    payload = r.json()
+    assert set(payload.keys()) == {"epoch"}
+    epoch = payload["epoch"]
+    assert isinstance(epoch, str)
+    assert len(epoch) == 36
+    assert epoch.count("-") == 4
+    _uuid.UUID(epoch)  # raises if not a valid UUID
+    assert epoch == serve_mod._server_epoch

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -4,6 +4,8 @@ Tests classification, helpers, render methods, and pipeline bar
 without any live terminal or network I/O.
 """
 
+import threading
+
 import httpx
 from rich.panel import Panel
 from rich.table import Table
@@ -1147,3 +1149,130 @@ def test_autostart_activity_default_starts_thread(monkeypatch):
 def test_autostart_activity_false_does_not_start_thread():
     tui = AntfarmTUI(colony_url="http://localhost:7433", token=None, autostart_activity=False)
     assert tui._activity_thread is None
+
+
+# ---------------------------------------------------------------------------
+# Epoch-aware ingestion (#306)
+# ---------------------------------------------------------------------------
+
+
+def test_ingest_first_event_learns_epoch():
+    tui = _make_tui()
+    tui._ingest_event({"id": 1, "epoch": "E1", "type": "merged", "actor": "soldier"})
+    assert tui._activity_epoch == "E1"
+    assert tui._activity_cursor == 1
+
+
+def test_ingest_event_same_epoch_advances_cursor():
+    tui = _make_tui()
+    tui._ingest_event({"id": 1, "epoch": "E1", "type": "merged"})
+    tui._ingest_event({"id": 4, "epoch": "E1", "type": "harvested"})
+    assert tui._activity_epoch == "E1"
+    assert tui._activity_cursor == 4
+
+
+def test_ingest_event_different_epoch_resets_cursor():
+    tui = _make_tui()
+    tui._ingest_event({"id": 5, "epoch": "E1", "type": "merged"})
+    assert tui._activity_cursor == 5
+    tui._ingest_event({"id": 2, "epoch": "E2", "type": "harvested"})
+    assert tui._activity_epoch == "E2"
+    assert tui._activity_cursor == 2
+
+
+def test_ingest_event_missing_epoch_keeps_current():
+    tui = _make_tui()
+    tui._ingest_event({"id": 1, "epoch": "E1", "type": "merged"})
+    # Second event has no `epoch` key — backward compat with older servers.
+    tui._ingest_event({"id": 3, "type": "harvested"})
+    assert tui._activity_epoch == "E1"
+    assert tui._activity_cursor == 3
+
+
+# ---------------------------------------------------------------------------
+# Activity loop backoff (#307)
+# ---------------------------------------------------------------------------
+
+
+def test_activity_loop_backs_off_on_connect_error(monkeypatch):
+    """ConnectError repeats trigger exponential backoff starting at 1.0s."""
+    import contextlib
+
+    tui = _make_tui()
+    sleeps: list[float] = []
+    calls = {"n": 0}
+
+    def fake_sleep(s):
+        sleeps.append(s)
+
+    def always_fail():
+        calls["n"] += 1
+        if calls["n"] > 3:
+            raise SystemExit
+        raise httpx.ConnectError("down")
+
+    monkeypatch.setattr("antfarm.core.tui.time.sleep", fake_sleep)
+    monkeypatch.setattr(tui, "_poll_events_once", always_fail)
+
+    with contextlib.suppress(SystemExit):
+        tui._activity_loop()
+
+    assert sleeps == [1.0, 2.0, 4.0]
+    assert tui._activity_status.startswith("reconnecting")
+
+
+def test_activity_loop_stops_on_auth_error(monkeypatch):
+    """401/403 is terminal — the loop returns and records an auth status."""
+    tui = _make_tui()
+
+    class _FakeResponse:
+        def __init__(self, status_code: int):
+            self.status_code = status_code
+
+    poll_calls = {"n": 0}
+
+    def auth_fail():
+        poll_calls["n"] += 1
+        raise httpx.HTTPStatusError("unauthorized", request=None, response=_FakeResponse(401))
+
+    monkeypatch.setattr(tui, "_poll_events_once", auth_fail)
+
+    t = threading.Thread(target=tui._activity_loop, daemon=True)
+    t.start()
+    t.join(timeout=1.0)
+
+    assert not t.is_alive(), "loop should have returned on auth error"
+    assert poll_calls["n"] == 1, "auth error should terminate after a single poll"
+    assert tui._activity_status.startswith("auth error")
+
+
+def test_activity_loop_resets_backoff_on_success(monkeypatch):
+    """After a successful poll, backoff resets to 1.0s for the next failure."""
+    import contextlib
+
+    tui = _make_tui()
+    sleeps: list[float] = []
+    calls = {"n": 0}
+
+    def flaky_poll():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.ReadTimeout("slow")
+        if calls["n"] == 2:
+            return  # success
+        if calls["n"] == 3:
+            raise httpx.ReadTimeout("slow again")
+        # Bail out of the infinite loop once we have enough data.
+        raise SystemExit
+
+    def fake_sleep(s):
+        sleeps.append(s)
+
+    monkeypatch.setattr(tui, "_poll_events_once", flaky_poll)
+    monkeypatch.setattr("antfarm.core.tui.time.sleep", fake_sleep)
+
+    with contextlib.suppress(SystemExit):
+        tui._activity_loop()
+
+    # Failure -> backoff 1.0s; success -> 0.5s rate-limit; failure -> 1.0s again.
+    assert sleeps == [1.0, 0.5, 1.0]


### PR DESCRIPTION
## Summary

- **#306** — Colony restart silently froze the TUI event cursor. The server now stamps every SSE event with a `_server_epoch` UUID generated on each `get_app()`. The TUI tracks that epoch and zeros its cursor on mismatch, so a fresh colony is replayed from id=1 instead of being filtered out.
- **#307** — The TUI's `_activity_loop` used a bare `except Exception: time.sleep(1)`. It now classifies errors (transport vs HTTP vs auth vs unknown), applies exponential backoff 1s → 30s, and surfaces a human-readable `stream: <status>` line in the header banner. 401/403 terminates the loop.

A new `GET /events/epoch` endpoint is available for clients that want to learn the epoch without waiting for the first event.

## Test plan

- [x] `pytest tests/ -x -q` — 1112 passed (was 1100 before; 12 new tests covering the acceptance criteria).
- [x] `ruff check .` — clean.
- [x] `ruff format antfarm/core/tui.py antfarm/core/serve.py tests/test_tui.py tests/test_serve.py` — applied.
- [x] Empty-epoch query uses `after` literally (old TUIs keep working).
- [x] Event without `epoch` key does not reset the cursor (old servers keep working).
- [x] Auth-error path does not sleep; transport errors back off; success resets the backoff.
- [x] The single `except Exception` in `_activity_loop` sets `_activity_status` before continuing.

Closes #306
Closes #307