### PR TITLE
Bump version to 0.6.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antfarm"
-version = "0.6.8"
+version = "0.6.9"
 description = "Lightweight orchestration layer for distributing coding work across multiple AI coding agents"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
In `pyproject.toml`, change `version = "0.6.8"` to `version = "0.6.9"`. This release ships the depth-aware autoscaler for issue #320. No other changes.