### PR TITLE
fix(tui): compute mission merged count from live task attempts

### DIFF
--- a/antfarm/core/tui.py
+++ b/antfarm/core/tui.py
@@ -282,7 +282,7 @@ class AntfarmTUI:
 
         layout["missions"].update(
             Panel(
-                self._render_missions(missions),
+                self._render_missions(missions, tasks=tasks),
                 title=f"[bold bright_white]Missions ({len(missions)})[/bold bright_white]",
             )
         )
@@ -605,12 +605,23 @@ class AntfarmTUI:
 
         return table
 
-    def _render_missions(self, missions: list[dict], max_shown: int = 5) -> Table:
-        """Render mission list with status, task counts, and progress time."""
+    def _render_missions(
+        self,
+        missions: list[dict],
+        tasks: list[dict] | None = None,
+        max_shown: int = 5,
+    ) -> Table:
+        """Render mission list with status, task counts, and progress time.
+
+        Live merged counts come from the tasks list (fixes #331 — reports are
+        only populated after a mission completes, so in-flight missions would
+        otherwise show 0/N until done). Falls back to report["merged_tasks"]
+        when no tasks list is supplied, preserving legacy behaviour.
+        """
         table = Table(show_header=True, header_style="bold", box=None, padding=(0, 1))
         table.add_column("ID", max_width=25, no_wrap=True)
         table.add_column("Status", max_width=15, no_wrap=True)
-        table.add_column("Tasks", max_width=8, no_wrap=True)
+        table.add_column("Tasks", max_width=10, no_wrap=True)
         table.add_column("Progress", max_width=20, no_wrap=True)
 
         if not missions:
@@ -627,6 +638,8 @@ class AntfarmTUI:
             "cancelled": "dim",
         }
 
+        task_by_id = {t.get("id", ""): t for t in (tasks or [])}
+
         shown = missions[:max_shown]
         for m in shown:
             mid = m.get("mission_id", "")
@@ -639,9 +652,14 @@ class AntfarmTUI:
             total = len(task_ids)
             blocked = len(blocked_ids)
 
-            # Derive merged count from report if available
-            report = m.get("report")
-            merged = report.get("merged_tasks", 0) if report else 0
+            # Prefer live count from task attempts so in-flight missions show
+            # real progress. Fall back to the report only when the caller
+            # didn't supply a tasks list (legacy/test callers).
+            if tasks is not None:
+                merged = self._count_merged_tasks(task_ids, task_by_id)
+            else:
+                report = m.get("report")
+                merged = report.get("merged_tasks", 0) if report else 0
             tasks_text = f"{merged}/{total}"
             if blocked > 0:
                 tasks_text += f" ({blocked}blk)"
@@ -658,6 +676,20 @@ class AntfarmTUI:
 
         self._add_overflow_hint(table, len(missions), max_shown)
         return table
+
+    @staticmethod
+    def _count_merged_tasks(task_ids: list[str], task_by_id: dict[str, dict]) -> int:
+        """Count task_ids whose task has at least one merged attempt."""
+        merged = 0
+        for tid in task_ids:
+            task = task_by_id.get(tid)
+            if not task:
+                continue
+            for att in task.get("attempts", []):
+                if att.get("status") == "merged":
+                    merged += 1
+                    break
+        return merged
 
     def _format_mission_progress(self, mission: dict) -> str:
         """Format progress column for a mission.

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -858,6 +858,56 @@ def test_tui_mission_panel_overflow():
     assert result.row_count == 6
 
 
+def _render_to_text(renderable) -> str:
+    """Render a rich renderable to plain text for assertions."""
+    from io import StringIO
+
+    from rich.console import Console
+
+    buf = StringIO()
+    Console(file=buf, width=120, force_terminal=False).print(renderable)
+    return buf.getvalue()
+
+
+def test_tui_mission_panel_live_merged_count_from_tasks():
+    """In-flight mission (report=None) shows merged count derived from task attempts (#331)."""
+    tui = _make_tui()
+    missions = [
+        {
+            "mission_id": "m-x",
+            "status": "building",
+            "task_ids": ["task-x-01", "task-x-02", "task-x-03"],
+            "blocked_task_ids": [],
+            "report": None,
+        }
+    ]
+    tasks = [
+        _task(task_id="task-x-01", attempts=[_attempt(status="merged")]),
+        _task(task_id="task-x-02", attempts=[_attempt(status="merged")]),
+        _task(task_id="task-x-03", attempts=[_attempt(status="done")]),
+        # Non-mission task with a merged attempt must not be counted.
+        _task(task_id="other-task", attempts=[_attempt(status="merged")]),
+    ]
+    rendered = _render_to_text(tui._render_missions(missions, tasks=tasks))
+    assert "2/3" in rendered
+
+
+def test_tui_mission_panel_falls_back_to_report_when_no_tasks():
+    """Legacy callers (no tasks arg) still read merged count from mission report."""
+    tui = _make_tui()
+    missions = [
+        {
+            "mission_id": "m-y",
+            "status": "complete",
+            "task_ids": ["task-y-01", "task-y-02"],
+            "blocked_task_ids": [],
+            "report": {"merged_tasks": 2},
+        }
+    ]
+    rendered = _render_to_text(tui._render_missions(missions))
+    assert "2/2" in rendered
+
+
 # ---------------------------------------------------------------------------
 # Connection error handling
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix TUI Missions panel showing `0/N` merged while a mission is in-flight (#331).
- `_render_missions` previously read merged count from `mission["report"]`, but the report is only populated after a mission completes, so running missions always displayed `0/N` regardless of progress.
- Now passes the tasks list through to `_render_missions` and counts task_ids whose attempts contain a `merged` status. Falls back to `report["merged_tasks"]` when no tasks list is supplied, preserving legacy callers.
- Widened the Tasks column slightly (`max_width` 8 → 10) to keep `"N/N (Mblk)"` readable with 3-digit counts.

## Root cause

`report` is mission-terminal metadata. Intermediate merge progress never landed on the mission object, so the TUI had no live signal. The tasks list (already fetched via `/status/full` in `_build_display`) has the authoritative per-attempt merge state — the fix just plumbs it through.

## Test coverage

- `test_tui_mission_panel_live_merged_count_from_tasks` — in-flight mission (`report=None`) with mixed attempt statuses renders `2/3`; non-mission tasks are excluded.
- `test_tui_mission_panel_falls_back_to_report_when_no_tasks` — legacy callers without a tasks arg still read the report-derived count.

## Test Plan

- [x] `pytest tests/ -x -q` — 1171 passed on branch (baseline 1169 + 2 new). The one pre-existing flake (`test_tmux_pm_adopt_existing`, tmux env pollution) is unrelated and also fails on clean main on this box.
- [x] `ruff check .` — clean.
- [x] `ruff format --check antfarm/core/tui.py tests/test_tui.py` — clean.
- [x] Existing `test_tui_mission_panel_*` tests still pass (backward-compat).

## Related Issues

Closes #331