### PR TITLE
Add retry-pattern doctor check

### DIFF
--- a/antfarm/core/doctor.py
+++ b/antfarm/core/doctor.py
@@ -76,6 +76,7 @@ def run_doctor(
     findings.extend(check_stale_workers(backend, config, fix))
     findings.extend(check_stuck_workers(backend, config, fix))
     findings.extend(check_stale_tasks(backend, config, fix))
+    findings.extend(check_retry_patterns(backend, config))
     findings.extend(check_no_reviewer_capacity(backend, config))
     findings.extend(check_stale_guards(backend, config, fix))
     findings.extend(check_workspace_conflicts(backend))
@@ -510,6 +511,130 @@ def check_stale_tasks(backend, config: dict, fix: bool = False) -> list[Finding]
                 else:
                     f.message += " (worker recovered or task drifted; no action taken)"
             findings.append(f)
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Check 5a: Retry patterns (#325)
+# ---------------------------------------------------------------------------
+
+
+_RETRY_INFRA_ID_PREFIXES = ("plan-", "review-", "review-plan-")
+
+
+def _is_retry_infra_task(task: dict) -> bool:
+    """Return True for plan/review infrastructure tasks.
+
+    The doctor check filters these out because operators care about
+    implementation retry failures, not scaffolding turnover.
+    """
+    task_id = task.get("id", "") or ""
+    title = task.get("title", "") or ""
+    for prefix in _RETRY_INFRA_ID_PREFIXES:
+        if task_id.startswith(prefix) or title.startswith(prefix):
+            return True
+    return False
+
+
+def _extract_last_failure_reason(task: dict) -> str:
+    """Return a human-readable reason for the task's most recent failure.
+
+    Scans the trail in reverse for the first entry with
+    ``action_type=='kickback'``; falls back to the last trail entry whose
+    message mentions ``stderr``; finally falls back to the last trail
+    message. Returns an empty string when no trail exists.
+    """
+    trail = task.get("trail") or []
+    for entry in reversed(trail):
+        if entry.get("action_type") == "kickback":
+            return str(entry.get("message") or "")
+    for entry in reversed(trail):
+        msg = str(entry.get("message") or "")
+        if "stderr" in msg:
+            return msg
+    if trail:
+        return str(trail[-1].get("message") or "")
+    return ""
+
+
+def check_retry_patterns(backend, config: dict) -> list[Finding]:
+    """Surface tasks that are retrying or at the retry ceiling.
+
+    For each non-infra task, count finished attempts (DONE or SUPERSEDED —
+    the same definition ``kickback()`` uses). The effective attempt budget
+    is the task's ``max_attempts`` override, else ``config['max_attempts']``,
+    else ``3``.
+
+    - ``finished >= effective_max`` AND ``status == 'blocked'`` →
+      ``error`` severity, ``retry_ceiling`` check.
+    - ``finished >= effective_max - 1`` AND ``status != 'blocked'`` AND
+      ``finished > 0`` → ``warning`` severity, ``retrying`` check.
+
+    Both findings are report-only (``auto_fixable=False``). Operators
+    resolve them by inspecting the trail or calling ``antfarm kickback``.
+
+    Args:
+        backend: TaskBackend instance.
+        config: Doctor config dict (``max_attempts`` optional, default 3).
+
+    Returns:
+        List of findings, one per flagged task.
+    """
+    findings: list[Finding] = []
+
+    try:
+        tasks = backend.list_tasks()
+    except Exception:
+        return findings
+
+    default_max = config.get("max_attempts", 3)
+    finished_statuses = {"done", "superseded"}
+
+    for task in tasks:
+        if _is_retry_infra_task(task):
+            continue
+
+        attempts = task.get("attempts") or []
+        finished = sum(1 for a in attempts if a.get("status") in finished_statuses)
+        if finished == 0:
+            continue
+
+        effective_max = task.get("max_attempts") or default_max
+        status = task.get("status", "")
+        task_id = task.get("id", "")
+        reason = _extract_last_failure_reason(task)
+
+        if finished >= effective_max and status == "blocked":
+            message = (
+                f"Task '{task_id}' has failed {finished}/{effective_max} attempts."
+            )
+            if reason:
+                message += f" Last failure: {reason}"
+            findings.append(
+                Finding(
+                    severity="error",
+                    check="retry_ceiling",
+                    message=message,
+                    auto_fixable=False,
+                )
+            )
+            continue
+
+        if finished >= effective_max - 1 and status != "blocked":
+            message = (
+                f"Task '{task_id}' has failed {finished} of max {effective_max} attempts."
+            )
+            if reason:
+                message += f" Last failure: {reason}"
+            findings.append(
+                Finding(
+                    severity="warning",
+                    check="retrying",
+                    message=message,
+                    auto_fixable=False,
+                )
+            )
 
     return findings
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1816,3 +1816,166 @@ def test_check_stale_tasks_fix_respects_max_attempts(setup):
     data = json.loads(blocked_path.read_text())
     assert data["status"] == "blocked"
     assert any("moved to blocked" in t["message"] for t in data.get("trail", []))
+
+
+# ---------------------------------------------------------------------------
+# Retry-pattern checks (#325)
+# ---------------------------------------------------------------------------
+
+
+def _write_task_file(
+    data_dir: Path,
+    folder: str,
+    task_id: str,
+    *,
+    status: str,
+    attempts: list[dict] | None = None,
+    trail: list[dict] | None = None,
+    title: str | None = None,
+    max_attempts: int | None = None,
+) -> Path:
+    """Place a task JSON file directly into {data_dir}/tasks/{folder}/."""
+    task = _make_task(task_id)
+    task["status"] = status
+    task["current_attempt"] = None
+    task["attempts"] = attempts or []
+    task["trail"] = trail or []
+    task["signals"] = []
+    if title is not None:
+        task["title"] = title
+    if max_attempts is not None:
+        task["max_attempts"] = max_attempts
+    path = data_dir / "tasks" / folder / f"{task_id}.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(task))
+    return path
+
+
+def _att(attempt_id: str, status: str) -> dict:
+    return {
+        "attempt_id": attempt_id,
+        "worker_id": "worker-x",
+        "status": status,
+        "branch": None,
+        "pr": None,
+        "started_at": datetime.now(UTC).isoformat(),
+        "completed_at": datetime.now(UTC).isoformat(),
+    }
+
+
+def test_retry_patterns_flags_retry_ceiling(setup):
+    """3 superseded attempts + status=blocked → one retry_ceiling error."""
+    backend, config = setup
+    data_dir = Path(config["data_dir"])
+    _write_task_file(
+        data_dir,
+        "blocked",
+        "task-dead",
+        status="blocked",
+        attempts=[
+            _att("att-001", "superseded"),
+            _att("att-002", "superseded"),
+            _att("att-003", "superseded"),
+        ],
+    )
+
+    findings = run_doctor(backend, config, fix=False)
+    retry = [f for f in findings if f.check == "retry_ceiling"]
+    assert len(retry) == 1
+    assert retry[0].severity == "error"
+    assert retry[0].auto_fixable is False
+    assert "task-dead" in retry[0].message
+    assert "3/3" in retry[0].message
+
+
+def test_retry_patterns_flags_retrying_at_two_of_three(setup):
+    """2 finished attempts, task still ready → one retrying warning."""
+    backend, config = setup
+    data_dir = Path(config["data_dir"])
+    _write_task_file(
+        data_dir,
+        "ready",
+        "task-warn",
+        status="ready",
+        attempts=[
+            _att("att-001", "superseded"),
+            _att("att-002", "superseded"),
+        ],
+    )
+
+    findings = run_doctor(backend, config, fix=False)
+    retrying = [f for f in findings if f.check == "retrying"]
+    ceilings = [f for f in findings if f.check == "retry_ceiling"]
+    assert ceilings == []
+    assert len(retrying) == 1
+    assert retrying[0].severity == "warning"
+    assert retrying[0].auto_fixable is False
+    assert "task-warn" in retrying[0].message
+    assert "2 of max 3" in retrying[0].message
+
+
+def test_retry_patterns_ignores_fresh_task(setup):
+    """A task with zero finished attempts triggers no retry findings."""
+    backend, config = setup
+    backend.carry(_make_task("task-fresh"))
+
+    findings = run_doctor(backend, config, fix=False)
+    retry = [f for f in findings if f.check in ("retry_ceiling", "retrying")]
+    assert retry == []
+
+
+def test_retry_patterns_skips_infra_tasks(setup):
+    """Plan/review infra tasks are never flagged for retry patterns."""
+    backend, config = setup
+    data_dir = Path(config["data_dir"])
+    infra_ids = ["plan-foo", "review-foo", "review-plan-foo"]
+    for tid in infra_ids:
+        _write_task_file(
+            data_dir,
+            "blocked",
+            tid,
+            status="blocked",
+            attempts=[
+                _att("att-001", "superseded"),
+                _att("att-002", "superseded"),
+                _att("att-003", "superseded"),
+            ],
+        )
+
+    findings = run_doctor(backend, config, fix=False)
+    retry = [f for f in findings if f.check in ("retry_ceiling", "retrying")]
+    assert retry == []
+
+
+def test_retry_patterns_extracts_last_failure_reason(setup):
+    """The most recent kickback trail message is surfaced in the finding."""
+    backend, config = setup
+    data_dir = Path(config["data_dir"])
+    now = datetime.now(UTC).isoformat()
+    trail = [
+        {"ts": now, "worker_id": "w1", "message": "started work"},
+        {
+            "ts": now,
+            "worker_id": "system",
+            "message": "tests failed: ImportError while loading conftest",
+            "action_type": "kickback",
+        },
+        {"ts": now, "worker_id": "w2", "message": "later noise unrelated to failure"},
+    ]
+    _write_task_file(
+        data_dir,
+        "blocked",
+        "task-reason",
+        status="blocked",
+        attempts=[
+            _att("att-001", "superseded"),
+            _att("att-002", "superseded"),
+            _att("att-003", "superseded"),
+        ],
+        trail=trail,
+    )
+
+    findings = run_doctor(backend, config, fix=False)
+    retry = [f for f in findings if f.check == "retry_ceiling"]
+    assert len(retry) == 1
+    assert "tests failed: ImportError while loading conftest" in retry[0].message


### PR DESCRIPTION
Add `check_retry_patterns(backend, config) -> list[Finding]` to antfarm/core/doctor.py. Scan all tasks via backend.list_tasks() across ready/active/done/blocked/paused. For each task, skip infra (title/id prefixes plan-*, review-*, review-plan-*). Count finished attempts where status in (DONE, SUPERSEDED) — same definition as kickback(). Resolve effective_max = task.get('max_attempts') or config.get('max_attempts', 3). Extract last failure reason by scanning trail in reverse for first entry with