### PR TITLE
fix(soldier,server): preserve data dir under git clean + gitignore warning

### DIFF
--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -87,6 +87,45 @@ def _emit_event(event_type: str, task_id: str, detail: str = "", actor: str = "c
         )
 
 
+def _warn_if_data_dir_not_gitignored(repo_path: str, data_dir_name: str) -> None:
+    """Warn operator if target repo's .gitignore doesn't list the colony data dir.
+
+    Naive matcher — line-scan for literal variants. False negatives are benign
+    (the -e flag on git clean still protects state); false positives just skip
+    an unneeded warning.
+    """
+    from pathlib import Path
+
+    gitignore = Path(repo_path) / ".gitignore"
+    if not gitignore.exists():
+        has_entry = False
+    else:
+        try:
+            lines = gitignore.read_text().splitlines()
+        except OSError:
+            return  # unreadable — skip
+        stripped = {
+            line.strip().lstrip("/").rstrip("/")
+            for line in lines
+            if line.strip() and not line.strip().startswith("#")
+        }
+        has_entry = data_dir_name.lstrip("/").rstrip("/") in stripped
+    if not has_entry:
+        logger.warning(
+            "target repo %s lacks %s in .gitignore — soldier's git clean "
+            "now excludes it via -e, but consider adding the entry for "
+            "belt-and-suspenders.",
+            repo_path,
+            data_dir_name,
+        )
+        _emit_event(
+            "data_dir_not_gitignored",
+            "",
+            f"repo={repo_path} data_dir={data_dir_name}",
+            actor="soldier",
+        )
+
+
 def _start_soldier_thread(backend: TaskBackend, data_dir: str) -> None:
     """Start the Soldier as a daemon thread (singleton guard)."""
     global _soldier_thread, _soldier_status
@@ -102,11 +141,19 @@ def _start_soldier_thread(backend: TaskBackend, data_dir: str) -> None:
     # Resolve: if data_dir is inside a git repo, use its parent.
     data_path = Path(data_dir).resolve()
     repo_path = str(data_path.parent) if data_path.name == ".antfarm" else str(data_path)
+    data_dir_name = data_path.name  # e.g. ".antfarm"
+
+    _warn_if_data_dir_not_gitignored(repo_path, data_dir_name)
 
     # Explicit require_review=True guards against silent regressions like
     # issue #284 — if the Soldier default ever changes, production still
     # runs with review enabled.
-    soldier = Soldier.from_backend(backend, repo_path=repo_path, require_review=True)
+    soldier = Soldier.from_backend(
+        backend,
+        repo_path=repo_path,
+        require_review=True,
+        data_dir_name=data_dir_name,
+    )
 
     def _soldier_loop():
         global _soldier_status

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -158,6 +158,7 @@ class Soldier:
         poll_interval: float = 30.0,
         require_review: bool = False,
         poll_external_merges: bool = True,
+        data_dir_name: str = ".antfarm",
         client=None,
     ):
         self.colony = ColonyClient(colony_url, client=client)
@@ -168,6 +169,11 @@ class Soldier:
         self.poll_interval = poll_interval
         self.require_review = require_review
         self.poll_external_merges = poll_external_merges
+        # Passed as -e <data_dir_name> to git clean so the colony's runtime
+        # state under repo_path is never wiped mid-mission (#323). Target repos
+        # whose .gitignore doesn't list the data dir were being reset to empty
+        # by _cleanup / _force_clean_repo.
+        self.data_dir_name = data_dir_name
         self.last_failure_reason = ""
         # Event cursor for /events SSE stream. In-memory only; never persists.
         self._event_cursor: int = 0
@@ -1128,8 +1134,11 @@ class Soldier:
            If the origin ref is missing (no fetch yet, or disconnected),
            fall back silently to ``git reset --hard HEAD`` so the routine
            still completes instead of failing hard.
-        4. ``git clean -fd`` — remove untracked files/dirs. NOTE: intentionally
-           NOT ``-fdx`` — we preserve ignored paths like ``.venv``.
+        4. ``git clean -fd -e <data_dir_name>`` — remove untracked files/dirs.
+           NOTE: intentionally NOT ``-fdx`` — we preserve ignored paths like
+           ``.venv``. The ``-e`` excludes the colony's data dir (default
+           ``.antfarm``) so target repos without a matching ``.gitignore``
+           entry don't lose runtime state mid-mission (#323).
         5. ``git branch -D antfarm/temp-merge`` — best-effort; tolerated if
            the branch does not exist.
 
@@ -1166,7 +1175,7 @@ class Soldier:
                     check=True,
                 )
             subprocess.run(
-                ["git", "clean", "-fd"],
+                ["git", "clean", "-fd", "-e", self.data_dir_name],
                 cwd=self.repo_path,
                 capture_output=True,
                 check=True,
@@ -1240,9 +1249,11 @@ class Soldier:
             capture_output=True,
             check=False,
         )
-        # 5) Remove untracked files and directories.
+        # 5) Remove untracked files and directories. -e excludes the colony's
+        # data dir so target repos without a matching .gitignore entry don't
+        # lose runtime state (#323).
         subprocess.run(
-            ["git", "clean", "-fd"],
+            ["git", "clean", "-fd", "-e", self.data_dir_name],
             cwd=self.repo_path,
             capture_output=True,
             check=False,
@@ -1792,6 +1803,7 @@ class Soldier:
         poll_interval: float = 30.0,
         require_review: bool = True,
         poll_external_merges: bool = True,
+        data_dir_name: str = ".antfarm",
     ) -> Soldier:
         """Create a Soldier that talks directly to a TaskBackend.
 
@@ -1809,6 +1821,7 @@ class Soldier:
         instance.poll_interval = poll_interval
         instance.require_review = require_review
         instance.poll_external_merges = poll_external_merges
+        instance.data_dir_name = data_dir_name
         instance.last_failure_reason = ""
         instance._event_cursor = 0
         return instance

--- a/tests/test_soldier.py
+++ b/tests/test_soldier.py
@@ -3239,3 +3239,206 @@ def test_cleanup_emits_diagnostic_when_incomplete(soldier_env, monkeypatch, tmp_
 
     incomplete = [e for e in events if e[0] == "cleanup_incomplete"]
     assert incomplete, f"expected cleanup_incomplete event, got {events}"
+
+
+# ---------------------------------------------------------------------------
+# #323: preserve colony data dir under git clean
+# ---------------------------------------------------------------------------
+
+
+def test_cleanup_preserves_data_dir_when_not_gitignored(soldier_env):
+    """_cleanup must not wipe the configured data dir, even when target repo's
+    .gitignore doesn't list it (#323)."""
+    soldier = soldier_env["soldier"]
+    repo = soldier_env["repo_path"]
+
+    # soldier_env does not create a .gitignore — this matches the bug scenario
+    # where a fresh target repo has no entry for .antfarm/.
+    import os
+
+    os.makedirs(f"{repo}/.antfarm/tasks", exist_ok=True)
+    with open(f"{repo}/.antfarm/tasks/t.json", "w") as f:
+        f.write('{"id": "t-323"}')
+
+    soldier._cleanup()
+
+    assert os.path.exists(f"{repo}/.antfarm/tasks/t.json"), (
+        "colony data dir was wiped by git clean -fd in _cleanup (#323)"
+    )
+    with open(f"{repo}/.antfarm/tasks/t.json") as f:
+        assert f.read() == '{"id": "t-323"}'
+
+
+def test_force_clean_repo_preserves_data_dir_when_not_gitignored(soldier_env):
+    """_force_clean_repo must not wipe the configured data dir. Other untracked
+    files must still be removed (confirming clean still runs)."""
+    soldier = soldier_env["soldier"]
+    repo = soldier_env["repo_path"]
+
+    import os
+
+    os.makedirs(f"{repo}/.antfarm/tasks", exist_ok=True)
+    with open(f"{repo}/.antfarm/tasks/t.json", "w") as f:
+        f.write('{"id": "t-323-force"}')
+
+    # Force the full destructive recovery code path: tracked dirty + untracked.
+    with open(f"{repo}/README.md", "w") as f:
+        f.write("dirty tracked change\n")
+    with open(f"{repo}/junk.txt", "w") as f:
+        f.write("untracked noise\n")
+
+    assert soldier._force_clean_repo() is True
+
+    # Data dir survived, other untracked files removed.
+    assert os.path.exists(f"{repo}/.antfarm/tasks/t.json")
+    assert not os.path.exists(f"{repo}/junk.txt")
+
+
+def test_cleanup_with_custom_data_dir_name(soldier_env):
+    """A soldier configured with a custom data_dir_name protects only that dir."""
+    repo = soldier_env["repo_path"]
+
+    # Build a soldier with a custom exclude dir.
+    soldier = Soldier(
+        colony_url="http://testserver",
+        repo_path=repo,
+        integration_branch="dev",
+        test_command=["true"],
+        poll_interval=0.0,
+        data_dir_name="custom-dir",
+        client=soldier_env["soldier"].colony._client,
+    )
+
+    import os
+
+    os.makedirs(f"{repo}/custom-dir", exist_ok=True)
+    with open(f"{repo}/custom-dir/state.json", "w") as f:
+        f.write("{}")
+
+    os.makedirs(f"{repo}/.antfarm/tasks", exist_ok=True)
+    with open(f"{repo}/.antfarm/tasks/t.json", "w") as f:
+        f.write("{}")
+
+    soldier._cleanup()
+
+    # Configured dir survives; un-configured .antfarm is cleaned.
+    assert os.path.exists(f"{repo}/custom-dir/state.json")
+    assert not os.path.exists(f"{repo}/.antfarm/tasks/t.json")
+
+
+def test_cleanup_still_removes_other_untracked_files(soldier_env):
+    """With the default data_dir_name, untracked files outside it still clean."""
+    soldier = soldier_env["soldier"]
+    repo = soldier_env["repo_path"]
+
+    import os
+
+    with open(f"{repo}/some-random.txt", "w") as f:
+        f.write("should be removed\n")
+
+    soldier._cleanup()
+
+    assert not os.path.exists(f"{repo}/some-random.txt")
+
+
+def test_start_soldier_thread_passes_data_dir_name(tmp_path, monkeypatch):
+    """_start_soldier_thread must propagate data_dir_name to Soldier.from_backend."""
+    from antfarm.core import serve as serve_mod
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+
+    captured: dict = {}
+
+    class _FakeSoldier:
+        @classmethod
+        def from_backend(cls, backend_arg, **kwargs):  # noqa: N803
+            captured["backend"] = backend_arg
+            captured["kwargs"] = kwargs
+            inst = cls.__new__(cls)
+            inst.require_review = kwargs.get("require_review", False)
+            return inst
+
+        def run(self):
+            return None
+
+    import antfarm.core.soldier as soldier_mod
+
+    monkeypatch.setattr(soldier_mod, "Soldier", _FakeSoldier)
+    monkeypatch.setattr(serve_mod, "_soldier_thread", None, raising=False)
+    monkeypatch.setattr(serve_mod, "_soldier_status", "not started", raising=False)
+
+    serve_mod._start_soldier_thread(backend, data_dir=str(tmp_path / ".antfarm"))
+
+    assert captured.get("kwargs", {}).get("data_dir_name") == ".antfarm"
+
+
+def test_start_soldier_thread_warns_when_gitignore_missing_entry(tmp_path, monkeypatch):
+    """When the target repo's .gitignore doesn't list the data dir, emit
+    data_dir_not_gitignored for operator visibility (#323)."""
+    from antfarm.core import serve as serve_mod
+
+    # tmp_path itself acts as the (no-.gitignore) target repo root.
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+
+    events: list[tuple[str, str, str, str]] = []
+
+    def _capture(event_type, task_id, detail="", actor="colony"):
+        events.append((event_type, task_id, detail, actor))
+
+    class _FakeSoldier:
+        @classmethod
+        def from_backend(cls, backend_arg, **kwargs):  # noqa: N803
+            inst = cls.__new__(cls)
+            inst.require_review = kwargs.get("require_review", False)
+            return inst
+
+        def run(self):
+            return None
+
+    import antfarm.core.soldier as soldier_mod
+
+    monkeypatch.setattr(soldier_mod, "Soldier", _FakeSoldier)
+    monkeypatch.setattr(serve_mod, "_emit_event", _capture)
+    monkeypatch.setattr(serve_mod, "_soldier_thread", None, raising=False)
+    monkeypatch.setattr(serve_mod, "_soldier_status", "not started", raising=False)
+
+    serve_mod._start_soldier_thread(backend, data_dir=str(tmp_path / ".antfarm"))
+
+    warn = [e for e in events if e[0] == "data_dir_not_gitignored"]
+    assert warn, f"expected data_dir_not_gitignored, got {events}"
+
+
+def test_start_soldier_thread_silent_when_gitignore_has_entry(tmp_path, monkeypatch):
+    """No data_dir_not_gitignored event when .gitignore lists the data dir."""
+    from antfarm.core import serve as serve_mod
+
+    (tmp_path / ".gitignore").write_text(".antfarm/\n")
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+
+    events: list[tuple[str, str, str, str]] = []
+
+    def _capture(event_type, task_id, detail="", actor="colony"):
+        events.append((event_type, task_id, detail, actor))
+
+    class _FakeSoldier:
+        @classmethod
+        def from_backend(cls, backend_arg, **kwargs):  # noqa: N803
+            inst = cls.__new__(cls)
+            inst.require_review = kwargs.get("require_review", False)
+            return inst
+
+        def run(self):
+            return None
+
+    import antfarm.core.soldier as soldier_mod
+
+    monkeypatch.setattr(soldier_mod, "Soldier", _FakeSoldier)
+    monkeypatch.setattr(serve_mod, "_emit_event", _capture)
+    monkeypatch.setattr(serve_mod, "_soldier_thread", None, raising=False)
+    monkeypatch.setattr(serve_mod, "_soldier_status", "not started", raising=False)
+
+    serve_mod._start_soldier_thread(backend, data_dir=str(tmp_path / ".antfarm"))
+
+    warn = [e for e in events if e[0] == "data_dir_not_gitignored"]
+    assert not warn, f"unexpected data_dir_not_gitignored, got {events}"


### PR DESCRIPTION
## Root cause

Soldier's `_cleanup` and `_force_clean_repo` both run `git clean -fd` in `self.repo_path`. When the TARGET repo's `.gitignore` doesn't list the colony's data dir (default `.antfarm/`), git clean wipes the colony state mid-mission. Discovered during Phase 4 M1 validation on a fresh target repo — antfarm's own `.gitignore` includes the entry, which masked the bug throughout development.

## Fix

Thread `data_dir_name` from `serve._start_soldier_thread` into `Soldier` (via both `__init__` and `from_backend`), then pass `-e <data_dir_name>` to both `git clean -fd` calls. Data protection now lives in the soldier regardless of the target repo's gitignore.

Additionally, emit a startup warning event (`data_dir_not_gitignored`, actor=`soldier`) and log entry when the target repo's `.gitignore` is missing the entry, so operators get a belt-and-suspenders nudge to add it.

## Summary
- `antfarm/core/soldier.py` — add `data_dir_name` kwarg (default `.antfarm`) on `Soldier.__init__` and `Soldier.from_backend`; apply `-e self.data_dir_name` to both `git clean -fd` invocations (in `_cleanup` and `_force_clean_repo`); docstring updated.
- `antfarm/core/serve.py` — derive `data_dir_name = Path(data_dir).resolve().name` in `_start_soldier_thread`; pass to `Soldier.from_backend`; new helper `_warn_if_data_dir_not_gitignored` emits a `data_dir_not_gitignored` event when the target repo's `.gitignore` lacks the entry.
- `tests/test_soldier.py` — 7 new tests.

## Test Plan
- [x] `pytest tests/ -x -q` — 1157 passed (was 1150; +7 new)
- [x] `ruff check .` — clean
- [x] T1 `test_cleanup_preserves_data_dir_when_not_gitignored` — `.antfarm/` survives `_cleanup()` on a repo with no gitignore entry
- [x] T2 `test_force_clean_repo_preserves_data_dir_when_not_gitignored` — same protection under the destructive recovery path; other untracked files still removed
- [x] T3 `test_cleanup_with_custom_data_dir_name` — a soldier configured with `data_dir_name="custom-dir"` protects only that dir, not an unrelated `.antfarm/`
- [x] T4 `test_cleanup_still_removes_other_untracked_files` — regression guard: clean still removes untracked files outside the excluded dir
- [x] T5 `test_start_soldier_thread_passes_data_dir_name` — plumbing: `_start_soldier_thread` forwards `data_dir_name` kwarg to `Soldier.from_backend`
- [x] T6 `test_start_soldier_thread_warns_when_gitignore_missing_entry` — fires `data_dir_not_gitignored` when target repo has no `.gitignore`
- [x] T7 `test_start_soldier_thread_silent_when_gitignore_has_entry` — no warning when `.gitignore` lists `.antfarm/`

Closes #323

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>