### PR TITLE
fix(worker,cli): configurable agent_timeout for subprocess.run

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -426,6 +426,16 @@ def worker():
         "0 = exit on first empty."
     ),
 )
+@click.option(
+    "--agent-timeout",
+    type=float,
+    default=7200.0,
+    show_default=True,
+    help=(
+        "Seconds before the agent subprocess is killed. Default 2h. "
+        "Set lower for tight loops, higher for long missions."
+    ),
+)
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def worker_start(
@@ -439,6 +449,7 @@ def worker_start(
     capabilities: str | None,
     poll_interval: float,
     max_empty_polls: int | None,
+    agent_timeout: float,
     colony_url: str,
     token: str | None,
 ):
@@ -466,6 +477,7 @@ def worker_start(
         integration_branch=integration_branch,
         poll_interval=poll_interval,
         max_empty_polls=max_empty_polls,
+        agent_timeout=agent_timeout,
         capabilities=caps,
         token=token,
     )

--- a/antfarm/core/worker.py
+++ b/antfarm/core/worker.py
@@ -232,6 +232,12 @@ class WorkerRuntime:
         heartbeat_interval: Seconds between heartbeat posts (default 30).
         poll_interval: Seconds to sleep between empty forage polls (default 30).
             Must be > 0; non-positive values raise ValueError.
+        agent_timeout: Seconds before the agent subprocess is killed by
+            ``subprocess.run``. Default 7200 (2h). Must be > 0; non-positive
+            values raise ValueError. On timeout the worker synthesizes an
+            ``AgentResult(returncode=-15)`` so the existing failure pipeline
+            classifies it as ``FailureType.AGENT_TIMEOUT`` and the standard
+            retry policy applies (see #301).
         max_empty_polls: Max consecutive empty forages before the worker exits.
             When None (default), the role-based default applies:
             reviewer=10, builder=5, planner=0 (exit on first empty). An explicit
@@ -252,6 +258,7 @@ class WorkerRuntime:
         integration_branch: str = "main",
         heartbeat_interval: float = 30.0,
         poll_interval: float = 30.0,
+        agent_timeout: float = 7200.0,
         max_empty_polls: int | None = None,
         capabilities: list[str] | None = None,
         client: httpx.Client | None = None,
@@ -261,12 +268,17 @@ class WorkerRuntime:
             raise ValueError(
                 f"poll_interval must be > 0, got {poll_interval}"
             )
+        if agent_timeout <= 0:
+            raise ValueError(
+                f"agent_timeout must be > 0, got {agent_timeout}"
+            )
         self.worker_id = f"{node_id}/{name}"
         self.node_id = node_id
         self.agent_type = agent_type
         self.workspace_root = workspace_root
         self.heartbeat_interval = heartbeat_interval
         self.poll_interval = poll_interval
+        self.agent_timeout = agent_timeout
         self.capabilities = capabilities or []
         self._token = token
         self._data_dir = os.environ.get("ANTFARM_DATA_DIR", ".antfarm")
@@ -795,12 +807,25 @@ class WorkerRuntime:
 
         Selects the command based on agent_type. Never uses shell=True.
 
+        The subprocess is bounded by ``self.agent_timeout`` (default 7200s/2h,
+        overridable via ``--agent-timeout`` on ``worker start``). On timeout
+        ``subprocess.TimeoutExpired`` is caught and a synthetic
+        ``AgentResult(returncode=-15, ...)`` is returned so ``classify_failure``
+        maps it to ``FailureType.AGENT_TIMEOUT`` and the standard retry policy
+        runs. Without this guard the worker would block forever while the
+        background heartbeat thread kept reporting it healthy (#301).
+
+        Note: Python's stdlib only kills the direct child process on timeout.
+        Orphaned grandchild processes are a known v0.1 limitation and are not
+        addressed here.
+
         Args:
             task: Task dict from the colony (contains id, spec, etc.).
             workspace: Absolute path to the git worktree for this attempt.
 
         Returns:
             AgentResult with returncode, stdout, stderr, and branch name.
+            Returncode is -15 if the subprocess timed out.
         """
         spec = task.get("spec", "")
         title = task.get("title", "")
@@ -930,14 +955,41 @@ class WorkerRuntime:
         if self._token:
             env["ANTFARM_TOKEN"] = self._token
 
-        proc = subprocess.run(
-            cmd,
-            cwd=workspace,
-            capture_output=True,
-            text=True,
-            env=env,
-            input=prompt if use_stdin else None,
-        )
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=workspace,
+                capture_output=True,
+                text=True,
+                env=env,
+                input=prompt if use_stdin else None,
+                timeout=self.agent_timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            logger.error(
+                "agent subprocess timed out task_id=%s worker_id=%s after=%.0fs",
+                task["id"],
+                self.worker_id,
+                self.agent_timeout,
+            )
+            # TimeoutExpired.stdout/stderr may be bytes or str depending on
+            # whether text=True was honored before the timeout fired. Normalize.
+            raw_stdout = exc.stdout or ""
+            stdout = (
+                raw_stdout
+                if isinstance(raw_stdout, str)
+                else raw_stdout.decode("utf-8", "replace")
+            )
+            raw_stderr = exc.stderr or ""
+            stderr_partial = (
+                raw_stderr
+                if isinstance(raw_stderr, str)
+                else raw_stderr.decode("utf-8", "replace")
+            )
+            stderr = f"[TIMEOUT after {self.agent_timeout:.0f}s] {stderr_partial}"
+            return AgentResult(
+                returncode=-15, stdout=stdout, stderr=stderr, branch=branch
+            )
 
         return AgentResult(
             returncode=proc.returncode,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -955,6 +955,54 @@ def test_worker_start_poll_flags_flow_through():
     assert captured_kwargs["max_empty_polls"] == 3
 
 
+def test_worker_start_agent_timeout_flag_propagates():
+    """--agent-timeout is plumbed through to WorkerRuntime; default = 7200s."""
+    runner = CliRunner()
+
+    # Explicit override
+    captured: dict = {}
+
+    def fake_worker_runtime(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with patch("antfarm.core.worker.WorkerRuntime", side_effect=fake_worker_runtime):
+        result = runner.invoke(
+            main,
+            [
+                "worker", "start",
+                "--agent", "claude-code",
+                "--node", "n1",
+                "--agent-timeout", "60",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert captured["agent_timeout"] == 60.0
+
+    # Default when flag omitted
+    captured_default: dict = {}
+
+    def fake_worker_runtime_default(**kwargs):
+        captured_default.update(kwargs)
+        return MagicMock()
+
+    with patch(
+        "antfarm.core.worker.WorkerRuntime", side_effect=fake_worker_runtime_default
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "worker", "start",
+                "--agent", "claude-code",
+                "--node", "n1",
+                "--colony-url", "http://localhost:7433",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    assert captured_default["agent_timeout"] == 7200.0
+
+
 # ---------------------------------------------------------------------------
 # plan --carry dependency resolution (#93)
 # ---------------------------------------------------------------------------

--- a/tests/test_review_execution.py
+++ b/tests/test_review_execution.py
@@ -573,6 +573,7 @@ def _make_worker_with_fake_colony(fake: _FakeColony) -> WorkerRuntime:
     runtime.agent_type = "claude-code"
     runtime.workspace_root = "/tmp/ws"
     runtime.heartbeat_interval = 30.0
+    runtime.agent_timeout = 7200.0
     runtime.capabilities = ["review"]
     runtime._token = None
     runtime._last_task_id = None

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1832,3 +1832,207 @@ def test_worker_skips_merged_deps(tc, runtime):
     _, kwargs = runtime.workspace_mgr.create.call_args
     # Merged dep must NOT be included — falls back to integration
     assert kwargs.get("dep_branches") == []
+
+
+# ---------------------------------------------------------------------------
+# #301: agent_timeout — bound subprocess.run so a hung agent can't block forever
+# ---------------------------------------------------------------------------
+
+
+def test_agent_timeout_default_is_2_hours(tmp_path, http_client):
+    """WorkerRuntime defaults agent_timeout to 7200s (2 hours)."""
+    rt = WorkerRuntime(
+        colony_url="http://test",
+        node_id="node-1",
+        name="worker-default-timeout",
+        agent_type="generic",
+        workspace_root=str(tmp_path / "workspaces"),
+        repo_path=str(tmp_path),
+        integration_branch="main",
+        heartbeat_interval=999.0,
+        client=http_client,
+    )
+    assert rt.agent_timeout == 7200.0
+
+
+def test_agent_timeout_rejects_non_positive(tmp_path, http_client):
+    """agent_timeout must be > 0; non-positive raises ValueError."""
+    with pytest.raises(ValueError, match="agent_timeout must be > 0"):
+        WorkerRuntime(
+            colony_url="http://test",
+            node_id="node-1",
+            name="worker-bad-timeout",
+            agent_type="generic",
+            workspace_root=str(tmp_path / "workspaces"),
+            repo_path=str(tmp_path),
+            integration_branch="main",
+            heartbeat_interval=999.0,
+            client=http_client,
+            agent_timeout=0,
+        )
+
+
+def test_launch_agent_passes_timeout_to_subprocess(tmp_path, http_client):
+    """_launch_agent forwards self.agent_timeout to subprocess.run."""
+    import subprocess
+    import threading
+    from unittest.mock import patch
+
+    rt = WorkerRuntime(
+        colony_url="http://test",
+        node_id="node-1",
+        name="worker-tx",
+        agent_type="generic",
+        workspace_root=str(tmp_path / "workspaces"),
+        repo_path=str(tmp_path),
+        integration_branch="main",
+        heartbeat_interval=999.0,
+        agent_timeout=42.0,
+        client=http_client,
+    )
+    rt.workspace_mgr.create = MagicMock(return_value=str(tmp_path / "ws"))
+
+    task = {
+        "id": "task-tx-001",
+        "title": "Test",
+        "spec": "do",
+        "current_attempt": 1,
+    }
+
+    captured_kwargs: dict = {}
+    main_thread = threading.current_thread()
+
+    def fake_run(cmd, **kwargs):
+        if threading.current_thread() is main_thread:
+            captured_kwargs.update(kwargs)
+        return MagicMock(returncode=0, stdout="ok", stderr="")
+
+    with patch.object(subprocess, "run", side_effect=fake_run):
+        rt._launch_agent(task, str(tmp_path / "ws"))
+
+    assert captured_kwargs.get("timeout") == 42.0
+
+
+def test_launch_agent_normal_exit_not_affected(tmp_path, http_client):
+    """A normal subprocess exit returns AgentResult unchanged (regression
+    guard: timeout plumbing must not alter the success path)."""
+    import subprocess
+    import threading
+    from unittest.mock import patch
+
+    rt = WorkerRuntime(
+        colony_url="http://test",
+        node_id="node-1",
+        name="worker-ok",
+        agent_type="generic",
+        workspace_root=str(tmp_path / "workspaces"),
+        repo_path=str(tmp_path),
+        integration_branch="main",
+        heartbeat_interval=999.0,
+        client=http_client,
+    )
+    rt.workspace_mgr.create = MagicMock(return_value=str(tmp_path / "ws"))
+
+    task = {
+        "id": "task-ok-001",
+        "title": "Test",
+        "spec": "do",
+        "current_attempt": 1,
+    }
+
+    captured_kwargs: dict = {}
+    main_thread = threading.current_thread()
+
+    def fake_run(cmd, **kwargs):
+        if threading.current_thread() is main_thread:
+            captured_kwargs.update(kwargs)
+        return MagicMock(returncode=0, stdout="ok", stderr="")
+
+    with patch.object(subprocess, "run", side_effect=fake_run):
+        result = rt._launch_agent(task, str(tmp_path / "ws"))
+
+    assert result.returncode == 0
+    assert result.stdout == "ok"
+    assert result.stderr == ""
+    assert captured_kwargs.get("timeout") == rt.agent_timeout
+
+
+def test_launch_agent_timeout_returns_failure_result(tmp_path, http_client):
+    """TimeoutExpired → synthetic AgentResult(returncode=-15) classifiable
+    as AGENT_TIMEOUT."""
+    import subprocess
+    import threading
+    from unittest.mock import patch
+
+    from antfarm.core.worker import classify_failure
+
+    rt = WorkerRuntime(
+        colony_url="http://test",
+        node_id="node-1",
+        name="worker-timeout",
+        agent_type="generic",
+        workspace_root=str(tmp_path / "workspaces"),
+        repo_path=str(tmp_path),
+        integration_branch="main",
+        heartbeat_interval=999.0,
+        agent_timeout=0.5,
+        client=http_client,
+    )
+    rt.workspace_mgr.create = MagicMock(return_value=str(tmp_path / "ws"))
+
+    task = {
+        "id": "task-timeout-001",
+        "title": "Hangs",
+        "spec": "sleep forever",
+        "current_attempt": 1,
+    }
+
+    main_thread = threading.current_thread()
+
+    def fake_run(cmd, **kwargs):
+        if threading.current_thread() is main_thread:
+            raise subprocess.TimeoutExpired(
+                cmd=cmd, timeout=0.5, output="partial-stdout", stderr="hung-stderr"
+            )
+        return MagicMock(returncode=0, stdout="bg", stderr="")
+
+    with patch.object(subprocess, "run", side_effect=fake_run):
+        result = rt._launch_agent(task, str(tmp_path / "ws"))
+
+    assert result.returncode == -15
+    assert "[TIMEOUT after" in result.stderr
+    assert "hung-stderr" in result.stderr
+    assert result.stdout == "partial-stdout"
+    # The standard failure pipeline must classify this as AGENT_TIMEOUT,
+    # which is the whole point — retry policy then drives recovery.
+    assert (
+        classify_failure(result.returncode, result.stderr, result.stdout)
+        == FailureType.AGENT_TIMEOUT
+    )
+
+
+def test_process_one_task_handles_timeout(tc, runtime):
+    """A timed-out agent surfaces as a tagged trail entry + FAILURE_RECORD,
+    the loop proceeds (returns True), and the task is NOT harvested."""
+    _carry(tc, task_id="task-timeout-loop")
+
+    def timeout_agent(task, workspace) -> AgentResult:
+        branch = f"feat/{task['id']}-{task['current_attempt']}"
+        return AgentResult(
+            returncode=-15,
+            stdout="",
+            stderr="[TIMEOUT after 1s] hung",
+            branch=branch,
+        )
+
+    runtime._launch_agent = timeout_agent
+    had_task = runtime._process_one_task()
+    assert had_task is True
+
+    detail = tc.get("/tasks/task-timeout-loop").json()
+    # Task must NOT be harvested — it stays active so doctor/retry handles it.
+    assert detail["status"] != "done"
+
+    trail_msgs = [entry["message"] for entry in detail.get("trail", [])]
+    assert any("[agent_timeout]" in m for m in trail_msgs)
+    assert any("[FAILURE_RECORD]" in m for m in trail_msgs)


### PR DESCRIPTION
## Summary
- Adds an `agent_timeout` kwarg (default **7200s / 2h**) to `WorkerRuntime` and threads it into `subprocess.run` inside `_launch_agent`.
- Catches `subprocess.TimeoutExpired` and returns a synthetic `AgentResult(returncode=-15, stderr="[TIMEOUT after Ns] ...")` so the existing `classify_failure` pipeline maps it to `FailureType.AGENT_TIMEOUT` and the standard retry policy drives recovery — no new kickback plumbing needed.
- Exposes it as `worker start --agent-timeout` on the CLI.

Without this, a hung agent (e.g., model API stall, runaway shell) blocks the worker forever while the background heartbeat thread keeps reporting it healthy. The existing `check_stuck_workers` operator warning (300s default) and this hard kill (7200s default) layer cleanly: warn early, kill late.

Known limitation (called out in the `_launch_agent` docstring): stdlib only kills the direct child process; orphaned grandchildren are a v0.1 artifact and are not addressed here.

## Test plan
- [x] `pytest tests/ -x -q` — 1143 passed (was 1136; +7 new tests).
- [x] `ruff check .` — clean.
- New tests:
  - `test_agent_timeout_default_is_2_hours`
  - `test_agent_timeout_rejects_non_positive`
  - `test_launch_agent_passes_timeout_to_subprocess`
  - `test_launch_agent_normal_exit_not_affected` (regression guard for success path)
  - `test_launch_agent_timeout_returns_failure_result` (synthetic -15 + classify_failure → AGENT_TIMEOUT)
  - `test_process_one_task_handles_timeout` (loop continues, trail tagged, no harvest)
  - `test_worker_start_agent_timeout_flag_propagates` (CLI override + default)

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)