### PR TITLE
fix(soldier): route run() through run_once_with_review; observability on kickback

### DIFF
--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -189,23 +189,33 @@ class Soldier:
         so it can wake immediately on ``harvested``/``kickback``/``merged``
         events. On any connection failure the loop falls back to the
         legacy polling behaviour (``time.sleep(self.poll_interval)``).
+
+        When ``require_review=True`` (the production configuration — see
+        ``serve._start_soldier_thread``) every tick dispatches through
+        ``run_once_with_review``, which is the single source of truth for
+        verdict-gated merges AND kickbacks on ``needs_changes``. The
+        legacy inline merge loop below is only used when review is
+        disabled (``require_review=False``), which no production deploy
+        sets today (see #328 for the bug this split was hiding).
         """
         while True:
             if self.require_review:
-                self.process_done_tasks()
-            queue = self.get_merge_queue()
-            if not queue:
-                self._wait_for_event(timeout=self.poll_interval)
-                continue
-            for task in queue:
-                if self._reconcile_external_merge(task):
-                    continue
-                result = self.attempt_merge(task)
-                attempt_id = task["current_attempt"]
-                if result == MergeResult.MERGED:
-                    self._safe_mark_merged(task["id"], attempt_id)
-                else:
-                    self.kickback_with_cascade(task["id"], self.last_failure_reason)
+                self.run_once_with_review()
+            else:
+                queue = self.get_merge_queue()
+                for task in queue:
+                    if self._reconcile_external_merge(task):
+                        continue
+                    result = self.attempt_merge(task)
+                    attempt_id = task["current_attempt"]
+                    if result == MergeResult.MERGED:
+                        self._safe_mark_merged(task["id"], attempt_id)
+                    else:
+                        self.kickback_with_cascade(task["id"], self.last_failure_reason)
+            # ``_wait_for_event`` handles sleeping regardless of whether
+            # the tick did any work — the previous early-continue on an
+            # empty queue was harmless but added an extra code path.
+            self._wait_for_event(timeout=self.poll_interval)
 
     def run_once(self) -> list[tuple[str, MergeResult]]:
         """Process the merge queue once and return results.
@@ -348,12 +358,37 @@ class Soldier:
                     if result == MergeResult.MERGED:
                         self._safe_mark_merged(task_id, attempt_id)
                     else:
-                        self.kickback_with_cascade(task_id, self.last_failure_reason)
+                        try:
+                            self.kickback_with_cascade(task_id, self.last_failure_reason)
+                        except Exception as exc:
+                            logger.exception("kickback failed for %s", task_id)
+                            _emit(
+                                "soldier_error",
+                                task_id,
+                                f"op=kickback_merge_failed type={type(exc).__name__} "
+                                f"msg={exc}",
+                            )
+                            raise
                     results.append((task_id, result))
                 else:
                     # Diagnostic skip before kickback: needs_changes verdict.
                     _emit("merge_skipped", task_id, "reason=needs_changes")
-                    self.kickback_with_cascade(task_id, f"review failed: {reason}")
+                    try:
+                        self.kickback_with_cascade(task_id, f"review failed: {reason}")
+                        _emit(
+                            "task_kicked_back",
+                            task_id,
+                            "reason=review:needs_changes",
+                        )
+                    except Exception as exc:
+                        logger.exception("kickback failed for %s", task_id)
+                        _emit(
+                            "soldier_error",
+                            task_id,
+                            f"op=kickback_needs_changes type={type(exc).__name__} "
+                            f"msg={exc}",
+                        )
+                        raise
                     results.append((task_id, MergeResult.FAILED))
                 continue
 
@@ -546,7 +581,12 @@ class Soldier:
             if not all(dep in merged_task_ids for dep in deps):
                 _emit("merge_skipped", task_id, "reason=dep_unmerged")
                 continue
-            # When review is required, gate on passing + fresh verdict
+            # When review is required, gate on passing + fresh verdict.
+            # NOTE: ``run_once_with_review`` is the primary enforcement
+            # point for review gating AND needs_changes kickbacks. This
+            # check is defense-in-depth for the legacy ``run_once``
+            # callers that do NOT go through review orchestration. Do
+            # NOT add a kickback here — that's #328's intended contract.
             if self.require_review:
                 passed, _reason = self.check_review_verdict(task)
                 if not passed:

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -365,8 +365,7 @@ class Soldier:
                             _emit(
                                 "soldier_error",
                                 task_id,
-                                f"op=kickback_merge_failed type={type(exc).__name__} "
-                                f"msg={exc}",
+                                f"op=kickback_merge_failed type={type(exc).__name__} msg={exc}",
                             )
                             raise
                     results.append((task_id, result))
@@ -385,8 +384,7 @@ class Soldier:
                         _emit(
                             "soldier_error",
                             task_id,
-                            f"op=kickback_needs_changes type={type(exc).__name__} "
-                            f"msg={exc}",
+                            f"op=kickback_needs_changes type={type(exc).__name__} msg={exc}",
                         )
                         raise
                     results.append((task_id, MergeResult.FAILED))
@@ -656,9 +654,7 @@ class Soldier:
         if not self._assert_clean_repo():
             _emit("repo_dirty", task_id, "preflight=fail attempting=recover")
             if not self._force_clean_repo():
-                self.last_failure_reason = (
-                    "repo not in clean state and recovery failed"
-                )
+                self.last_failure_reason = "repo not in clean state and recovery failed"
                 _emit(
                     "merge_failed",
                     task_id,
@@ -1327,9 +1323,7 @@ class Soldier:
                     check=False,
                 )
                 dirty = (
-                    "yes"
-                    if status_r.returncode != 0 or status_r.stdout.decode().strip()
-                    else "no"
+                    "yes" if status_r.returncode != 0 or status_r.stdout.decode().strip() else "no"
                 )
             except OSError:
                 dirty = "yes"

--- a/tests/test_soldier.py
+++ b/tests/test_soldier.py
@@ -3524,18 +3524,14 @@ def test_run_kickbacks_on_needs_changes_when_require_review(tmp_path, monkeypatc
     backend = FileBackend(root=str(tmp_path / ".antfarm"))
     _make_done_task_with_mission(backend, "task-328-prod", mission_id=None)
     _set_attempt_artifact_sha(backend, "task-328-prod", sha)
-    _inject_verdict_on_current_attempt(
-        backend, "task-328-prod", _needs_changes_verdict_dict(sha)
-    )
+    _inject_verdict_on_current_attempt(backend, "task-328-prod", _needs_changes_verdict_dict(sha))
 
     pre = backend.get_task("task-328-prod")
     pre_attempt_id = pre["current_attempt"]
     assert pre["status"] == "done"
     assert pre_attempt_id is not None
 
-    soldier = Soldier.from_backend(
-        backend, repo_path=str(tmp_path), require_review=True
-    )
+    soldier = Soldier.from_backend(backend, repo_path=str(tmp_path), require_review=True)
     assert soldier.require_review is True
     # Idempotence guard from the plan: _get_done_candidates skips
     # current_attempt=None tasks, so a post-kickback re-tick is a no-op.
@@ -3549,12 +3545,11 @@ def test_run_kickbacks_on_needs_changes_when_require_review(tmp_path, monkeypatc
 
     # The prior attempt must be marked superseded.
     superseded = [
-        a for a in after["attempts"]
+        a
+        for a in after["attempts"]
         if a["attempt_id"] == pre_attempt_id and a["status"] == "superseded"
     ]
-    assert superseded, (
-        f"expected superseded attempt, attempts={after['attempts']}"
-    )
+    assert superseded, f"expected superseded attempt, attempts={after['attempts']}"
 
     trail_msgs = [e["message"] for e in after.get("trail", [])]
     assert any("review failed" in m.lower() for m in trail_msgs), (
@@ -3562,9 +3557,7 @@ def test_run_kickbacks_on_needs_changes_when_require_review(tmp_path, monkeypatc
     )
 
 
-def test_run_once_with_review_kickbacks_on_needs_changes(
-    tmp_path, monkeypatch
-):
+def test_run_once_with_review_kickbacks_on_needs_changes(tmp_path, monkeypatch):
     """Unit coverage for the new task_kicked_back emission in
     run_once_with_review's needs_changes branch (#328)."""
     from antfarm.core import soldier as soldier_mod
@@ -3573,9 +3566,7 @@ def test_run_once_with_review_kickbacks_on_needs_changes(
     backend = FileBackend(root=str(tmp_path / ".antfarm"))
     _make_done_task_with_mission(backend, "task-328-unit", mission_id=None)
     _set_attempt_artifact_sha(backend, "task-328-unit", sha)
-    _inject_verdict_on_current_attempt(
-        backend, "task-328-unit", _needs_changes_verdict_dict(sha)
-    )
+    _inject_verdict_on_current_attempt(backend, "task-328-unit", _needs_changes_verdict_dict(sha))
 
     captured: list[tuple[str, str, str]] = []
 
@@ -3584,9 +3575,7 @@ def test_run_once_with_review_kickbacks_on_needs_changes(
 
     monkeypatch.setattr(soldier_mod, "_emit", _fake_emit)
 
-    soldier = Soldier.from_backend(
-        backend, repo_path=str(tmp_path), require_review=True
-    )
+    soldier = Soldier.from_backend(backend, repo_path=str(tmp_path), require_review=True)
     results = soldier.run_once_with_review()
 
     assert results == [("task-328-unit", MergeResult.FAILED)]
@@ -3598,14 +3587,11 @@ def test_run_once_with_review_kickbacks_on_needs_changes(
     assert "task_kicked_back" in types, types
     assert types.index("merge_skipped") < types.index("task_kicked_back")
     assert any(
-        c[0] == "task_kicked_back" and "reason=review:needs_changes" in c[2]
-        for c in task_events
+        c[0] == "task_kicked_back" and "reason=review:needs_changes" in c[2] for c in task_events
     ), f"expected task_kicked_back with reason=review:needs_changes, got {task_events}"
 
 
-def test_kickback_cascade_on_needs_changes_includes_downstream(
-    tmp_path, monkeypatch
-):
+def test_kickback_cascade_on_needs_changes_includes_downstream(tmp_path, monkeypatch):
     """A needs_changes kickback on a parent must cascade to a downstream
     done task (depends_on=[parent]). Both should end up in ready/ with
     their prior attempts marked superseded (#328)."""
@@ -3615,9 +3601,7 @@ def test_kickback_cascade_on_needs_changes_includes_downstream(
     # Parent: done with needs_changes verdict.
     _make_done_task_with_mission(backend, "task-328-parent", mission_id=None)
     _set_attempt_artifact_sha(backend, "task-328-parent", sha)
-    _inject_verdict_on_current_attempt(
-        backend, "task-328-parent", _needs_changes_verdict_dict(sha)
-    )
+    _inject_verdict_on_current_attempt(backend, "task-328-parent", _needs_changes_verdict_dict(sha))
 
     # Downstream: done, depends on parent (so cascade must fire).
     from datetime import UTC, datetime
@@ -3669,9 +3653,7 @@ def test_kickback_cascade_on_needs_changes_includes_downstream(
     assert parent_pre["status"] == "done"
     assert child_pre["status"] == "done"
 
-    soldier = Soldier.from_backend(
-        backend, repo_path=str(tmp_path), require_review=True
-    )
+    soldier = Soldier.from_backend(backend, repo_path=str(tmp_path), require_review=True)
     soldier.run_once_with_review()
 
     parent_after = backend.get_task("task-328-parent")
@@ -3700,9 +3682,7 @@ def test_kickback_exception_surfaces_diagnostic_event(tmp_path, monkeypatch):
     backend = FileBackend(root=str(tmp_path / ".antfarm"))
     _make_done_task_with_mission(backend, "task-328-err", mission_id=None)
     _set_attempt_artifact_sha(backend, "task-328-err", sha)
-    _inject_verdict_on_current_attempt(
-        backend, "task-328-err", _needs_changes_verdict_dict(sha)
-    )
+    _inject_verdict_on_current_attempt(backend, "task-328-err", _needs_changes_verdict_dict(sha))
 
     captured: list[tuple[str, str, str]] = []
 
@@ -3711,9 +3691,7 @@ def test_kickback_exception_surfaces_diagnostic_event(tmp_path, monkeypatch):
 
     monkeypatch.setattr(soldier_mod, "_emit", _fake_emit)
 
-    soldier = Soldier.from_backend(
-        backend, repo_path=str(tmp_path), require_review=True
-    )
+    soldier = Soldier.from_backend(backend, repo_path=str(tmp_path), require_review=True)
 
     def _boom(self, task_id, reason):
         raise RuntimeError("boom")
@@ -3726,9 +3704,7 @@ def test_kickback_exception_surfaces_diagnostic_event(tmp_path, monkeypatch):
     errs = [c for c in captured if c[0] == "soldier_error" and c[1] == "task-328-err"]
     assert errs, f"expected soldier_error event, captured={captured}"
     assert any(
-        "op=kickback_needs_changes" in c[2]
-        and "type=RuntimeError" in c[2]
-        and "msg=boom" in c[2]
+        "op=kickback_needs_changes" in c[2] and "type=RuntimeError" in c[2] and "msg=boom" in c[2]
         for c in errs
     ), f"detail mismatch, got: {errs}"
 
@@ -3741,13 +3717,9 @@ def test_run_preserves_passing_merge_path(tmp_path, monkeypatch):
     backend = FileBackend(root=str(tmp_path / ".antfarm"))
     _make_done_task_with_mission(backend, "task-328-pass", mission_id=None)
     _set_attempt_artifact_sha(backend, "task-328-pass", sha)
-    _inject_verdict_on_current_attempt(
-        backend, "task-328-pass", _pass_verdict_dict(sha)
-    )
+    _inject_verdict_on_current_attempt(backend, "task-328-pass", _pass_verdict_dict(sha))
 
-    soldier = Soldier.from_backend(
-        backend, repo_path=str(tmp_path), require_review=True
-    )
+    soldier = Soldier.from_backend(backend, repo_path=str(tmp_path), require_review=True)
 
     merges: list[tuple[str, str]] = []
     marked: list[tuple[str, str]] = []
@@ -3784,13 +3756,9 @@ def test_run_does_not_kickback_when_require_review_false(tmp_path, monkeypatch):
     backend = FileBackend(root=str(tmp_path / ".antfarm"))
     _make_done_task_with_mission(backend, "task-328-legacy", mission_id=None)
     _set_attempt_artifact_sha(backend, "task-328-legacy", sha)
-    _inject_verdict_on_current_attempt(
-        backend, "task-328-legacy", _needs_changes_verdict_dict(sha)
-    )
+    _inject_verdict_on_current_attempt(backend, "task-328-legacy", _needs_changes_verdict_dict(sha))
 
-    soldier = Soldier.from_backend(
-        backend, repo_path=str(tmp_path), require_review=False
-    )
+    soldier = Soldier.from_backend(backend, repo_path=str(tmp_path), require_review=False)
     assert soldier.require_review is False
 
     # Stub attempt_merge so we don't invoke real git from the legacy path.
@@ -3804,9 +3772,7 @@ def test_run_does_not_kickback_when_require_review_false(tmp_path, monkeypatch):
         return MergeResult.MERGED
 
     monkeypatch.setattr(Soldier, "attempt_merge", _fake_attempt_merge)
-    monkeypatch.setattr(
-        Soldier, "_safe_mark_merged", lambda self, tid, aid: None
-    )
+    monkeypatch.setattr(Soldier, "_safe_mark_merged", lambda self, tid, aid: None)
 
     _run_one_tick(soldier, monkeypatch)
 

--- a/tests/test_soldier.py
+++ b/tests/test_soldier.py
@@ -3442,3 +3442,381 @@ def test_start_soldier_thread_silent_when_gitignore_has_entry(tmp_path, monkeypa
 
     warn = [e for e in events if e[0] == "data_dir_not_gitignored"]
     assert not warn, f"unexpected data_dir_not_gitignored, got {events}"
+
+
+# ---------------------------------------------------------------------------
+# #328: Soldier.run() must route through run_once_with_review() when
+# require_review=True so needs_changes verdicts trigger kickback instead of
+# rotting in done/ forever. During Phase 4 M1-r3 we had to manually kickback.
+# ---------------------------------------------------------------------------
+
+
+class _LoopSentinel(Exception):
+    """Raised by the monkeypatched _wait_for_event to exit run()'s loop."""
+
+
+def _inject_verdict_on_current_attempt(backend, task_id, verdict_dict):
+    """Write a review verdict onto the current attempt of a done task.
+
+    Tasks live under tasks/done/<id>.json after harvest.
+    """
+    from pathlib import Path
+
+    done_path = Path(backend._root) / "tasks" / "done" / f"{task_id}.json"
+    data = json.loads(done_path.read_text())
+    current_attempt = data["current_attempt"]
+    for a in data["attempts"]:
+        if a["attempt_id"] == current_attempt:
+            a["review_verdict"] = verdict_dict
+            break
+    done_path.write_text(json.dumps(data, indent=2))
+
+
+def _needs_changes_verdict_dict(sha: str = "a" * 40) -> dict:
+    from antfarm.core.models import ReviewVerdict
+
+    return ReviewVerdict(
+        provider="human",
+        verdict="needs_changes",
+        summary="please fix X",
+        findings=["bug in Y"],
+        reviewed_commit_sha=sha,
+    ).to_dict()
+
+
+def _pass_verdict_dict(sha: str = "a" * 40) -> dict:
+    from antfarm.core.models import ReviewVerdict
+
+    return ReviewVerdict(
+        provider="human",
+        verdict="pass",
+        summary="LGTM",
+        reviewed_commit_sha=sha,
+    ).to_dict()
+
+
+def _run_one_tick(soldier, monkeypatch):
+    """Drive exactly one tick of soldier.run() via a sentinel exception.
+
+    Monkeypatches the Soldier instance's ``_wait_for_event`` so the first
+    call after a tick raises ``_LoopSentinel`` and breaks out of the
+    otherwise-infinite loop.
+    """
+
+    def _raise_after_one(timeout):
+        raise _LoopSentinel()
+
+    monkeypatch.setattr(soldier, "_wait_for_event", _raise_after_one)
+    with pytest.raises(_LoopSentinel):
+        soldier.run()
+
+
+def test_run_kickbacks_on_needs_changes_when_require_review(tmp_path, monkeypatch):
+    """#328: production path — require_review=True, needs_changes verdict
+    stored on the current attempt. Driving one tick of ``run()`` must
+    route through ``run_once_with_review``, which kicks the task back.
+
+    Before the fix, run()'s inline loop called get_merge_queue(), which
+    silently filtered needs_changes tasks and continued — leaving them
+    rotting in done/.
+    """
+    sha = "a" * 40
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    _make_done_task_with_mission(backend, "task-328-prod", mission_id=None)
+    _set_attempt_artifact_sha(backend, "task-328-prod", sha)
+    _inject_verdict_on_current_attempt(
+        backend, "task-328-prod", _needs_changes_verdict_dict(sha)
+    )
+
+    pre = backend.get_task("task-328-prod")
+    pre_attempt_id = pre["current_attempt"]
+    assert pre["status"] == "done"
+    assert pre_attempt_id is not None
+
+    soldier = Soldier.from_backend(
+        backend, repo_path=str(tmp_path), require_review=True
+    )
+    assert soldier.require_review is True
+    # Idempotence guard from the plan: _get_done_candidates skips
+    # current_attempt=None tasks, so a post-kickback re-tick is a no-op.
+    _run_one_tick(soldier, monkeypatch)
+
+    after = backend.get_task("task-328-prod")
+    assert after["status"] == "ready", (
+        f"expected ready after needs_changes kickback, got {after['status']}"
+    )
+    assert after["current_attempt"] is None
+
+    # The prior attempt must be marked superseded.
+    superseded = [
+        a for a in after["attempts"]
+        if a["attempt_id"] == pre_attempt_id and a["status"] == "superseded"
+    ]
+    assert superseded, (
+        f"expected superseded attempt, attempts={after['attempts']}"
+    )
+
+    trail_msgs = [e["message"] for e in after.get("trail", [])]
+    assert any("review failed" in m.lower() for m in trail_msgs), (
+        f"expected a 'review failed' trail entry, got: {trail_msgs}"
+    )
+
+
+def test_run_once_with_review_kickbacks_on_needs_changes(
+    tmp_path, monkeypatch
+):
+    """Unit coverage for the new task_kicked_back emission in
+    run_once_with_review's needs_changes branch (#328)."""
+    from antfarm.core import soldier as soldier_mod
+
+    sha = "b" * 40
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    _make_done_task_with_mission(backend, "task-328-unit", mission_id=None)
+    _set_attempt_artifact_sha(backend, "task-328-unit", sha)
+    _inject_verdict_on_current_attempt(
+        backend, "task-328-unit", _needs_changes_verdict_dict(sha)
+    )
+
+    captured: list[tuple[str, str, str]] = []
+
+    def _fake_emit(event_type, task_id, detail=""):
+        captured.append((event_type, task_id, detail))
+
+    monkeypatch.setattr(soldier_mod, "_emit", _fake_emit)
+
+    soldier = Soldier.from_backend(
+        backend, repo_path=str(tmp_path), require_review=True
+    )
+    results = soldier.run_once_with_review()
+
+    assert results == [("task-328-unit", MergeResult.FAILED)]
+
+    task_events = [c for c in captured if c[1] == "task-328-unit"]
+    types = [c[0] for c in task_events]
+    # Skip event must come BEFORE the new task_kicked_back event.
+    assert "merge_skipped" in types, types
+    assert "task_kicked_back" in types, types
+    assert types.index("merge_skipped") < types.index("task_kicked_back")
+    assert any(
+        c[0] == "task_kicked_back" and "reason=review:needs_changes" in c[2]
+        for c in task_events
+    ), f"expected task_kicked_back with reason=review:needs_changes, got {task_events}"
+
+
+def test_kickback_cascade_on_needs_changes_includes_downstream(
+    tmp_path, monkeypatch
+):
+    """A needs_changes kickback on a parent must cascade to a downstream
+    done task (depends_on=[parent]). Both should end up in ready/ with
+    their prior attempts marked superseded (#328)."""
+    sha = "c" * 40
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+
+    # Parent: done with needs_changes verdict.
+    _make_done_task_with_mission(backend, "task-328-parent", mission_id=None)
+    _set_attempt_artifact_sha(backend, "task-328-parent", sha)
+    _inject_verdict_on_current_attempt(
+        backend, "task-328-parent", _needs_changes_verdict_dict(sha)
+    )
+
+    # Downstream: done, depends on parent (so cascade must fire).
+    from datetime import UTC, datetime
+
+    now = datetime.now(UTC).isoformat()
+    child_raw = {
+        "id": "task-328-child",
+        "title": "child",
+        "spec": "depends on parent",
+        "complexity": "M",
+        "priority": 10,
+        "depends_on": ["task-328-parent"],
+        "touches": [],
+        "capabilities_required": [],
+        "mission_id": None,
+        "created_by": "test",
+        "status": "ready",
+        "current_attempt": None,
+        "attempts": [],
+        "trail": [],
+        "signals": [],
+        "created_at": now,
+        "updated_at": now,
+    }
+    backend.carry(child_raw)
+    backend.register_worker(
+        {
+            "worker_id": "w-child",
+            "node_id": "node-1",
+            "agent_type": "generic",
+            "workspace_root": "/tmp/ws",
+            "status": "idle",
+            "registered_at": now,
+            "last_heartbeat": now,
+        }
+    )
+    backend.pull("w-child")
+    child_pulled = backend.get_task("task-328-child")
+    child_attempt = child_pulled["current_attempt"]
+    backend.mark_harvested(
+        "task-328-child",
+        child_attempt,
+        pr="PR-child",
+        branch="feat/task-328-child",
+    )
+
+    parent_pre = backend.get_task("task-328-parent")
+    child_pre = backend.get_task("task-328-child")
+    assert parent_pre["status"] == "done"
+    assert child_pre["status"] == "done"
+
+    soldier = Soldier.from_backend(
+        backend, repo_path=str(tmp_path), require_review=True
+    )
+    soldier.run_once_with_review()
+
+    parent_after = backend.get_task("task-328-parent")
+    child_after = backend.get_task("task-328-child")
+    assert parent_after["status"] == "ready", parent_after["status"]
+    assert parent_after["current_attempt"] is None
+    assert child_after["status"] == "ready", (
+        f"downstream not cascaded, status={child_after['status']}"
+    )
+    assert child_after["current_attempt"] is None
+
+    # Child's prior attempt is superseded.
+    assert any(
+        a["attempt_id"] == child_attempt and a["status"] == "superseded"
+        for a in child_after["attempts"]
+    ), f"expected superseded child attempt, got {child_after['attempts']}"
+
+
+def test_kickback_exception_surfaces_diagnostic_event(tmp_path, monkeypatch):
+    """If ``kickback_with_cascade`` raises inside the needs_changes branch,
+    a ``soldier_error`` event with ``op=kickback_needs_changes`` must be
+    emitted and the exception must propagate (fail-loud). #328."""
+    from antfarm.core import soldier as soldier_mod
+
+    sha = "d" * 40
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    _make_done_task_with_mission(backend, "task-328-err", mission_id=None)
+    _set_attempt_artifact_sha(backend, "task-328-err", sha)
+    _inject_verdict_on_current_attempt(
+        backend, "task-328-err", _needs_changes_verdict_dict(sha)
+    )
+
+    captured: list[tuple[str, str, str]] = []
+
+    def _fake_emit(event_type, task_id, detail=""):
+        captured.append((event_type, task_id, detail))
+
+    monkeypatch.setattr(soldier_mod, "_emit", _fake_emit)
+
+    soldier = Soldier.from_backend(
+        backend, repo_path=str(tmp_path), require_review=True
+    )
+
+    def _boom(self, task_id, reason):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(Soldier, "kickback_with_cascade", _boom)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        soldier.run_once_with_review()
+
+    errs = [c for c in captured if c[0] == "soldier_error" and c[1] == "task-328-err"]
+    assert errs, f"expected soldier_error event, captured={captured}"
+    assert any(
+        "op=kickback_needs_changes" in c[2]
+        and "type=RuntimeError" in c[2]
+        and "msg=boom" in c[2]
+        for c in errs
+    ), f"detail mismatch, got: {errs}"
+
+
+def test_run_preserves_passing_merge_path(tmp_path, monkeypatch):
+    """Regression guard for #328: require_review=True + a passing verdict
+    must still route through run_once_with_review and merge (not kickback).
+    Ensures the fix doesn't regress the happy path."""
+    sha = "e" * 40
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    _make_done_task_with_mission(backend, "task-328-pass", mission_id=None)
+    _set_attempt_artifact_sha(backend, "task-328-pass", sha)
+    _inject_verdict_on_current_attempt(
+        backend, "task-328-pass", _pass_verdict_dict(sha)
+    )
+
+    soldier = Soldier.from_backend(
+        backend, repo_path=str(tmp_path), require_review=True
+    )
+
+    merges: list[tuple[str, str]] = []
+    marked: list[tuple[str, str]] = []
+
+    def _fake_attempt_merge(self, task):
+        merges.append((task["id"], task["current_attempt"]))
+        return MergeResult.MERGED
+
+    monkeypatch.setattr(Soldier, "attempt_merge", _fake_attempt_merge)
+    monkeypatch.setattr(
+        Soldier,
+        "_safe_mark_merged",
+        lambda self, tid, aid: marked.append((tid, aid)),
+    )
+
+    _run_one_tick(soldier, monkeypatch)
+
+    assert merges, f"expected attempt_merge call, got merges={merges}"
+    assert merges[0][0] == "task-328-pass"
+    assert marked, f"expected _safe_mark_merged call, got {marked}"
+    assert marked[0][0] == "task-328-pass"
+
+    after = backend.get_task("task-328-pass")
+    # Task was not kicked back — still done with a current attempt.
+    assert after["status"] == "done"
+    assert after["current_attempt"] is not None
+
+
+def test_run_does_not_kickback_when_require_review_false(tmp_path, monkeypatch):
+    """Legacy-path guard: require_review=False deployments must not touch
+    needs_changes verdicts (the verdict system is off). Task stays in
+    done/ through the legacy inline merge loop. #328."""
+    sha = "f" * 40
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    _make_done_task_with_mission(backend, "task-328-legacy", mission_id=None)
+    _set_attempt_artifact_sha(backend, "task-328-legacy", sha)
+    _inject_verdict_on_current_attempt(
+        backend, "task-328-legacy", _needs_changes_verdict_dict(sha)
+    )
+
+    soldier = Soldier.from_backend(
+        backend, repo_path=str(tmp_path), require_review=False
+    )
+    assert soldier.require_review is False
+
+    # Stub attempt_merge so we don't invoke real git from the legacy path.
+    # Without this, get_merge_queue would still skip due to verdict check
+    # under require_review=False (no verdict gating). We just need to
+    # confirm the inline path never kickbacks on needs_changes.
+    calls: list[str] = []
+
+    def _fake_attempt_merge(self, task):
+        calls.append(task["id"])
+        return MergeResult.MERGED
+
+    monkeypatch.setattr(Soldier, "attempt_merge", _fake_attempt_merge)
+    monkeypatch.setattr(
+        Soldier, "_safe_mark_merged", lambda self, tid, aid: None
+    )
+
+    _run_one_tick(soldier, monkeypatch)
+
+    after = backend.get_task("task-328-legacy")
+    # Legacy path merged (or at least did not kickback). Either way the
+    # task must NOT be in ready/ with a superseded attempt due to the
+    # verdict — that's the #328 bug path which is disabled here.
+    assert after["status"] != "ready", (
+        "require_review=False must not kickback on needs_changes, got ready"
+    )
+    # Either the task was merged (happy path) or stayed done — either is
+    # acceptable; the invariant is "no kickback on verdict" in legacy.
+    assert after["current_attempt"] is not None


### PR DESCRIPTION
Closes #328.

## Summary
- `Soldier.run()`'s inline merge loop silently filtered `needs_changes` tasks via `get_merge_queue`'s verdict gate and continued, so the task was never kicked back. `run_once_with_review()` already handled `needs_changes` correctly — it just wasn't called from `run()`. During Phase 4 M1-r3 we had to kick back manually.
- When `require_review=True` (the production config set by `serve._start_soldier_thread`), each tick now dispatches through `run_once_with_review()`. `require_review=False` preserves the legacy in-line merge loop unchanged.
- Wrapped both `kickback_with_cascade` calls in the stored-verdict branch with try/except + `soldier_error` emit (`op=kickback_needs_changes`, `op=kickback_merge_failed`). Exceptions propagate (fail-loud) so operators see breakage.
- New `task_kicked_back` emit with `reason=review:needs_changes` on the verdict-driven path, so operators can grep "why did this task regress?" on the SSE bus.

## Root cause
Two diverged code paths:
- `run()` at soldier.py:185 called `get_merge_queue()` → `attempt_merge()` for passing tasks, and emitted `merge_skipped reason=needs_changes` + `continue` for needs_changes tasks (soldier.py:549-554). No kickback.
- `run_once_with_review()` at soldier.py:314 correctly calls `kickback_with_cascade(task_id, f"review failed: {reason}")` on needs_changes.

`_start_soldier_thread` already passed `require_review=True`. The bug was purely in `soldier.run()` taking the wrong branch.

## Test coverage (6 new, 99 total in test_soldier.py)
- `test_run_kickbacks_on_needs_changes_when_require_review` — production-path test. Drives one tick of `run()` via a sentinel-raising `_wait_for_event`. Asserts task moved `done/` → `ready/`, attempt superseded, trail has `review failed` entry.
- `test_run_once_with_review_kickbacks_on_needs_changes` — unit test that the new `task_kicked_back` emit fires AFTER `merge_skipped`.
- `test_kickback_cascade_on_needs_changes_includes_downstream` — parent AND downstream (depends_on) both in `ready/` with superseded attempts.
- `test_kickback_exception_surfaces_diagnostic_event` — `RuntimeError` inside kickback emits `soldier_error` with `op=kickback_needs_changes type=RuntimeError msg=boom` and propagates.
- `test_run_preserves_passing_merge_path` — regression guard: passing verdict still merges through `run()`.
- `test_run_does_not_kickback_when_require_review_false` — legacy-path guard: verdict system off means no kickback on needs_changes.

## Test plan
- [x] 6 new tests pass
- [x] Full pytest suite green (1163 passed)
- [x] `ruff check .` clean
- [x] `run()` routes through `run_once_with_review()` when `require_review=True`
- [x] needs_changes verdict → task → ready/ with visible `task_kicked_back reason=review:needs_changes` event
- [x] Exceptions in kickback emit `soldier_error` and re-raise
- [x] Passing-verdict happy path still merges
- [x] `require_review=False` deployments unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)