### PR TITLE
fix(tui,soldier): activity log surfaces type+task_id + preflight test_command

### DIFF
--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -128,6 +128,17 @@ def _emit(event_type: str, task_id: str, detail: str = "") -> None:
         logger.debug("soldier _emit: _emit_event(%s) raised", event_type, exc_info=True)
 
 
+def _stderr_tail(stderr_bytes: bytes, n: int = 20) -> str:
+    """Return the last ``n`` lines of decoded stderr bytes.
+
+    Used to preserve diagnostic context on test failures (#326): without a
+    tail, short one-line summaries truncate the actual error into noise.
+    """
+    text = stderr_bytes.decode(errors="replace").rstrip()
+    lines = text.splitlines()
+    return "\n".join(lines[-n:]) if lines else ""
+
+
 class MergeResult(StrEnum):
     MERGED = "merged"
     FAILED = "failed"
@@ -177,6 +188,9 @@ class Soldier:
         self.last_failure_reason = ""
         # Event cursor for /events SSE stream. In-memory only; never persists.
         self._event_cursor: int = 0
+        # One-shot preflight validation of ``test_command`` — see #326. Fires
+        # at most once per Soldier lifetime from ``run`` or ``run_once``.
+        self._preflight_done: bool = False
 
     # ------------------------------------------------------------------
     # Public API
@@ -198,6 +212,7 @@ class Soldier:
         disabled (``require_review=False``), which no production deploy
         sets today (see #328 for the bug this split was hiding).
         """
+        self._run_preflight_if_needed()
         while True:
             if self.require_review:
                 self.run_once_with_review()
@@ -223,6 +238,7 @@ class Soldier:
         Returns:
             List of (task_id, MergeResult) tuples for each task processed.
         """
+        self._run_preflight_if_needed()
         if self.require_review:
             self.process_done_tasks()
         results = []
@@ -294,7 +310,8 @@ class Soldier:
                 continue
             task_id = task.get("id", "")
             if self._has_merged_attempt(task):
-                _emit("merge_skipped", task_id, "reason=already_merged")
+                # #327b: no emit here — merge_reconciled_external in
+                # _reconcile_external_merge is the operator-actionable signal.
                 continue
             # Post-kickback tasks have no current_attempt.
             if not task.get("current_attempt"):
@@ -565,7 +582,8 @@ class Soldier:
                 continue
             # Skip already-merged tasks
             if self._has_merged_attempt(task):
-                _emit("merge_skipped", task_id, "reason=already_merged")
+                # #327b: no emit here — merge_reconciled_external in
+                # _reconcile_external_merge is the operator-actionable signal.
                 continue
             # Post-kickback tasks have current_attempt=None.
             if not task.get("current_attempt"):
@@ -735,9 +753,13 @@ class Soldier:
                 check=False,
             )
             if r.returncode != 0:
-                self.last_failure_reason = (
-                    f"tests failed: {r.stdout.decode().strip()} {r.stderr.decode().strip()}"
+                stderr_tail = _stderr_tail(r.stderr or b"")
+                short = (
+                    r.stdout.decode(errors="replace").strip()
+                    + " "
+                    + r.stderr.decode(errors="replace").strip()
                 ).strip()
+                self.last_failure_reason = f"tests failed: {short[:120]}\n---\n{stderr_tail}\n---"
                 _emit(
                     "merge_failed",
                     task_id,
@@ -1043,9 +1065,13 @@ class Soldier:
             check=False,
         )
         if r.returncode != 0:
-            self.last_failure_reason = (
-                f"tests failed: {r.stdout.decode().strip()} {r.stderr.decode().strip()}"
+            stderr_tail = _stderr_tail(r.stderr or b"")
+            short = (
+                r.stdout.decode(errors="replace").strip()
+                + " "
+                + r.stderr.decode(errors="replace").strip()
             ).strip()
+            self.last_failure_reason = f"tests failed: {short[:120]}\n---\n{stderr_tail}\n---"
             _emit(
                 "merge_failed",
                 task_id,
@@ -1151,6 +1177,58 @@ class Soldier:
             return r.returncode != 0
         except OSError:
             return False
+
+    def _preflight_test_command(self) -> tuple[bool, str]:
+        """Run ``test_command`` once on a clean integration branch.
+
+        Returns:
+            Tuple of (passed, stderr_tail). ``passed`` is True if the command
+            exits 0 (or is empty). ``stderr_tail`` is the last 20 lines of
+            stderr on failure, or an exec-failure message if the command
+            could not be spawned.
+
+        See #326: catches operator mistakes like a missing ``test_command``
+        binary or a broken default ``pytest`` install before the first real
+        task fails. Fires at most once per Soldier lifetime.
+        """
+        if not self.test_command:
+            return True, ""
+        try:
+            r = subprocess.run(
+                self.test_command,
+                cwd=self.repo_path,
+                capture_output=True,
+                check=False,
+            )
+        except (OSError, FileNotFoundError) as exc:
+            return False, f"could not exec {self.test_command!r}: {exc}"
+        if r.returncode == 0:
+            return True, ""
+        return False, _stderr_tail(r.stderr or b"") or _stderr_tail(r.stdout or b"")
+
+    def _run_preflight_if_needed(self) -> None:
+        """One-shot preflight hook invoked by ``run`` and ``run_once``.
+
+        Sets ``_preflight_done=True`` BEFORE performing any work so that a
+        mid-preflight crash cannot cause an infinite retry loop on the next
+        lifetime. Skipped when ``_force_clean_repo`` cannot establish a
+        clean integration branch — a separate failure path already logs
+        that condition.
+        """
+        if self._preflight_done:
+            return
+        self._preflight_done = True
+        if not self._force_clean_repo():
+            return
+        passed, tail = self._preflight_test_command()
+        if passed:
+            return
+        logger.warning("soldier preflight: test_command failed:\n%s", tail)
+        _emit(
+            "test_command_broken",
+            "",
+            f"cmd={' '.join(self.test_command)} stderr=\n{tail}",
+        )
 
     def _force_clean_repo(self) -> bool:
         """Destructive recovery routine to restore a pristine clone.
@@ -1858,6 +1936,7 @@ class Soldier:
         instance.data_dir_name = data_dir_name
         instance.last_failure_reason = ""
         instance._event_cursor = 0
+        instance._preflight_done = False
         return instance
 
 

--- a/antfarm/core/tui.py
+++ b/antfarm/core/tui.py
@@ -936,11 +936,21 @@ class AntfarmTUI:
                 time_str = "--:--:--"
 
             actor = (ev.get("actor") or "-")[:12].ljust(12)
-            event_type = ev.get("type", "") or ""
-            detail = ev.get("detail") or event_type or "-"
+            event_type = (ev.get("type") or "-")[:16].ljust(16)
+            raw_tid = ev.get("task_id") or ""
+            tid_short = (raw_tid.rsplit("-", 1)[-1] if raw_tid else "")[:8].ljust(10)
+            detail = ev.get("detail") or "-"
 
-            style = "red" if "failed" in event_type else ""
-            text.append(f"{time_str}  {actor}  {detail}", style=style)
+            if "failed" in event_type:
+                style = "red"
+            elif "kick" in event_type:
+                style = "yellow"
+            else:
+                style = ""
+            text.append(
+                f"{time_str}  {actor}  {event_type}  {tid_short}  {detail}",
+                style=style,
+            )
             if i < len(tail) - 1:
                 text.append("\n")
 

--- a/tests/test_soldier.py
+++ b/tests/test_soldier.py
@@ -3786,3 +3786,129 @@ def test_run_does_not_kickback_when_require_review_false(tmp_path, monkeypatch):
     # Either the task was merged (happy path) or stayed done — either is
     # acceptable; the invariant is "no kickback on verdict" in legacy.
     assert after["current_attempt"] is not None
+
+
+# ---------------------------------------------------------------------------
+# #327 + #326: observability — activity-log task_id + preflight validation
+# ---------------------------------------------------------------------------
+
+
+def test_get_merge_queue_does_not_emit_already_merged_spam(soldier_env, clear_events, monkeypatch):
+    """#327b: no ``merge_skipped reason=already_merged`` emit on repeat polls.
+
+    After a task is merged, subsequent calls to ``run_once`` must not
+    re-emit the log-noise event every tick.
+    """
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _carry_and_harvest(cc, repo, "task-327-spam", "feat/task-327-spam")
+
+    # First tick merges it; clear the queue so we can isolate the second tick.
+    soldier.run_once()
+    clear_events.clear()
+
+    # Skip preflight on the 2nd tick so we isolate the merge-queue path.
+    soldier._preflight_done = True
+
+    # Second tick should find the task already merged and skip — but must
+    # NOT emit merge_skipped with reason=already_merged. It may emit other
+    # events (e.g. internal ticks); those are allowed.
+    soldier.run_once()
+
+    for e in clear_events:
+        if e.get("type") == "merge_skipped":
+            assert "already_merged" not in (e.get("detail") or ""), (
+                f"soldier must not spam already_merged merge_skipped events: {e}"
+            )
+
+
+def test_preflight_test_command_passes_on_clean(tmp_path, monkeypatch):
+    """#326: ``_preflight_test_command`` returns (True, '') when the command exits 0."""
+    soldier = _build_bare_soldier(tmp_path, test_command=["true"])
+    monkeypatch.setattr(Soldier, "_force_clean_repo", lambda self: True)
+
+    passed, tail = soldier._preflight_test_command()
+    assert passed is True
+    assert tail == ""
+
+
+def test_preflight_test_command_emits_broken_when_fails(tmp_path, monkeypatch):
+    """#326: ``_preflight_test_command`` returns (False, tail) with last-20 stderr."""
+    soldier = _build_bare_soldier(
+        tmp_path,
+        test_command=["sh", "-c", "echo line1 1>&2; echo line2 1>&2; exit 1"],
+    )
+    monkeypatch.setattr(Soldier, "_force_clean_repo", lambda self: True)
+
+    passed, tail = soldier._preflight_test_command()
+    assert passed is False
+    assert "line2" in tail
+
+
+def test_preflight_emits_test_command_broken_event_in_run_once(
+    soldier_env, clear_events, monkeypatch
+):
+    """#326: preflight fires ONCE per Soldier lifetime and emits test_command_broken."""
+    soldier = soldier_env["soldier"]
+
+    # Swap in a failing test_command for preflight purposes.
+    soldier.test_command = ["sh", "-c", "echo boom 1>&2; exit 1"]
+    soldier._preflight_done = False
+
+    # Skip real git recovery; assume the integration branch is clean.
+    monkeypatch.setattr(Soldier, "_force_clean_repo", lambda self: True)
+
+    # Two ticks, yet preflight must emit test_command_broken exactly once.
+    soldier.run_once()
+    soldier.run_once()
+
+    broken = _events_of_type(clear_events, "test_command_broken")
+    assert len(broken) == 1, f"expected exactly one test_command_broken, got {broken}"
+    assert broken[0]["actor"] == "soldier"
+    assert "boom" in broken[0]["detail"]
+
+
+def test_trail_includes_full_stderr_on_test_failure(tmp_path, monkeypatch):
+    """#326: task-failure ``last_failure_reason`` embeds last 20 lines of stderr."""
+    # Build 24 lines of stderr; first 4 should be dropped by the tail.
+    err_lines = "\n".join(f"err-line-{i}" for i in range(1, 25))
+    script = f"printf '%s\\n' '{err_lines}' 1>&2; exit 1"
+
+    soldier = _build_bare_soldier(tmp_path, test_command=["sh", "-c", script])
+    # Skip the preflight path so run_once below doesn't swallow the
+    # behaviour under test; we're asserting on attempt_merge's output.
+    soldier._preflight_done = True
+
+    task = _make_mock_task()
+
+    real_run = subprocess.run
+
+    def fake_run(args, **kwargs):
+        import subprocess as _sp
+
+        # Let the test_command ("sh -c ...") run for real so its actual
+        # stderr is captured; short-circuit all git invocations to success.
+        if args and args[0] == "sh":
+            return real_run(args, **kwargs)
+        return _sp.CompletedProcess(args, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(soldier_module.subprocess, "run", fake_run)
+
+    result = soldier.attempt_merge(task)
+    assert result == MergeResult.FAILED
+
+    reason = soldier.last_failure_reason
+    # The reason has a short prefix then '---<tail>---' with the last 20
+    # stderr lines. Extract the tail block and assert against it.
+    assert "---" in reason
+    tail_block = reason.split("---", 2)[1]
+    tail_lines = tail_block.strip().splitlines()
+    # Exactly 20 lines of tail, newest last.
+    assert tail_lines[-1] == "err-line-24"
+    assert tail_lines[0] == "err-line-5"
+    assert len(tail_lines) == 20
+    # First four lines must not appear in the tail block.
+    for dropped in ("err-line-1", "err-line-2", "err-line-3", "err-line-4"):
+        assert dropped not in tail_lines, f"{dropped} should have been trimmed"

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1087,6 +1087,45 @@ def test_render_activity_failed_type_is_red():
     assert any("red" in s for s in styles)
 
 
+def test_render_activity_includes_type_and_task_id():
+    """#327: activity log must surface event type and task id columns."""
+    tui = _make_tui()
+    tui._ingest_event(
+        {
+            "id": 1,
+            "type": "merge_skipped",
+            "actor": "soldier",
+            "task_id": "r3-06",
+            "detail": "reason=already_merged",
+            "ts": "2026-04-16T14:32:11+00:00",
+        }
+    )
+    rendered = tui._render_activity()
+    plain = rendered.plain
+    assert "merge_skipped" in plain
+    # task_id column uses last segment after final '-'
+    assert "r3-06" in plain or "06" in plain
+    assert "reason=already_merged" in plain
+
+
+def test_render_activity_kickback_is_yellow():
+    """#327: kickback events should render in yellow."""
+    tui = _make_tui()
+    tui._ingest_event(
+        {
+            "id": 1,
+            "type": "task_kicked_back",
+            "actor": "soldier",
+            "task_id": "task-y",
+            "detail": "reason=review:needs_changes",
+            "ts": "2026-04-16T14:32:11+00:00",
+        }
+    )
+    rendered = tui._render_activity()
+    styles = [str(s.style) for s in rendered.spans]
+    assert any("yellow" in s for s in styles)
+
+
 def test_build_display_includes_activity_panel(monkeypatch):
     tui = _make_tui()
 


### PR DESCRIPTION
## Summary
Closes #327 and #326.

- **#327 TUI observability**: activity log rows now render event type + short task_id columns (previously only `time  actor  detail`, making skips and kickbacks unattributable). Kickback events render yellow; failures stay red.
- **#327b soldier log noise**: removed the two `merge_skipped reason=already_merged` emit sites (`_get_done_candidates`, `get_merge_queue`) that were firing every poll for every merged task. `reconciled_external` already provides the operator-actionable signal for externally-merged PRs; the filter stays in place so merged tasks are still skipped. `already_merged` stays in `_MERGE_SKIP_REASONS` for historical event compatibility.
- **#326 preflight test_command validation**: new one-shot `_preflight_test_command` + `_run_preflight_if_needed`, invoked from the top of `run` and `run_once`. On failure it emits `test_command_broken` with a tail of stderr and logs a warning. `_preflight_done` is set BEFORE the work so a mid-preflight crash cannot infinite-loop. Initialized in both `__init__` and `from_backend`.
- **#326 stderr truncation**: test-failure `last_failure_reason` now embeds the last 20 lines of stderr via a new `_stderr_tail` helper, applied at both `attempt_merge` and `_rebase_and_retry_merge` test-failure sites. The existing `merge_failed` event and trail entry carry the block through unchanged.

## Scope decisions
- **No serve.py changes**: preflight fires via `run()` / `run_once()`, which `_start_soldier_thread` already invokes — no new wiring needed.
- **No inbox finding / venv auto-detect**: intentionally out of scope for this PR.
- `_MERGE_SKIP_REASONS` retains `already_merged` — only the emit sites were removed.

## Test plan
- [x] `pytest tests/ -x -q` — 1170 passed (7 new)
- [x] `ruff check .` — clean
- [x] `ruff format --check` on touched files — clean
- [x] 2 new TUI tests: type+task_id surfacing, yellow kickback styling
- [x] 5 new soldier tests: no `already_merged` spam on repeat ticks, preflight pass/fail, one-shot lifetime guarantee, trail carries full last-20-line stderr tail

🤖 Generated with [Claude Code](https://claude.com/claude-code)