### PR TITLE
Bump version to 0.6.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antfarm"
-version = "0.6.7"
+version = "0.6.8"
 description = "Lightweight orchestration layer for distributing coding work across multiple AI coding agents"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Edit pyproject.toml: change `version = "0.6.7"` to `version = "0.6.8"`. No CHANGELOG is maintained in this repo per the spec, so skip that. Verify no other version-pinned references in the repo need updating (grep for 0.6.7). This is a trivial independent change that must land as part of the PR that closes #325.