### PR TITLE
fix(backend,server): lock release_guard + _emit_event (Closes #308) (Closes #309)

### DIFF
--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -888,24 +888,28 @@ class FileBackend(TaskBackend):
     def release_guard(self, resource: str, owner: str) -> None:
         """Release a guard. Only the owner can release.
 
+        Thread-safe: serialized under self._lock so the exists/read/unlink
+        triple cannot race with a concurrent acquire or another release on
+        the same resource. Double-release is idempotent via
+        unlink(missing_ok=True). See #308.
+
         Raises:
             PermissionError: If the owner field doesn't match.
             FileNotFoundError: If no guard exists for this resource.
         """
         guard_path = self._guard_path(resource)
-        if not guard_path.exists():
-            raise FileNotFoundError(f"No guard exists for resource '{resource}'")
-
-        try:
-            data = json.loads(guard_path.read_text())
-        except (json.JSONDecodeError, FileNotFoundError) as exc:
-            raise FileNotFoundError(f"Guard file for '{resource}' is unreadable") from exc
-
-        if data.get("owner") != owner:
-            raise PermissionError(
-                f"Guard on '{resource}' is owned by '{data.get('owner')}', not '{owner}'"
-            )
-        guard_path.unlink()
+        with self._lock:
+            if not guard_path.exists():
+                raise FileNotFoundError(f"No guard exists for resource '{resource}'")
+            try:
+                data = json.loads(guard_path.read_text())
+            except (json.JSONDecodeError, FileNotFoundError) as exc:
+                raise FileNotFoundError(f"Guard file for '{resource}' is unreadable") from exc
+            if data.get("owner") != owner:
+                raise PermissionError(
+                    f"Guard on '{resource}' is owned by '{data.get('owner')}', not '{owner}'"
+                )
+            guard_path.unlink(missing_ok=True)
 
     def release_guard_if_owner_dead(self, resource: str) -> bool:
         """Atomically release the guard only if its owner is no longer alive.

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -43,6 +43,10 @@ _autoscaler_instance = None
 # SSE event bus
 _event_queue: collections.deque = collections.deque(maxlen=1000)
 _event_counter: int = 0
+# Serializes _event_counter increment + _event_queue append. Kept separate
+# from _lock so task-state mutations don't block event emission and vice
+# versa. See #309.
+_event_lock = threading.Lock()
 # UUID regenerated every time get_app() runs. Tags every emitted event so the
 # TUI can detect a colony restart and reset its cursor — see #306.
 _server_epoch: str = str(uuid.uuid4())
@@ -55,6 +59,10 @@ def _now_iso() -> str:
 def _emit_event(event_type: str, task_id: str, detail: str = "", actor: str = "colony") -> None:
     """Append an event to the SSE event bus.
 
+    Thread-safe: counter increment and queue append are performed under
+    _event_lock as one atomic step so ids are monotonic and unique under
+    concurrent emits. See #309.
+
     Args:
         event_type: Event kind (e.g. "harvested", "kickback", "merged").
         task_id: Task identifier the event relates to. Empty string if not task-scoped.
@@ -64,18 +72,19 @@ def _emit_event(event_type: str, task_id: str, detail: str = "", actor: str = "c
             inside colony HTTP handlers.
     """
     global _event_counter
-    _event_counter += 1
-    _event_queue.append(
-        {
-            "id": _event_counter,
-            "epoch": _server_epoch,
-            "actor": actor,
-            "type": event_type,
-            "task_id": task_id,
-            "detail": detail,
-            "ts": _now_iso(),
-        }
-    )
+    with _event_lock:
+        _event_counter += 1
+        _event_queue.append(
+            {
+                "id": _event_counter,
+                "epoch": _server_epoch,
+                "actor": actor,
+                "type": event_type,
+                "task_id": task_id,
+                "detail": detail,
+                "ts": _now_iso(),
+            }
+        )
 
 
 def _start_soldier_thread(backend: TaskBackend, data_dir: str) -> None:

--- a/tests/test_file_backend.py
+++ b/tests/test_file_backend.py
@@ -1531,3 +1531,130 @@ def test_release_guard_if_owner_dead_unlinks_when_owner_gone(backend: FileBacken
 def test_release_guard_if_owner_dead_missing_returns_false(backend: FileBackend) -> None:
     """A guard that does not exist returns False (no error)."""
     assert backend.release_guard_if_owner_dead("never-locked") is False
+
+
+# ---------------------------------------------------------------------------
+# release_guard concurrency / locking (issue #308)
+# ---------------------------------------------------------------------------
+
+
+def test_release_guard_concurrent_acquire_release(backend: FileBackend) -> None:
+    """release_guard must not race with a concurrent acquire on the same resource.
+
+    Pre-fix, exists/read/unlink ran without _lock — a second worker could observe
+    the guard as "present and reacquired by me" while the original release thread
+    was still about to unlink, producing the stale-unlink outcome where the guard
+    file is missing yet a worker believes it owns the lock. Post-fix, the only
+    valid final states are:
+
+      A) file absent  AND release returned cleanly
+      B) file present AND owned by worker-B AND release returned cleanly
+    """
+    backend.guard("res-c", "worker-A")
+
+    barrier = threading.Barrier(2)
+    errors: list[BaseException] = []
+    reacquired: list[bool] = []
+
+    def releaser() -> None:
+        try:
+            barrier.wait()
+            backend.release_guard("res-c", "worker-A")
+        except BaseException as e:  # noqa: BLE001
+            errors.append(e)
+
+    def reacquirer() -> None:
+        try:
+            barrier.wait()
+            deadline = time.time() + 2.0
+            got = False
+            while time.time() < deadline:
+                if backend.guard("res-c", "worker-B"):
+                    got = True
+                    break
+            reacquired.append(got)
+        except BaseException as e:  # noqa: BLE001
+            errors.append(e)
+
+    t1 = threading.Thread(target=releaser)
+    t2 = threading.Thread(target=reacquirer)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert errors == []
+    guard_path = backend._guard_path("res-c")
+    if guard_path.exists():
+        # Outcome B: reacquirer won — file must record worker-B (not stale worker-A)
+        data = json.loads(guard_path.read_text())
+        assert data.get("owner") == "worker-B", (
+            f"stale unlink race: file present but owner={data.get('owner')!r}"
+        )
+    else:
+        # Outcome A: release won and reacquirer either lost or the spin-loop
+        # ended after release with no successful reacquire. Both are valid.
+        assert True
+
+
+def test_release_guard_double_release_serialized(backend: FileBackend) -> None:
+    """Two concurrent release_guard calls by the same owner are serialized cleanly.
+
+    Under the new lock, the two calls run sequentially: exactly one finds the
+    guard present and unlinks it; the other observes the missing file and
+    raises FileNotFoundError (preserved invariant — see baseline test below).
+
+    Critically: neither call must raise an *unexpected* error (e.g. a race
+    between exists() and unlink() producing FileNotFoundError from os.unlink
+    rather than the explicit raise). unlink(missing_ok=True) is the
+    belt-and-suspenders defense against any future code path that mutates
+    guards outside the lock.
+    """
+    backend.guard("res-d", "worker-A")
+
+    barrier = threading.Barrier(2)
+    results: list[BaseException | None] = []
+    results_lock = threading.Lock()
+
+    def releaser() -> None:
+        try:
+            barrier.wait()
+            backend.release_guard("res-d", "worker-A")
+            with results_lock:
+                results.append(None)
+        except BaseException as e:  # noqa: BLE001
+            with results_lock:
+                results.append(e)
+
+    t1 = threading.Thread(target=releaser)
+    t2 = threading.Thread(target=releaser)
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    successes = [r for r in results if r is None]
+    failures = [r for r in results if r is not None]
+    assert len(successes) == 1, f"expected exactly one successful release, got {results!r}"
+    assert len(failures) == 1
+    assert isinstance(failures[0], FileNotFoundError), (
+        f"second release should raise FileNotFoundError (preserved invariant), got {failures[0]!r}"
+    )
+    assert not backend._guard_path("res-d").exists()
+
+
+def test_release_guard_permission_error_still_raises(backend: FileBackend) -> None:
+    """Baseline preservation: wrong-owner release still raises PermissionError."""
+    backend.guard("res-e", "worker-A")
+
+    with pytest.raises(PermissionError):
+        backend.release_guard("res-e", "worker-B")
+
+    # File should remain — wrong-owner release must not unlink.
+    assert backend._guard_path("res-e").exists()
+
+
+def test_release_guard_missing_guard_raises(backend: FileBackend) -> None:
+    """Baseline preservation: releasing a non-existent guard raises FileNotFoundError."""
+    with pytest.raises(FileNotFoundError):
+        backend.release_guard("never-locked", "worker-A")

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1229,3 +1229,91 @@ def test_events_epoch_endpoint(tmp_path):
     assert epoch.count("-") == 4
     _uuid.UUID(epoch)  # raises if not a valid UUID
     assert epoch == serve_mod._server_epoch
+
+
+# ---------------------------------------------------------------------------
+# _emit_event concurrency / locking (issue #309)
+# ---------------------------------------------------------------------------
+
+
+def test_emit_event_concurrent_ids_are_unique():
+    """Concurrent emits must produce strictly unique, monotonically-assigned ids.
+
+    Pre-fix, the `_event_counter += 1` and queue append were not serialized,
+    so two threads could read the same counter value, both increment to N+1,
+    and both append events with id=N+1. That breaks SSE cursor semantics
+    (after=N+1 would skip a real event). 10 threads x 100 emits = 1000 ids;
+    the deque has maxlen=1000, so all retained.
+    """
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    n_threads = 10
+    n_per_thread = 100
+    barrier = threading.Barrier(n_threads)
+    errors: list[BaseException] = []
+
+    def emit_burst() -> None:
+        try:
+            barrier.wait()
+            for i in range(n_per_thread):
+                serve_mod._emit_event("burst", f"task-{i}", "d")
+        except BaseException as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=emit_burst) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    assert serve_mod._event_counter == n_threads * n_per_thread
+    queued = list(serve_mod._event_queue)
+    assert len(queued) == n_threads * n_per_thread
+    ids = [e["id"] for e in queued]
+    assert len(set(ids)) == len(ids), "duplicate event ids under concurrent emits"
+    assert queued[-1]["id"] == n_threads * n_per_thread
+
+
+def test_emit_event_serial_still_works():
+    """Baseline preservation: serial emits still yield contiguous ids."""
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    serve_mod._emit_event("a", "t-1", "")
+    serve_mod._emit_event("b", "t-2", "")
+    serve_mod._emit_event("c", "t-3", "")
+
+    assert serve_mod._event_counter == 3
+    ids = [e["id"] for e in serve_mod._event_queue]
+    assert ids == [1, 2, 3]
+
+
+def test_emit_event_ordering_preserved_under_concurrency():
+    """Insertion order in the deque must be strictly monotonic.
+
+    Counter increment + queue append are inside the same critical section,
+    so the queue's recorded order matches the assigned id order.
+    """
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    n_threads = 4
+    n_per_thread = 50
+    barrier = threading.Barrier(n_threads)
+
+    def emit_burst() -> None:
+        barrier.wait()
+        for i in range(n_per_thread):
+            serve_mod._emit_event("burst", f"task-{i}", "d")
+
+    threads = [threading.Thread(target=emit_burst) for _ in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    ids = [e["id"] for e in serve_mod._event_queue]
+    assert len(set(ids)) == len(ids)
+    assert ids == sorted(ids), "deque insertion order does not match id order"


### PR DESCRIPTION
## Summary

Two compact concurrency fixes, both in-place, no public surface changes.

### #308 — `FileBackend.release_guard` race

`release_guard` ran `exists() → read() → unlink()` without holding `self._lock`. A concurrent `guard()` acquire on the same resource could slot in between `exists()` and `unlink()`, so the releaser would delete a guard that another worker had just legitimately reacquired — leaving a stale "owned but no file" state and enabling a double-acquire down the road.

**Fix:** wrap the entire body in `with self._lock:` so the exists/read/unlink triple is atomic with respect to other guard mutations. Switch `unlink()` to `unlink(missing_ok=True)` as belt-and-suspenders defense against any future code path that mutates guards outside the lock.

`PermissionError` (wrong owner) and `FileNotFoundError` (missing guard) invariants preserved exactly. Lock is plain `threading.Lock` and the body makes no nested backend calls — no reentrancy risk.

### #309 — `_emit_event` counter race

`_emit_event` did `_event_counter += 1` then `_event_queue.append(...)` with no serialization. Two threads could read the same counter value, both increment to N+1, and both append events with `id=N+1`. That breaks SSE cursor semantics — `after=N+1` would silently skip a real event.

**Fix:** add a dedicated `_event_lock = threading.Lock()` next to the `_event_queue` / `_event_counter` globals. Wrap the counter increment + queue append inside one critical section. Lock is intentionally separate from the colony `_lock` so task-state mutations don't block event emission and vice versa. The #306 `epoch` field is tagged inside the same critical section.

## Files

- `antfarm/core/backends/file.py` — `release_guard` body now under `self._lock`; `unlink(missing_ok=True)`.
- `antfarm/core/serve.py` — new `_event_lock` global; `_emit_event` body wrapped under it.
- `tests/test_file_backend.py` — 4 new tests.
- `tests/test_serve.py` — 3 new tests.

## Test Plan

New tests:

**test_file_backend.py (#308):**
- `test_release_guard_concurrent_acquire_release` — concurrent release-of-A + reacquire-as-B; final state is either (file absent + release returned) or (file present, owner=B + release returned). Stale "file absent yet release returned while B believes it owns the lock" outcome is impossible.
- `test_release_guard_double_release_serialized` — two concurrent releases by the same owner: exactly one wins, the other raises `FileNotFoundError`. Both serialize cleanly.
- `test_release_guard_permission_error_still_raises` — baseline preservation for `PermissionError`.
- `test_release_guard_missing_guard_raises` — baseline preservation for `FileNotFoundError`.

**test_serve.py (#309):**
- `test_emit_event_concurrent_ids_are_unique` — 10 threads × 100 emits via `Barrier`. Asserts counter == 1000, all 1000 ids unique, last id == 1000.
- `test_emit_event_serial_still_works` — baseline: 3 serial emits → ids `[1, 2, 3]`.
- `test_emit_event_ordering_preserved_under_concurrency` — 4 × 50 emits; deque insertion order is strictly monotonic in id.

Verification:

- [x] `pytest tests/ -x -q` — **1136 passed** (143 → 150 in touched modules; +7 tests).
- [x] `ruff check .` — clean.
- [x] No public signatures, exception types, or HTTP status mappings changed.

## Related Issues

Closes #308
Closes #309