### PR TITLE
Add retry-pattern inbox scanner

### DIFF
--- a/antfarm/core/inbox.py
+++ b/antfarm/core/inbox.py
@@ -27,12 +27,30 @@ def _age_seconds(ts: str) -> float:
     return (datetime.now(UTC) - dt).total_seconds()
 
 
+def _is_infra_task_id(task_id: str) -> bool:
+    """Return True if the task id identifies plan/review infrastructure work."""
+    return task_id.startswith(("plan-", "review-", "review-plan-"))
+
+
+def _last_failure_reason(trail: list[dict]) -> str:
+    """Extract the most recent kickback reason, else the last trail message."""
+    for entry in reversed(trail):
+        if entry.get("action_type") == "kickback":
+            msg = entry.get("message", "")
+            if msg:
+                return msg
+    if trail:
+        return trail[-1].get("message", "") or "unknown"
+    return "unknown"
+
+
 def collect_inbox_items(
     tasks: list[dict],
     workers: list[dict],
     *,
     stale_worker_ttl: float = 300.0,
     long_running_threshold: float = 3600.0,
+    max_attempts_default: int = 3,
 ) -> list[dict]:
     """Collect actionable items from colony state.
 
@@ -41,6 +59,9 @@ def collect_inbox_items(
         workers: List of worker dicts from the colony.
         stale_worker_ttl: Seconds after which a worker heartbeat is stale.
         long_running_threshold: Seconds after which an active task is flagged.
+        max_attempts_default: Default attempt ceiling when a task has no
+            ``max_attempts`` override. Finished attempts (DONE or SUPERSEDED)
+            are counted against this value.
 
     Returns:
         List of inbox item dicts with keys:
@@ -166,6 +187,54 @@ def collect_inbox_items(
                     "type": "kicked_back",
                     "message": f"Task '{tid}' was kicked back: {reason[:100]}",
                     "action": "Review rejection reason and requeue",
+                    "task_id": tid,
+                })
+
+        # --- Retry-pattern failures ---
+        # Count finished (DONE or SUPERSEDED) attempts and compare to the
+        # effective max_attempts budget. Blocked tasks at the ceiling become
+        # errors (retry_ceiling); non-blocked tasks one attempt away from the
+        # ceiling become warnings (retrying). Infra tasks (plan/review) are
+        # skipped — they're handled by their own lifecycle.
+        if not _is_infra_task_id(tid):
+            attempts = t.get("attempts", [])
+            finished = sum(
+                1 for a in attempts if a.get("status") in ("done", "superseded")
+            )
+            effective_max = t.get("max_attempts") or max_attempts_default
+            trail = t.get("trail", [])
+            if finished >= effective_max and status == "blocked":
+                reason = _last_failure_reason(trail)
+                items.append({
+                    "severity": "error",
+                    "type": "retry_ceiling",
+                    "message": (
+                        f"Task '{tid}' has failed {finished}/{effective_max} "
+                        f"attempts. Last failure: {reason[:120]}"
+                    ),
+                    "action": (
+                        "Task is at the retry ceiling. Inspect trail or "
+                        f"unblock via: antfarm kickback {tid}"
+                    ),
+                    "task_id": tid,
+                })
+            elif (
+                finished >= effective_max - 1
+                and finished > 0
+                and status != "blocked"
+            ):
+                reason = _last_failure_reason(trail)
+                items.append({
+                    "severity": "warning",
+                    "type": "retrying",
+                    "message": (
+                        f"Task '{tid}' has failed {finished} of max "
+                        f"{effective_max} attempts. Last failure: {reason[:120]}"
+                    ),
+                    "action": (
+                        "Task may block the mission if the next attempt fails. "
+                        "Inspect trail before it hits the retry ceiling."
+                    ),
                     "task_id": tid,
                 })
 

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -143,6 +143,235 @@ def test_inbox_empty_when_healthy():
     assert len(items) == 0
 
 
+def test_inbox_retry_ceiling_flags_blocked_task_at_max():
+    """Blocked task with finished attempts >= max emits retry_ceiling error."""
+    tasks = [
+        {
+            "id": "task-1",
+            "status": "blocked",
+            "depends_on": [],
+            "attempts": [
+                {"attempt_id": "att-1", "status": "superseded"},
+                {"attempt_id": "att-2", "status": "superseded"},
+                {"attempt_id": "att-3", "status": "superseded"},
+            ],
+            "trail": [
+                {"message": "tests failed: ImportError", "action_type": "kickback"},
+            ],
+            "signals": [],
+        },
+    ]
+    items = collect_inbox_items(tasks=tasks, workers=[])
+    ceiling = [i for i in items if i["type"] == "retry_ceiling"]
+    assert len(ceiling) == 1
+    assert ceiling[0]["severity"] == "error"
+    assert "task-1" in ceiling[0]["message"]
+    assert "3/3" in ceiling[0]["message"]
+    assert "ImportError" in ceiling[0]["message"]
+
+
+def test_inbox_retrying_flags_task_near_ceiling():
+    """Non-blocked task with finished attempts == max-1 emits retrying warning."""
+    tasks = [
+        {
+            "id": "task-2",
+            "status": "ready",
+            "depends_on": [],
+            "attempts": [
+                {"attempt_id": "att-1", "status": "superseded"},
+                {"attempt_id": "att-2", "status": "superseded"},
+            ],
+            "trail": [
+                {"message": "review failed: needs_changes", "action_type": "kickback"},
+            ],
+            "signals": [],
+        },
+    ]
+    items = collect_inbox_items(tasks=tasks, workers=[])
+    retrying = [i for i in items if i["type"] == "retrying"]
+    assert len(retrying) == 1
+    assert retrying[0]["severity"] == "warning"
+    assert "task-2" in retrying[0]["message"]
+    assert "2 of max 3" in retrying[0]["message"]
+    assert "needs_changes" in retrying[0]["message"]
+
+
+def test_inbox_retry_skips_infra_tasks():
+    """Plan/review infra tasks are excluded from retry-pattern emissions."""
+    tasks = [
+        {
+            "id": "plan-123",
+            "status": "blocked",
+            "depends_on": [],
+            "attempts": [
+                {"attempt_id": "att-1", "status": "superseded"},
+                {"attempt_id": "att-2", "status": "superseded"},
+                {"attempt_id": "att-3", "status": "superseded"},
+            ],
+            "trail": [{"message": "plan failure", "action_type": "kickback"}],
+            "signals": [],
+        },
+        {
+            "id": "review-456",
+            "status": "ready",
+            "depends_on": [],
+            "attempts": [
+                {"attempt_id": "att-1", "status": "superseded"},
+                {"attempt_id": "att-2", "status": "superseded"},
+            ],
+            "trail": [{"message": "review failure", "action_type": "kickback"}],
+            "signals": [],
+        },
+        {
+            "id": "review-plan-789",
+            "status": "blocked",
+            "depends_on": [],
+            "attempts": [
+                {"attempt_id": "att-1", "status": "superseded"},
+                {"attempt_id": "att-2", "status": "superseded"},
+                {"attempt_id": "att-3", "status": "superseded"},
+            ],
+            "trail": [{"message": "plan review failure", "action_type": "kickback"}],
+            "signals": [],
+        },
+    ]
+    items = collect_inbox_items(tasks=tasks, workers=[])
+    retry_items = [
+        i for i in items if i["type"] in ("retry_ceiling", "retrying")
+    ]
+    assert retry_items == []
+
+
+def test_inbox_retry_ignores_fresh_tasks():
+    """Tasks with zero or one finished attempt do not trigger retry emissions."""
+    tasks = [
+        {
+            "id": "task-fresh",
+            "status": "ready",
+            "depends_on": [],
+            "attempts": [],
+            "trail": [],
+            "signals": [],
+        },
+        {
+            "id": "task-one-attempt",
+            "status": "ready",
+            "depends_on": [],
+            "attempts": [{"attempt_id": "att-1", "status": "superseded"}],
+            "trail": [{"message": "first failure", "action_type": "kickback"}],
+            "signals": [],
+        },
+    ]
+    items = collect_inbox_items(tasks=tasks, workers=[])
+    retry_items = [
+        i for i in items if i["type"] in ("retry_ceiling", "retrying")
+    ]
+    assert retry_items == []
+
+
+def test_inbox_retry_last_failure_reason_prefers_kickback_entry():
+    """Last failure reason prefers most-recent kickback over trailing chatter."""
+    tasks = [
+        {
+            "id": "task-9",
+            "status": "blocked",
+            "depends_on": [],
+            "attempts": [
+                {"attempt_id": "att-1", "status": "superseded"},
+                {"attempt_id": "att-2", "status": "superseded"},
+                {"attempt_id": "att-3", "status": "superseded"},
+            ],
+            "trail": [
+                {"message": "merge conflict on models.py", "action_type": "kickback"},
+                {"message": "doctor recovered task"},
+            ],
+            "signals": [],
+        },
+    ]
+    items = collect_inbox_items(tasks=tasks, workers=[])
+    ceiling = [i for i in items if i["type"] == "retry_ceiling"]
+    assert len(ceiling) == 1
+    assert "merge conflict on models.py" in ceiling[0]["message"]
+
+
+def test_inbox_retry_falls_back_to_last_trail_entry():
+    """If no kickback entry exists, fall back to the most recent trail message."""
+    tasks = [
+        {
+            "id": "task-10",
+            "status": "ready",
+            "depends_on": [],
+            "attempts": [
+                {"attempt_id": "att-1", "status": "superseded"},
+                {"attempt_id": "att-2", "status": "superseded"},
+            ],
+            "trail": [{"message": "generic failure trace"}],
+            "signals": [],
+        },
+    ]
+    items = collect_inbox_items(tasks=tasks, workers=[])
+    retrying = [i for i in items if i["type"] == "retrying"]
+    assert len(retrying) == 1
+    assert "generic failure trace" in retrying[0]["message"]
+
+
+def test_inbox_retry_respects_per_task_max_attempts_override():
+    """Per-task max_attempts overrides the default budget."""
+    tasks = [
+        {
+            "id": "task-11",
+            "status": "blocked",
+            "depends_on": [],
+            "max_attempts": 2,
+            "attempts": [
+                {"attempt_id": "att-1", "status": "superseded"},
+                {"attempt_id": "att-2", "status": "superseded"},
+            ],
+            "trail": [{"message": "failure", "action_type": "kickback"}],
+            "signals": [],
+        },
+    ]
+    items = collect_inbox_items(tasks=tasks, workers=[])
+    ceiling = [i for i in items if i["type"] == "retry_ceiling"]
+    assert len(ceiling) == 1
+    assert "2/2" in ceiling[0]["message"]
+
+
+def test_inbox_retry_ceiling_sorts_before_retrying():
+    """Errors (retry_ceiling) sort before warnings (retrying)."""
+    tasks = [
+        {
+            "id": "task-warn",
+            "status": "ready",
+            "depends_on": [],
+            "attempts": [
+                {"attempt_id": "att-1", "status": "superseded"},
+                {"attempt_id": "att-2", "status": "superseded"},
+            ],
+            "trail": [{"message": "warn reason", "action_type": "kickback"}],
+            "signals": [],
+        },
+        {
+            "id": "task-err",
+            "status": "blocked",
+            "depends_on": [],
+            "attempts": [
+                {"attempt_id": "att-1", "status": "superseded"},
+                {"attempt_id": "att-2", "status": "superseded"},
+                {"attempt_id": "att-3", "status": "superseded"},
+            ],
+            "trail": [{"message": "err reason", "action_type": "kickback"}],
+            "signals": [],
+        },
+    ]
+    items = collect_inbox_items(tasks=tasks, workers=[])
+    retry_items = [
+        i for i in items if i["type"] in ("retry_ceiling", "retrying")
+    ]
+    assert retry_items[0]["type"] == "retry_ceiling"
+    assert retry_items[1]["type"] == "retrying"
+
+
 def test_inbox_sorts_by_severity():
     """Errors come before warnings, warnings before info."""
     tasks = [


### PR DESCRIPTION
Extend antfarm/core/inbox.py collect_inbox_items to emit retry_ceiling and retrying entries. inbox.py already has its own task scanner (not a Finding consumer), so add a parallel code path inside the task loop. Reuse the same semantics as the doctor check: skip infra tasks (id starts with plan-, review-, review-plan-), count attempts whose status is 'done' or 'superseded', resolve effective_max from t.get('max_attempts') or a parameter default of 3 (add `max_attempts_default: int = 3` kwarg to c