### PR TITLE
fix(backend,worker): recover honors max_attempts + heartbeat spans whole run()

### DIFF
--- a/antfarm/core/backends/base.py
+++ b/antfarm/core/backends/base.py
@@ -96,7 +96,9 @@ class TaskBackend(ABC):
         ...
 
     @abstractmethod
-    def recover_stale_task_if_worker_dead(self, task_id: str, current_attempt_id: str) -> bool:
+    def recover_stale_task_if_worker_dead(
+        self, task_id: str, current_attempt_id: str, max_attempts: int = 3
+    ) -> bool:
         """Atomically recover a stale active task only if its worker is dead.
 
         Under the backend lock, verify that the task is still in the active
@@ -106,10 +108,14 @@ class TaskBackend(ABC):
         observation was stale and another actor has already moved state
         forward.
 
-        When the conditions hold, supersede the current attempt, reset the
-        task to READY with ``current_attempt=None``, append a doctor trail
-        entry ("recovered by doctor"), and move the JSON from ``active/`` to
-        ``ready/``.
+        When the conditions hold, supersede the current attempt and then
+        route the task the same way ``kickback()`` does: if total
+        finished (DONE+SUPERSEDED) attempts >= effective max_attempts, move
+        the JSON from ``active/`` to ``blocked/`` with status BLOCKED.
+        Otherwise reset the task to READY with ``current_attempt=None``,
+        append a doctor trail entry ("recovered by doctor"), and move the
+        JSON from ``active/`` to ``ready/``. Per-task ``max_attempts``
+        overrides the function parameter (issue #333).
 
         Drift conditions that trigger a False return:
 
@@ -125,9 +131,12 @@ class TaskBackend(ABC):
         Args:
             task_id: ID of the task suspected to be stale.
             current_attempt_id: The attempt ID the caller observed as current.
+            max_attempts: Default max finished attempts before the task
+                is routed to BLOCKED instead of READY. Per-task
+                ``max_attempts`` on the task dict overrides this default.
 
         Returns:
-            True if the task was recovered to READY.
+            True if the task was recovered (to READY or BLOCKED).
             False if any drift condition prevented the recovery.
         """
         ...

--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -450,11 +450,15 @@ class FileBackend(TaskBackend):
         # stall every other worker for its duration.
         self._close_superseded_pr(superseded_attempt, reason)
 
-    def recover_stale_task_if_worker_dead(self, task_id: str, current_attempt_id: str) -> bool:
+    def recover_stale_task_if_worker_dead(
+        self, task_id: str, current_attempt_id: str, max_attempts: int = 3
+    ) -> bool:
         """Atomically recover a stale active task iff its worker is dead.
 
         Re-validates all drift conditions under ``self._lock`` before moving
-        state forward. See the ABC docstring for the full contract.
+        state forward. Honors ``max_attempts`` so unbounded stale-recovery
+        loops cannot bypass the blocked/ routing that ``kickback()`` enforces
+        (issue #333). See the ABC docstring for the full contract.
 
         Within-process only; cross-process racers are out of scope.
         """
@@ -487,13 +491,40 @@ class FileBackend(TaskBackend):
                     a["completed_at"] = now
                     break
 
-            data["status"] = TaskStatus.READY.value
             data["current_attempt"] = None
             data["updated_at"] = now
             data.setdefault("trail", []).append(
                 {"ts": now, "worker_id": "doctor", "message": "recovered by doctor"}
             )
 
+            # Respect max_attempts — same routing logic as kickback(). Without
+            # this, a flapping worker can loop through active→ready unbounded
+            # times past the configured attempt cap (issue #333, M2 task-06).
+            effective_max = data.get("max_attempts") or max_attempts
+            finished = sum(
+                1
+                for a in data.get("attempts", [])
+                if a.get("status") in (AttemptStatus.DONE.value, AttemptStatus.SUPERSEDED.value)
+            )
+
+            if finished >= effective_max:
+                data["status"] = TaskStatus.BLOCKED.value
+                data["trail"].append(
+                    {
+                        "ts": now,
+                        "worker_id": "doctor",
+                        "message": (
+                            f"moved to blocked: {finished} finished attempts "
+                            f"exceeds max={effective_max}"
+                        ),
+                    }
+                )
+                blocked_path = self._blocked_path(task_id)
+                self._write_json(blocked_path, data)
+                active_path.unlink()
+                return True
+
+            data["status"] = TaskStatus.READY.value
             ready_path = self._ready_path(task_id)
             self._write_json(ready_path, data)
             active_path.unlink()
@@ -1070,9 +1101,7 @@ class FileBackend(TaskBackend):
         worker_path = self._worker_path(worker_id)
         with self._lock:
             data = (
-                self._read_json(worker_path)
-                if worker_path.exists()
-                else {"worker_id": worker_id}
+                self._read_json(worker_path) if worker_path.exists() else {"worker_id": worker_id}
             )
             data.update(status)
             data["last_heartbeat"] = _now_iso()

--- a/antfarm/core/backends/github.py
+++ b/antfarm/core/backends/github.py
@@ -589,7 +589,9 @@ class GitHubBackend(TaskBackend):
 
         self._close_superseded_pr(superseded_attempt, reason)
 
-    def recover_stale_task_if_worker_dead(self, task_id: str, current_attempt_id: str) -> bool:
+    def recover_stale_task_if_worker_dead(
+        self, task_id: str, current_attempt_id: str, max_attempts: int = 3
+    ) -> bool:
         """Not supported on GitHubBackend — logs a warning and returns False.
 
         Task recovery requires a file-based state machine. GitHub Issues
@@ -598,11 +600,12 @@ class GitHubBackend(TaskBackend):
         ``check_stale_tasks`` only inspects FileBackend directories. This
         method exists to satisfy the ABC; operators running a GitHub-backed
         colony should rely on manual intervention or a parallel FileBackend
-        for task recovery.
+        for task recovery. ``max_attempts`` is accepted for signature parity
+        but ignored.
         """
         import logging
 
-        del task_id, current_attempt_id  # unused — no-op implementation
+        del task_id, current_attempt_id, max_attempts  # no-op implementation
         logging.getLogger(__name__).warning(
             "recover_stale_task_if_worker_dead is not supported for GitHubBackend; "
             "task recovery is a filesystem-only operation in v0.1."

--- a/antfarm/core/doctor.py
+++ b/antfarm/core/doctor.py
@@ -446,6 +446,10 @@ def check_stale_tasks(backend, config: dict, fix: bool = False) -> list[Finding]
     data_dir = Path(config["data_dir"])
     active_dir = data_dir / "tasks" / "active"
     workers_dir = data_dir / "workers"
+    # Plumb max_attempts through so stale-recovery honors the same attempt
+    # budget as kickback(). Without this, a flapping worker loops through
+    # active→ready without the blocked/ routing kicking in (issue #333).
+    max_attempts = config.get("max_attempts", 3)
 
     if not active_dir.exists():
         return findings
@@ -493,7 +497,9 @@ def check_stale_tasks(backend, config: dict, fix: bool = False) -> list[Finding]
                 # attempt rotated between this check and the mutation, the
                 # backend returns False and we leave the finding as unfixed
                 # (issue #310).
-                if backend.recover_stale_task_if_worker_dead(task_id, current_attempt_id):
+                if backend.recover_stale_task_if_worker_dead(
+                    task_id, current_attempt_id, max_attempts=max_attempts
+                ):
                     f.fixed = True
                     _emit_event(
                         "stale_task_recovered",

--- a/antfarm/core/worker.py
+++ b/antfarm/core/worker.py
@@ -82,8 +82,12 @@ def classify_failure(returncode: int, stderr: str, stdout: str) -> FailureType:
 
     # 2. Infrastructure (clear external failures)
     infra_markers = [
-        "permission denied", "disk full", "connection refused",
-        "network unreachable", "enospc", "eacces",
+        "permission denied",
+        "disk full",
+        "connection refused",
+        "network unreachable",
+        "enospc",
+        "eacces",
     ]
     if any(m in combined for m in infra_markers):
         return FailureType.INFRA_FAILURE
@@ -95,8 +99,11 @@ def classify_failure(returncode: int, stderr: str, stdout: str) -> FailureType:
 
     # 4. Build (check before test — "pip install failed" is build, not test)
     build_markers = [
-        "build failed", "compilation error", "pip install",
-        "modulenotfounderror", "importerror",
+        "build failed",
+        "compilation error",
+        "pip install",
+        "modulenotfounderror",
+        "importerror",
     ]
     if any(m in combined for m in build_markers):
         return FailureType.BUILD_FAILURE
@@ -265,13 +272,9 @@ class WorkerRuntime:
         token: str | None = None,
     ):
         if poll_interval <= 0:
-            raise ValueError(
-                f"poll_interval must be > 0, got {poll_interval}"
-            )
+            raise ValueError(f"poll_interval must be > 0, got {poll_interval}")
         if agent_timeout <= 0:
-            raise ValueError(
-                f"agent_timeout must be > 0, got {agent_timeout}"
-            )
+            raise ValueError(f"agent_timeout must be > 0, got {agent_timeout}")
         self.worker_id = f"{node_id}/{name}"
         self.node_id = node_id
         self.agent_type = agent_type
@@ -301,9 +304,7 @@ class WorkerRuntime:
             role_max_idle_polls = 5  # 5 * 30s = 2.5min
 
         # Explicit CLI override wins over role default; None preserves it (#272).
-        self._max_idle_polls = (
-            role_max_idle_polls if max_empty_polls is None else max_empty_polls
-        )
+        self._max_idle_polls = role_max_idle_polls if max_empty_polls is None else max_empty_polls
 
         self.colony = ColonyClient(colony_url, client=client, token=token)
         self.workspace_mgr = WorkspaceManager(workspace_root, repo_path, integration_branch)
@@ -334,6 +335,13 @@ class WorkerRuntime:
         )
         logger.info("worker registered worker_id=%s", self.worker_id)
 
+        # Heartbeat spans the entire run() lifetime, not just the agent
+        # subprocess window. Previously it was started/stopped per-task
+        # around _launch_agent, leaving slow git fetches, harvest POSTs, and
+        # colony contention outside the coverage window — doctor could reap
+        # a still-alive worker (issue #333, M2 task-06 runaway).
+        self._start_heartbeat_loop()
+
         try:
             idle_polls = 0
             max_idle_polls = self._max_idle_polls  # 0 = exit immediately, >0 = poll
@@ -344,12 +352,22 @@ class WorkerRuntime:
                         logger.info("queue empty, worker exiting worker_id=%s", self.worker_id)
                         break
                     idle_polls += 1
-                    logger.debug("queue empty, polling (%d/%d) worker_id=%s role=%s",
-                                 idle_polls, max_idle_polls, self.worker_id, self._role)
+                    logger.debug(
+                        "queue empty, polling (%d/%d) worker_id=%s role=%s",
+                        idle_polls,
+                        max_idle_polls,
+                        self.worker_id,
+                        self._role,
+                    )
                     time.sleep(self.poll_interval)
                 else:
                     idle_polls = 0  # reset on successful forage
         finally:
+            # Stop the heartbeat before deregistering so no stray POST arrives
+            # after the worker record is gone. Guarded: if _start failed or
+            # was never reached, _stop is still a safe no-op.
+            with contextlib.suppress(Exception):
+                self._stop_heartbeat_loop()
             if self._last_task_id:
                 with contextlib.suppress(Exception):
                     self.colony.trail(
@@ -383,33 +401,23 @@ class WorkerRuntime:
         _emit("task_claimed", task_id, task.get("title", ""))
 
         with contextlib.suppress(Exception):
-            self.colony.trail(
-                task_id, self.worker_id, "task claimed, creating workspace"
-            )
+            self.colony.trail(task_id, self.worker_id, "task claimed, creating workspace")
 
         dep_branches = self._resolve_dep_branches(task)
-        workspace = self.workspace_mgr.create(
-            task_id, attempt_id, dep_branches=dep_branches
-        )
+        workspace = self.workspace_mgr.create(task_id, attempt_id, dep_branches=dep_branches)
         logger.info("workspace created path=%s", workspace)
         _emit("workspace_created", task_id, workspace)
 
         with contextlib.suppress(Exception):
-            self.colony.trail(
-                task_id, self.worker_id, "workspace ready, launching agent"
-            )
+            self.colony.trail(task_id, self.worker_id, "workspace ready, launching agent")
 
-        self._start_heartbeat_loop()
-        try:
-            _emit("agent_launched", task_id, self.agent_type)
-            result = self._launch_agent(task, workspace)
-        finally:
-            self._stop_heartbeat_loop()
+        # Heartbeat thread is managed by run() (issue #333) — coverage now
+        # spans the whole worker lifetime, not just the agent subprocess.
+        _emit("agent_launched", task_id, self.agent_type)
+        result = self._launch_agent(task, workspace)
 
         is_silent = (
-            result.returncode == 0
-            and not result.stdout.strip()
-            and not result.stderr.strip()
+            result.returncode == 0 and not result.stdout.strip() and not result.stderr.strip()
         )
 
         if result.returncode != 0 or is_silent:
@@ -454,8 +462,7 @@ class WorkerRuntime:
             self.colony.trail(
                 task_id,
                 self.worker_id,
-                f"[{failure.failure_type.value}] {failure.message}: "
-                f"{result.stderr[:200]}",
+                f"[{failure.failure_type.value}] {failure.message}: {result.stderr[:200]}",
             )
             # Persist structured failure record in trail for downstream consumers
             self.colony.trail(
@@ -466,17 +473,13 @@ class WorkerRuntime:
             return True
 
         with contextlib.suppress(Exception):
-            self.colony.trail(
-                task_id, self.worker_id, "agent completed, building artifact"
-            )
+            self.colony.trail(task_id, self.worker_id, "agent completed, building artifact")
 
         # Plan task: parse output, validate, carry children, harvest with plan artifact
         caps_req = set(task.get("capabilities_required", []))
         is_plan = "plan" in caps_req
         if is_plan:
-            plan_result = self._process_plan_output(
-                task, attempt_id, result.stdout + result.stderr
-            )
+            plan_result = self._process_plan_output(task, attempt_id, result.stdout + result.stderr)
             if plan_result:
                 is_mission_mode = plan_result.get("mission_mode", False)
                 if is_mission_mode:
@@ -499,30 +502,36 @@ class WorkerRuntime:
                         "warnings": plan_result["warnings"],
                         "dependency_summary": plan_result["dep_summary"],
                     }
-                    trail_msg = (
-                        f"plan complete: created {len(plan_result['created_ids'])} tasks"
-                    )
+                    trail_msg = f"plan complete: created {len(plan_result['created_ids'])} tasks"
                 try:
                     self.colony.mark_harvest_pending(task_id, attempt_id)
                 except Exception as exc:
                     logger.warning(
                         "mark_harvest_pending failed task_id=%s attempt_id=%s: %s",
-                        task_id, attempt_id, exc,
+                        task_id,
+                        attempt_id,
+                        exc,
                     )
                 try:
                     self.colony.harvest(
-                        task_id, attempt_id, pr="", branch="",
+                        task_id,
+                        attempt_id,
+                        pr="",
+                        branch="",
                         artifact=artifact,
                     )
                     logger.info("plan harvested task_id=%s", task_id)
                 except Exception as exc:
                     logger.error(
                         "plan harvest FAILED task_id=%s attempt_id=%s: %s",
-                        task_id, attempt_id, exc,
+                        task_id,
+                        attempt_id,
+                        exc,
                     )
                     with contextlib.suppress(Exception):
                         self.colony.trail(
-                            task_id, self.worker_id,
+                            task_id,
+                            self.worker_id,
                             f"plan harvest failed: {exc}",
                         )
                 with contextlib.suppress(Exception):
@@ -532,7 +541,8 @@ class WorkerRuntime:
             # Plan parsing failed — trail the error
             with contextlib.suppress(Exception):
                 self.colony.trail(
-                    task_id, self.worker_id,
+                    task_id,
+                    self.worker_id,
                     "plan failed: could not parse agent output into tasks",
                 )
             return True
@@ -566,10 +576,9 @@ class WorkerRuntime:
             )
 
         # For review tasks: parse verdict from output and store on original task
-        is_review_task = (
-            "review" in set(task.get("capabilities_required", []))
-            or task_id.startswith("review-")
-        )
+        is_review_task = "review" in set(
+            task.get("capabilities_required", [])
+        ) or task_id.startswith("review-")
         if is_review_task and result.returncode == 0:
             original_task_id = task_id.removeprefix("review-")
             verdict = _parse_review_verdict(result.stdout + result.stderr)
@@ -601,9 +610,7 @@ class WorkerRuntime:
                 # max_attempts — once exhausted, the review task moves to
                 # blocked and Soldier.run_once_with_review kicks back the
                 # *original* task with a clear reason.
-                logger.warning(
-                    "reviewer produced no verdict for %s", original_task_id
-                )
+                logger.warning("reviewer produced no verdict for %s", original_task_id)
                 with contextlib.suppress(Exception):
                     self.colony.trail(
                         task_id,
@@ -662,9 +669,7 @@ class WorkerRuntime:
             try:
                 dep = self.colony.get_task(dep_id)
             except Exception as exc:
-                logger.warning(
-                    "dep lookup failed dep_id=%s error=%s — skipping", dep_id, exc
-                )
+                logger.warning("dep lookup failed dep_id=%s error=%s — skipping", dep_id, exc)
                 continue
             if not dep or dep.get("status") != "done":
                 continue
@@ -702,7 +707,9 @@ class WorkerRuntime:
         # Find adapter agents relative to the antfarm package
         adapter_dir = os.path.join(
             os.path.dirname(os.path.dirname(__file__)),
-            "adapters", "claude_code", "agents",
+            "adapters",
+            "claude_code",
+            "agents",
         )
         if not os.path.isdir(adapter_dir):
             return
@@ -732,9 +739,7 @@ class WorkerRuntime:
             )
         return proc.stdout.strip()
 
-    def _build_artifact(
-        self, task: dict, attempt_id: str, workspace: str, branch: str
-    ) -> dict:
+    def _build_artifact(self, task: dict, attempt_id: str, workspace: str, branch: str) -> dict:
         """Collect git diff stats and commit metadata for the harvest payload."""
         artifact: dict = {}
         try:
@@ -777,10 +782,15 @@ class WorkerRuntime:
         try:
             proc = subprocess.run(
                 [
-                    "gh", "pr", "create",
-                    "--title", title,
-                    "--body", body,
-                    "--head", branch,
+                    "gh",
+                    "pr",
+                    "create",
+                    "--title",
+                    title,
+                    "--body",
+                    body,
+                    "--head",
+                    branch,
                     "--fill",
                 ],
                 cwd=workspace,
@@ -933,9 +943,12 @@ class WorkerRuntime:
         use_stdin = False
         if self.agent_type == "claude-code":
             cmd = [
-                "claude", "-p",
-                "--agent", agent_role,
-                "--permission-mode", "bypassPermissions",
+                "claude",
+                "-p",
+                "--agent",
+                agent_role,
+                "--permission-mode",
+                "bypassPermissions",
             ]
             # Pass prompt via stdin to avoid OS arg length limits on large specs
             use_stdin = True
@@ -976,20 +989,14 @@ class WorkerRuntime:
             # whether text=True was honored before the timeout fired. Normalize.
             raw_stdout = exc.stdout or ""
             stdout = (
-                raw_stdout
-                if isinstance(raw_stdout, str)
-                else raw_stdout.decode("utf-8", "replace")
+                raw_stdout if isinstance(raw_stdout, str) else raw_stdout.decode("utf-8", "replace")
             )
             raw_stderr = exc.stderr or ""
             stderr_partial = (
-                raw_stderr
-                if isinstance(raw_stderr, str)
-                else raw_stderr.decode("utf-8", "replace")
+                raw_stderr if isinstance(raw_stderr, str) else raw_stderr.decode("utf-8", "replace")
             )
             stderr = f"[TIMEOUT after {self.agent_timeout:.0f}s] {stderr_partial}"
-            return AgentResult(
-                returncode=-15, stdout=stdout, stderr=stderr, branch=branch
-            )
+            return AgentResult(returncode=-15, stdout=stdout, stderr=stderr, branch=branch)
 
         return AgentResult(
             returncode=proc.returncode,
@@ -1003,7 +1010,10 @@ class WorkerRuntime:
     # ------------------------------------------------------------------
 
     def _process_plan_output(
-        self, task: dict, attempt_id: str, output: str,
+        self,
+        task: dict,
+        attempt_id: str,
+        output: str,
     ) -> dict | None:
         """Parse plan output, validate, and carry child tasks.
 
@@ -1015,7 +1025,8 @@ class WorkerRuntime:
         # Extract JSON from [PLAN_RESULT]...[/PLAN_RESULT] tags
         match = re.search(
             r"\[PLAN_RESULT\]\s*(.*?)\s*\[/PLAN_RESULT\]",
-            output, re.DOTALL,
+            output,
+            re.DOTALL,
         )
         if not match:
             logger.warning("no [PLAN_RESULT] tags in planner output")
@@ -1031,7 +1042,8 @@ class WorkerRuntime:
             logger.warning("plan produced no tasks")
             with contextlib.suppress(Exception):
                 self.colony.trail(
-                    task["id"], self.worker_id,
+                    task["id"],
+                    self.worker_id,
                     "plan produced no tasks"
                     + (f": {plan_result.warnings[0]}" if plan_result.warnings else ""),
                 )
@@ -1043,7 +1055,8 @@ class WorkerRuntime:
                 logger.warning("plan validation error: %s", err)
                 with contextlib.suppress(Exception):
                     self.colony.trail(
-                        task["id"], self.worker_id,
+                        task["id"],
+                        self.worker_id,
                         f"plan validation error: {err}",
                     )
             return None
@@ -1055,7 +1068,8 @@ class WorkerRuntime:
             logger.warning("plan has %d tasks, max 10", len(tasks))
             with contextlib.suppress(Exception):
                 self.colony.trail(
-                    task["id"], self.worker_id,
+                    task["id"],
+                    self.worker_id,
                     f"plan rejected: {len(tasks)} tasks exceeds max 10",
                 )
             return None
@@ -1087,8 +1101,7 @@ class WorkerRuntime:
                 plan_task_id=task["id"],
                 attempt_id=attempt_id,
                 proposed_tasks=[
-                    t.to_carry_dict(child_ids[i])
-                    for i, t in enumerate(resolved_tasks)
+                    t.to_carry_dict(child_ids[i]) for i, t in enumerate(resolved_tasks)
                 ],
                 task_count=len(resolved_tasks),
                 warnings=warn_strs,
@@ -1144,11 +1157,13 @@ class WorkerRuntime:
         if failed_ids:
             logger.warning(
                 "plan partial failure: %d/%d tasks failed",
-                len(failed_ids), len(resolved_tasks),
+                len(failed_ids),
+                len(resolved_tasks),
             )
             with contextlib.suppress(Exception):
                 self.colony.trail(
-                    task["id"], self.worker_id,
+                    task["id"],
+                    self.worker_id,
                     f"plan partial failure: {len(created_ids)} created, "
                     f"{len(failed_ids)} failed: {', '.join(failed_ids)}",
                 )

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1738,10 +1738,10 @@ def test_check_stale_tasks_fix_respects_late_heartbeat(setup, monkeypatch):
 
     real = backend.recover_stale_task_if_worker_dead
 
-    def wrapped(task_id: str, attempt_id: str) -> bool:
+    def wrapped(task_id: str, attempt_id: str, max_attempts: int = 3) -> bool:
         # Simulate the worker reviving between detection and mutation.
         backend.register_worker(_make_worker("worker-late"))
-        return real(task_id, attempt_id)
+        return real(task_id, attempt_id, max_attempts=max_attempts)
 
     monkeypatch.setattr(backend, "recover_stale_task_if_worker_dead", wrapped)
 
@@ -1777,3 +1777,42 @@ def test_check_stale_guards_fix_respects_owner_revival(setup, monkeypatch):
     assert stale[0].fixed is False
     assert "recovered" in stale[0].message
     assert guard_file.exists()
+
+
+def test_check_stale_tasks_fix_respects_max_attempts(setup):
+    """After max_attempts stale recoveries, doctor --fix routes task to blocked/ (issue #333).
+
+    This is the integration-level proof that doctor passes max_attempts through
+    to recover_stale_task_if_worker_dead so a flapping worker cannot bypass the
+    blocked/ routing that kickback() enforces.
+    """
+    backend, config = setup
+    config["max_attempts"] = 2  # smaller budget to keep the test compact
+
+    backend.carry(_make_task("task-runaway"))
+
+    # Cycle 1: worker claims, dies, doctor --fix recovers → ready/
+    backend.register_worker(_make_worker("w1"))
+    backend.pull("w1")
+    backend.deregister_worker("w1")
+    run_doctor(backend, config, fix=True)
+    assert (Path(config["data_dir"]) / "tasks" / "ready" / "task-runaway.json").exists()
+
+    # Cycle 2: same pattern. finished attempts now = 2, which hits max_attempts=2.
+    backend.register_worker(_make_worker("w2"))
+    backend.pull("w2")
+    backend.deregister_worker("w2")
+    findings = run_doctor(backend, config, fix=True)
+
+    stale = [f for f in findings if f.check == "stale_task"]
+    assert len(stale) == 1
+    assert stale[0].fixed is True
+
+    blocked_path = Path(config["data_dir"]) / "tasks" / "blocked" / "task-runaway.json"
+    ready_path = Path(config["data_dir"]) / "tasks" / "ready" / "task-runaway.json"
+    assert blocked_path.exists()
+    assert not ready_path.exists()
+
+    data = json.loads(blocked_path.read_text())
+    assert data["status"] == "blocked"
+    assert any("moved to blocked" in t["message"] for t in data.get("trail", []))

--- a/tests/test_file_backend.py
+++ b/tests/test_file_backend.py
@@ -1511,6 +1511,92 @@ def test_recover_stale_task_succeeds_when_worker_dead(backend: FileBackend) -> N
     assert any("recovered by doctor" in t["message"] for t in data.get("trail", []))
 
 
+def test_recover_stale_task_moves_to_blocked_after_max_attempts(
+    backend: FileBackend,
+) -> None:
+    """Repeated stale-recovery cycles must eventually route to blocked/ (issue #333)."""
+    backend.carry(_make_task("task-1"))
+
+    # Cycle 1: worker claims, dies, doctor recovers → ready/
+    backend.register_worker(_make_worker("w1"))
+    pulled = backend.pull("w1")
+    assert pulled is not None
+    attempt_id_1 = pulled["current_attempt"]
+    backend.deregister_worker("w1")
+    assert backend.recover_stale_task_if_worker_dead("task-1", attempt_id_1, max_attempts=3) is True
+    assert backend._ready_path("task-1").exists()
+
+    # Cycle 2: same pattern — still under max (2 finished < 3)
+    backend.register_worker(_make_worker("w2"))
+    pulled = backend.pull("w2")
+    assert pulled is not None
+    attempt_id_2 = pulled["current_attempt"]
+    backend.deregister_worker("w2")
+    assert backend.recover_stale_task_if_worker_dead("task-1", attempt_id_2, max_attempts=3) is True
+    assert backend._ready_path("task-1").exists()
+    assert not backend._blocked_path("task-1").exists()
+
+    # Cycle 3: 3rd supersede → finished=3 >= max=3 → blocked/
+    backend.register_worker(_make_worker("w3"))
+    pulled = backend.pull("w3")
+    assert pulled is not None
+    attempt_id_3 = pulled["current_attempt"]
+    backend.deregister_worker("w3")
+    assert backend.recover_stale_task_if_worker_dead("task-1", attempt_id_3, max_attempts=3) is True
+
+    assert not backend._active_path("task-1").exists()
+    assert not backend._ready_path("task-1").exists()
+    assert backend._blocked_path("task-1").exists()
+
+    data = json.loads(backend._blocked_path("task-1").read_text())
+    assert data["status"] == TaskStatus.BLOCKED.value
+    assert data["current_attempt"] is None
+    assert any(
+        "moved to blocked" in t["message"] and "max=3" in t["message"]
+        for t in data.get("trail", [])
+    )
+
+
+def test_recover_stale_task_respects_per_task_max_attempts(backend: FileBackend) -> None:
+    """Per-task ``max_attempts`` field overrides the function parameter (issue #333)."""
+    task = _make_task("task-1")
+    task["max_attempts"] = 5
+    backend.carry(task)
+
+    # 4 stale-recovery cycles: still ready (4 < 5)
+    for i in range(4):
+        worker = f"w{i}"
+        backend.register_worker(_make_worker(worker))
+        pulled = backend.pull(worker)
+        assert pulled is not None
+        attempt = pulled["current_attempt"]
+        backend.deregister_worker(worker)
+        assert (
+            backend.recover_stale_task_if_worker_dead(
+                "task-1",
+                attempt,
+                max_attempts=3,  # intentionally lower than per-task 5
+            )
+            is True
+        )
+        assert backend._ready_path("task-1").exists()
+        assert not backend._blocked_path("task-1").exists()
+
+    # 5th cycle: 5 finished >= per-task max=5 → blocked/
+    backend.register_worker(_make_worker("w-final"))
+    pulled = backend.pull("w-final")
+    assert pulled is not None
+    attempt_final = pulled["current_attempt"]
+    backend.deregister_worker("w-final")
+    assert (
+        backend.recover_stale_task_if_worker_dead("task-1", attempt_final, max_attempts=3) is True
+    )
+    assert backend._blocked_path("task-1").exists()
+
+    data = json.loads(backend._blocked_path("task-1").read_text())
+    assert any("max=5" in t["message"] for t in data.get("trail", []))
+
+
 def test_release_guard_if_owner_dead_skips_when_owner_alive(backend: FileBackend) -> None:
     """A live owner's guard must not be released — returns False."""
     backend.register_worker(_make_worker("w1"))
@@ -1774,12 +1860,8 @@ def test_heartbeat_serialized_with_updates(tmp_path: Path) -> None:
     backend = FileBackend(root=tmp_path / ".antfarm", guard_ttl=5)
     backend.register_worker(_make_worker("worker-1"))
 
-    t1 = threading.Thread(
-        target=backend.heartbeat, args=("worker-1", {"status": "active"})
-    )
-    t2 = threading.Thread(
-        target=backend.update_worker_activity, args=("worker-1", "tool:bash")
-    )
+    t1 = threading.Thread(target=backend.heartbeat, args=("worker-1", {"status": "active"}))
+    t2 = threading.Thread(target=backend.update_worker_activity, args=("worker-1", "tool:bash"))
     t1.start()
     t2.start()
     t1.join()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -229,7 +229,6 @@ def test_exit_deregisters_on_empty_queue(tc, backend):
     # Create a fresh runtime and run against empty queue
     import httpx
 
-
     transport = _StarletteTransport(tc.app)
     client = httpx.Client(transport=transport, base_url="http://test")
     rt = WorkerRuntime(
@@ -510,8 +509,12 @@ def test_build_failure_record():
     from antfarm.core.worker import build_failure_record
 
     rec = build_failure_record(
-        task_id="t1", attempt_id="a1", worker_id="w1",
-        returncode=1, stderr="connection refused", stdout="",
+        task_id="t1",
+        attempt_id="a1",
+        worker_id="w1",
+        returncode=1,
+        stderr="connection refused",
+        stdout="",
     )
     assert rec.failure_type == FailureType.INFRA_FAILURE
     assert rec.retryable is True
@@ -716,9 +719,7 @@ def test_build_artifact_collects_stats(tmp_path, http_client):
         return ""
 
     with patch.object(WorkerRuntime, "_git", side_effect=fake_git):
-        artifact = rt._build_artifact(
-            {"id": "t1"}, "att-001", str(tmp_path), "feat/t1-att-001"
-        )
+        artifact = rt._build_artifact({"id": "t1"}, "att-001", str(tmp_path), "feat/t1-att-001")
 
     assert artifact["lines_added"] == 7
     assert artifact["lines_removed"] == 3
@@ -746,9 +747,7 @@ def test_build_artifact_handles_git_failure(tmp_path, http_client):
         raise subprocess.CalledProcessError(1, ["git", *args])
 
     with patch.object(WorkerRuntime, "_git", side_effect=failing_git):
-        artifact = rt._build_artifact(
-            {"id": "t1"}, "att-001", str(tmp_path), "feat/t1-att-001"
-        )
+        artifact = rt._build_artifact({"id": "t1"}, "att-001", str(tmp_path), "feat/t1-att-001")
 
     assert artifact["diff_stat"] == ""
     assert artifact["lines_added"] == 0
@@ -764,12 +763,15 @@ def test_build_artifact_handles_git_failure(tmp_path, http_client):
 
 def _carry_plan(tc, task_id="plan-test", title="Plan Test", spec="decompose this"):
     """Carry a plan task with capabilities_required=["plan"]."""
-    r = tc.post("/tasks", json={
-        "id": task_id,
-        "title": title,
-        "spec": spec,
-        "capabilities_required": ["plan"],
-    })
+    r = tc.post(
+        "/tasks",
+        json={
+            "id": task_id,
+            "title": title,
+            "spec": spec,
+            "capabilities_required": ["plan"],
+        },
+    )
     assert r.status_code == 201
     return r.json()
 
@@ -802,10 +804,18 @@ def test_planner_mode_detects_plan_task(tc, tmp_path, http_client):
     _carry_plan(tc)
     rt = _make_planner_runtime(tmp_path, http_client)
 
-    plan_json = _json.dumps([
-        {"title": "Task A", "spec": "do A", "touches": ["api"],
-         "depends_on": [], "priority": 5, "complexity": "S"},
-    ])
+    plan_json = _json.dumps(
+        [
+            {
+                "title": "Task A",
+                "spec": "do A",
+                "touches": ["api"],
+                "depends_on": [],
+                "priority": 5,
+                "complexity": "S",
+            },
+        ]
+    )
 
     def plan_agent(task, workspace) -> AgentResult:
         return AgentResult(
@@ -835,16 +845,29 @@ def test_planner_creates_deterministic_child_ids(tc, tmp_path, http_client):
     _carry_plan(tc, task_id="plan-auth-system")
     rt = _make_planner_runtime(tmp_path, http_client)
 
-    plan_json = _json.dumps([
-        {"title": "Add middleware", "spec": "do middleware", "touches": ["api"],
-         "depends_on": [], "priority": 5, "complexity": "M"},
-        {"title": "Add routes", "spec": "do routes", "touches": ["api"],
-         "depends_on": [1], "priority": 10, "complexity": "M"},
-    ])
+    plan_json = _json.dumps(
+        [
+            {
+                "title": "Add middleware",
+                "spec": "do middleware",
+                "touches": ["api"],
+                "depends_on": [],
+                "priority": 5,
+                "complexity": "M",
+            },
+            {
+                "title": "Add routes",
+                "spec": "do routes",
+                "touches": ["api"],
+                "depends_on": [1],
+                "priority": 10,
+                "complexity": "M",
+            },
+        ]
+    )
 
     def plan_agent(task, workspace) -> AgentResult:
-        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json),
-                           stderr="", branch="")
+        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json), stderr="", branch="")
 
     rt._launch_agent = plan_agent
     rt.run()
@@ -867,15 +890,20 @@ def test_planner_rejects_more_than_10_tasks(tc, tmp_path, http_client):
     rt = _make_planner_runtime(tmp_path, http_client)
 
     tasks = [
-        {"title": f"Task {i}", "spec": f"do {i}", "touches": [],
-         "depends_on": [], "priority": 10, "complexity": "S"}
+        {
+            "title": f"Task {i}",
+            "spec": f"do {i}",
+            "touches": [],
+            "depends_on": [],
+            "priority": 10,
+            "complexity": "S",
+        }
         for i in range(11)
     ]
     plan_json = _json.dumps(tasks)
 
     def plan_agent(task, workspace) -> AgentResult:
-        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json),
-                           stderr="", branch="")
+        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json), stderr="", branch="")
 
     rt._launch_agent = plan_agent
     rt.run()
@@ -914,14 +942,21 @@ def test_planner_children_no_recursive_plans(tc, tmp_path, http_client):
     _carry_plan(tc)
     rt = _make_planner_runtime(tmp_path, http_client)
 
-    plan_json = _json.dumps([
-        {"title": "Sub task", "spec": "do sub", "touches": [],
-         "depends_on": [], "priority": 5, "complexity": "S"},
-    ])
+    plan_json = _json.dumps(
+        [
+            {
+                "title": "Sub task",
+                "spec": "do sub",
+                "touches": [],
+                "depends_on": [],
+                "priority": 5,
+                "complexity": "S",
+            },
+        ]
+    )
 
     def plan_agent(task, workspace) -> AgentResult:
-        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json),
-                           stderr="", branch="")
+        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json), stderr="", branch="")
 
     rt._launch_agent = plan_agent
     rt.run()
@@ -936,16 +971,29 @@ def test_planner_harvest_artifact(tc, tmp_path, http_client):
     _carry_plan(tc, task_id="plan-feat")
     rt = _make_planner_runtime(tmp_path, http_client)
 
-    plan_json = _json.dumps([
-        {"title": "A", "spec": "do A", "touches": [], "depends_on": [],
-         "priority": 5, "complexity": "S"},
-        {"title": "B", "spec": "do B", "touches": [], "depends_on": [1],
-         "priority": 10, "complexity": "M"},
-    ])
+    plan_json = _json.dumps(
+        [
+            {
+                "title": "A",
+                "spec": "do A",
+                "touches": [],
+                "depends_on": [],
+                "priority": 5,
+                "complexity": "S",
+            },
+            {
+                "title": "B",
+                "spec": "do B",
+                "touches": [],
+                "depends_on": [1],
+                "priority": 10,
+                "complexity": "M",
+            },
+        ]
+    )
 
     def plan_agent(task, workspace) -> AgentResult:
-        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json),
-                           stderr="", branch="")
+        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json), stderr="", branch="")
 
     rt._launch_agent = plan_agent
     rt.run()
@@ -964,14 +1012,21 @@ def test_planner_spawned_by_lineage(tc, tmp_path, http_client):
     _carry_plan(tc, task_id="plan-lineage")
     rt = _make_planner_runtime(tmp_path, http_client)
 
-    plan_json = _json.dumps([
-        {"title": "Child", "spec": "do child", "touches": [],
-         "depends_on": [], "priority": 5, "complexity": "S"},
-    ])
+    plan_json = _json.dumps(
+        [
+            {
+                "title": "Child",
+                "spec": "do child",
+                "touches": [],
+                "depends_on": [],
+                "priority": 5,
+                "complexity": "S",
+            },
+        ]
+    )
 
     def plan_agent(task, workspace) -> AgentResult:
-        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json),
-                           stderr="", branch="")
+        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json), stderr="", branch="")
 
     rt._launch_agent = plan_agent
     rt.run()
@@ -1002,23 +1057,33 @@ def test_planner_agent_failure_no_harvest(tc, tmp_path, http_client):
 def test_planner_409_idempotent(tc, tmp_path, http_client):
     """409 on child carry (already exists) is treated as idempotent success."""
     # Pre-create a child task that will collide
-    tc.post("/tasks", json={
-        "id": "task-idem-01",
-        "title": "Pre-existing",
-        "spec": "already here",
-    })
+    tc.post(
+        "/tasks",
+        json={
+            "id": "task-idem-01",
+            "title": "Pre-existing",
+            "spec": "already here",
+        },
+    )
 
     _carry_plan(tc, task_id="plan-idem")
     rt = _make_planner_runtime(tmp_path, http_client)
 
-    plan_json = _json.dumps([
-        {"title": "Child", "spec": "do child", "touches": [],
-         "depends_on": [], "priority": 5, "complexity": "S"},
-    ])
+    plan_json = _json.dumps(
+        [
+            {
+                "title": "Child",
+                "spec": "do child",
+                "touches": [],
+                "depends_on": [],
+                "priority": 5,
+                "complexity": "S",
+            },
+        ]
+    )
 
     def plan_agent(task, workspace) -> AgentResult:
-        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json),
-                           stderr="", branch="")
+        return AgentResult(returncode=0, stdout=_plan_agent_output(plan_json), stderr="", branch="")
 
     rt._launch_agent = plan_agent
     rt.run()
@@ -1089,18 +1154,22 @@ def test_planner_prompt_includes_plan_instructions(tmp_path, http_client):
 # ---------------------------------------------------------------------------
 
 
-def _carry_mission_plan(tc, task_id="plan-mission", title="Mission Plan", spec="plan this",
-                        mission_id="mission-001"):
+def _carry_mission_plan(
+    tc, task_id="plan-mission", title="Mission Plan", spec="plan this", mission_id="mission-001"
+):
     """Carry a plan task with mission_id set."""
     # First create the mission so link_task_to_mission works
     tc.post("/missions", json={"mission_id": mission_id, "spec": "test mission"})
-    r = tc.post("/tasks", json={
-        "id": task_id,
-        "title": title,
-        "spec": spec,
-        "capabilities_required": ["plan"],
-        "mission_id": mission_id,
-    })
+    r = tc.post(
+        "/tasks",
+        json={
+            "id": task_id,
+            "title": title,
+            "spec": spec,
+            "capabilities_required": ["plan"],
+            "mission_id": mission_id,
+        },
+    )
     assert r.status_code == 201
     return r.json()
 
@@ -1110,12 +1179,26 @@ def test_planner_mission_mode_stores_artifact(tc, tmp_path, http_client):
     _carry_mission_plan(tc, task_id="plan-m-001", mission_id="mission-art")
     rt = _make_planner_runtime(tmp_path, http_client)
 
-    plan_json = _json.dumps([
-        {"title": "Task A", "spec": "do A", "touches": ["api"],
-         "depends_on": [], "priority": 5, "complexity": "S"},
-        {"title": "Task B", "spec": "do B", "touches": ["db"],
-         "depends_on": [1], "priority": 10, "complexity": "M"},
-    ])
+    plan_json = _json.dumps(
+        [
+            {
+                "title": "Task A",
+                "spec": "do A",
+                "touches": ["api"],
+                "depends_on": [],
+                "priority": 5,
+                "complexity": "S",
+            },
+            {
+                "title": "Task B",
+                "spec": "do B",
+                "touches": ["db"],
+                "depends_on": [1],
+                "priority": 10,
+                "complexity": "M",
+            },
+        ]
+    )
 
     def plan_agent(task, workspace) -> AgentResult:
         return AgentResult(
@@ -1162,10 +1245,18 @@ def test_planner_legacy_mode_carries_children(tc, tmp_path, http_client):
     _carry_plan(tc, task_id="plan-legacy")
     rt = _make_planner_runtime(tmp_path, http_client)
 
-    plan_json = _json.dumps([
-        {"title": "Legacy Child", "spec": "do legacy", "touches": ["api"],
-         "depends_on": [], "priority": 5, "complexity": "S"},
-    ])
+    plan_json = _json.dumps(
+        [
+            {
+                "title": "Legacy Child",
+                "spec": "do legacy",
+                "touches": ["api"],
+                "depends_on": [],
+                "priority": 5,
+                "complexity": "S",
+            },
+        ]
+    )
 
     def plan_agent(task, workspace) -> AgentResult:
         return AgentResult(
@@ -1364,8 +1455,12 @@ def test_build_failure_record_silent():
     from antfarm.core.worker import build_failure_record, get_retry_policy
 
     rec = build_failure_record(
-        task_id="t1", attempt_id="a1", worker_id="w1",
-        returncode=0, stderr="", stdout="",
+        task_id="t1",
+        attempt_id="a1",
+        worker_id="w1",
+        returncode=0,
+        stderr="",
+        stdout="",
     )
     assert rec.failure_type == FailureType.SILENT_FAILURE
     assert rec.retryable is False
@@ -1404,10 +1499,9 @@ def test_process_one_task_silent_failure_trails_warning(tc, runtime):
     messages = [e["message"] for e in task["trail"]]
 
     # Human-readable warning present
-    assert any(
-        "silent_failure" in m or "empty stdout" in m
-        for m in messages
-    ), f"expected silent_failure trail entry, got: {messages}"
+    assert any("silent_failure" in m or "empty stdout" in m for m in messages), (
+        f"expected silent_failure trail entry, got: {messages}"
+    )
     # Structured FAILURE_RECORD emitted
     assert any("[FAILURE_RECORD]" in m for m in messages)
     # Harvest was NOT called — silent failure takes the failure branch
@@ -1503,7 +1597,8 @@ def test_process_one_task_emits_events_in_order(tc, runtime):
     runtime.run()
 
     lifecycle_types = [
-        e["type"] for e in _worker_events()
+        e["type"]
+        for e in _worker_events()
         if e["type"] in {"task_claimed", "workspace_created", "agent_launched"}
     ]
     assert lifecycle_types == ["task_claimed", "workspace_created", "agent_launched"]
@@ -1785,10 +1880,15 @@ def test_worker_passes_unmerged_dep_branch_to_workspace(tc, runtime):
     assert dep_branch, "dep attempt should have a branch after harvest"
 
     # Carry the child that depends on it
-    r = tc.post("/tasks", json={
-        "id": "task-child", "title": "Child", "spec": "c",
-        "depends_on": ["task-dep"],
-    })
+    r = tc.post(
+        "/tasks",
+        json={
+            "id": "task-child",
+            "title": "Child",
+            "spec": "c",
+            "depends_on": ["task-dep"],
+        },
+    )
     assert r.status_code == 201
 
     # Now forage the child — WorkspaceManager.create should be called with
@@ -1819,10 +1919,15 @@ def test_worker_skips_merged_deps(tc, runtime):
     assert r.status_code in (200, 201, 204)
 
     # Carry child
-    r = tc.post("/tasks", json={
-        "id": "task-child-merged", "title": "Child", "spec": "c",
-        "depends_on": ["task-dep-merged"],
-    })
+    r = tc.post(
+        "/tasks",
+        json={
+            "id": "task-child-merged",
+            "title": "Child",
+            "spec": "c",
+            "depends_on": ["task-dep-merged"],
+        },
+    )
     assert r.status_code == 201
 
     runtime.workspace_mgr.create.reset_mock()
@@ -2036,3 +2141,82 @@ def test_process_one_task_handles_timeout(tc, runtime):
     trail_msgs = [entry["message"] for entry in detail.get("trail", [])]
     assert any("[agent_timeout]" in m for m in trail_msgs)
     assert any("[FAILURE_RECORD]" in m for m in trail_msgs)
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat lifecycle (issue #333)
+# ---------------------------------------------------------------------------
+
+
+def test_heartbeat_starts_once_per_run_not_per_task(tc, runtime):
+    """_start_heartbeat_loop is called exactly once per run() (not per task).
+
+    Before the #333 fix, the heartbeat was started/stopped around each
+    _launch_agent call, so two tasks meant two starts. After the fix,
+    the heartbeat spans the whole run() and fires exactly once.
+    """
+    _carry(tc, task_id="task-hb-001", title="hb-1", spec="x")
+    _carry(tc, task_id="task-hb-002", title="hb-2", spec="y")
+
+    start_calls = 0
+    stop_calls = 0
+    real_start = runtime._start_heartbeat_loop
+    real_stop = runtime._stop_heartbeat_loop
+
+    def counting_start():
+        nonlocal start_calls
+        start_calls += 1
+        real_start()
+
+    def counting_stop():
+        nonlocal stop_calls
+        stop_calls += 1
+        real_stop()
+
+    runtime._start_heartbeat_loop = counting_start
+    runtime._stop_heartbeat_loop = counting_stop
+    runtime._launch_agent = _good_agent
+    runtime.run()
+
+    # Two tasks processed, but heartbeat lifecycle fires exactly once.
+    assert start_calls == 1, f"expected 1 start, got {start_calls}"
+    assert stop_calls == 1, f"expected 1 stop, got {stop_calls}"
+
+
+def test_heartbeat_running_during_full_run_lifetime(tc, runtime, monkeypatch):
+    """Heartbeat thread is alive across workspace creation AND agent run.
+
+    Before the #333 fix, heartbeat started only after workspace creation.
+    A slow git fetch outside the window would let doctor reap the worker.
+    This test asserts the thread is alive at both points.
+    """
+    _carry(tc, task_id="task-hb-live", title="live", spec="x")
+
+    # Make workspace creation observably take some "time" and assert the
+    # heartbeat thread is alive at that point.
+    alive_at_workspace = []
+    alive_at_agent = []
+
+    real_create = runtime.workspace_mgr.create
+
+    def observing_create(*args, **kwargs):
+        alive_at_workspace.append(
+            runtime._heartbeat_thread is not None and runtime._heartbeat_thread.is_alive()
+        )
+        return real_create(*args, **kwargs)
+
+    runtime.workspace_mgr.create = observing_create
+
+    def observing_agent(task, workspace):
+        alive_at_agent.append(
+            runtime._heartbeat_thread is not None and runtime._heartbeat_thread.is_alive()
+        )
+        return _good_agent(task, workspace)
+
+    runtime._launch_agent = observing_agent
+    runtime.run()
+
+    assert alive_at_workspace == [True], "heartbeat thread must be alive during workspace creation"
+    assert alive_at_agent == [True], "heartbeat thread must be alive during agent run"
+    # After run() exits, the thread is stopped.
+    assert runtime._heartbeat_thread is None


### PR DESCRIPTION
## Summary

Closes #333. Two surgical sub-fixes addressing the M2 task-06 runaway loop (8 attempts, 6 failed with no PR). Each bug feeds the other — fixing both in one PR closes the whole failure mode.

### Sub-fix (a): `recover_stale_task_if_worker_dead` honors `max_attempts`

**Before:** the doctor's stale-recovery path always reset the task to READY in `ready/`, regardless of how many attempts had already failed. `kickback()` routes to `blocked/` after `max_attempts`, but doctor-driven recovery bypassed that gate entirely. Result: a flapping worker could loop through `active/` → `ready/` unbounded times past the configured attempt cap.

**Fix:** `FileBackend.recover_stale_task_if_worker_dead(task_id, current_attempt_id, max_attempts=3)` now applies the same routing as `kickback()` — after superseding the current attempt, if total finished (DONE+SUPERSEDED) attempts >= effective max, the task moves to `blocked/` instead of `ready/`. Per-task `max_attempts` on the task dict still overrides the parameter. `Doctor.check_stale_tasks` reads `max_attempts` from its config (default 3) and plumbs it through. `GitHubBackend`'s no-op stub accepts the kwarg for signature parity. ABC updated.

### Sub-fix (b): Worker heartbeat thread spans the full `run()` lifetime

**Before:** the heartbeat thread started inside `_process_one_task`, right before `_launch_agent`, and stopped in the `finally` of that same call. Anything outside that window — workspace creation (long `git fetch` on a slow remote), harvest POSTs under colony contention, inter-task bookkeeping — left no heartbeat. Doctor could and did reap an alive worker, triggering (a) above.

**Fix:** `_start_heartbeat_loop()` now fires from `run()` immediately after `register_worker`, and `_stop_heartbeat_loop()` runs in the final `finally`. Heartbeat runs continuously for the worker's entire lifetime. The per-task start/stop in `_process_one_task` was removed.

## Test plan

New tests:
- [x] `test_recover_stale_task_moves_to_blocked_after_max_attempts` — 3 stale-recovery cycles, last one routes to `blocked/`
- [x] `test_recover_stale_task_respects_per_task_max_attempts` — per-task `max_attempts=5` overrides function default of 3
- [x] `test_check_stale_tasks_fix_respects_max_attempts` — doctor integration-level proof
- [x] `test_heartbeat_starts_once_per_run_not_per_task` — heartbeat starts/stops exactly once per `run()` even with multiple tasks
- [x] `test_heartbeat_running_during_full_run_lifetime` — thread is alive during workspace creation AND agent subprocess

Existing tests:
- [x] `pytest tests/ -x -q` — 1177 passed (1172 baseline + 5 new)
- [x] `ruff check .` — clean
- [x] `ruff format --check` on touched files — clean

## Motivating evidence

M2 task-06 runaway (observed in the field): 8 attempts, 6 failed without a PR. `max_attempts=3` but the task never reached `blocked/` because each failure was a stale-recovery (doctor requeued) rather than a proper `kickback`. The heartbeat gap explains why doctor kept seeing the worker as "dead" in the first place.