### PR TITLE
feat(worker): bump builder idle polls to 20 (refs #321)

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -422,7 +422,7 @@ def worker():
     default=None,
     help=(
         "Max consecutive empty forages before exit. "
-        "Unset = role-based default (reviewer=10, builder=5, planner=0). "
+        "Unset = role-based default (reviewer=10, builder=20, planner=0). "
         "0 = exit on first empty."
     ),
 )

--- a/antfarm/core/worker.py
+++ b/antfarm/core/worker.py
@@ -247,7 +247,7 @@ class WorkerRuntime:
             retry policy applies (see #301).
         max_empty_polls: Max consecutive empty forages before the worker exits.
             When None (default), the role-based default applies:
-            reviewer=10, builder=5, planner=0 (exit on first empty). An explicit
+            reviewer=10, builder=20, planner=0 (exit on first empty). An explicit
             integer overrides the role default; 0 preserves the original
             "exit immediately on first empty" semantics as an opt-in.
         client: Optional httpx.Client for dependency injection in tests.
@@ -298,10 +298,11 @@ class WorkerRuntime:
             self._role = "planner"
             role_max_idle_polls = 0
         else:
-            # Builders wait up to 2.5min so they outlast a typical planner run
-            # and don't race the planner when started together (#144).
+            # Builders wait up to 10min so they amortize Claude Code subprocess
+            # and worktree setup cost across tasks during long missions, and
+            # give the autoscaler time to propagate scaling signals (#321).
             self._role = "builder"
-            role_max_idle_polls = 5  # 5 * 30s = 2.5min
+            role_max_idle_polls = 20  # 20 * 30s = 10min
 
         # Explicit CLI override wins over role default; None preserves it (#272).
         self._max_idle_polls = role_max_idle_polls if max_empty_polls is None else max_empty_polls

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antfarm"
-version = "0.6.9"
+version = "0.6.10"
 description = "Lightweight orchestration layer for distributing coding work across multiple AI coding agents"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1385,7 +1385,7 @@ def _make_runtime_with_caps(tmp_path, http_client, name, capabilities):
 
 
 def test_builder_polls_on_empty_queue(tmp_path, http_client):
-    """Builder workers poll 5 times (2.5min) before exiting on empty queue."""
+    """Builder workers poll 20 times (10min) before exiting on empty queue."""
     rt = _make_runtime_with_caps(tmp_path, http_client, "builder-1", capabilities=[])
 
     call_count = [0]
@@ -1397,8 +1397,8 @@ def test_builder_polls_on_empty_queue(tmp_path, http_client):
     rt.colony.forage = fake_forage
     rt.run()
 
-    # max_idle_polls=5 → one initial attempt + 5 retries = 6 forage calls
-    assert call_count[0] == 6
+    # max_idle_polls=20 → one initial attempt + 20 retries = 21 forage calls
+    assert call_count[0] == 21
 
 
 def test_planner_exits_immediately_on_empty_queue(tmp_path, http_client):
@@ -1816,7 +1816,7 @@ def test_max_empty_polls_zero_exits_immediately(tmp_path, http_client):
 
 
 def test_role_defaults_preserved_when_unset(tmp_path, http_client):
-    """max_empty_polls=None keeps reviewer=10, builder=5, planner=0."""
+    """max_empty_polls=None keeps reviewer=10, builder=20, planner=0."""
     reviewer = _make_runtime_with_polls(
         tmp_path, http_client, "r1", capabilities=["review"], max_empty_polls=None
     )
@@ -1828,8 +1828,35 @@ def test_role_defaults_preserved_when_unset(tmp_path, http_client):
     )
 
     assert reviewer._max_idle_polls == 10
-    assert builder._max_idle_polls == 5
+    assert builder._max_idle_polls == 20
     assert planner._max_idle_polls == 0
+
+
+def test_builder_default_max_empty_polls_is_twenty(tmp_path, http_client):
+    """Builders default to 20 idle polls so long missions amortize setup cost (#321)."""
+    builder = _make_runtime_with_polls(
+        tmp_path, http_client, "b-default", capabilities=[], max_empty_polls=None
+    )
+    assert builder._role == "builder"
+    assert builder._max_idle_polls == 20
+
+
+def test_reviewer_default_unchanged(tmp_path, http_client):
+    """Reviewer default stays at 10 after the builder bump (#321)."""
+    reviewer = _make_runtime_with_polls(
+        tmp_path, http_client, "r-default", capabilities=["review"], max_empty_polls=None
+    )
+    assert reviewer._role == "reviewer"
+    assert reviewer._max_idle_polls == 10
+
+
+def test_explicit_max_empty_polls_overrides_default(tmp_path, http_client):
+    """Explicit --max-empty-polls wins over the role default for builders (#321)."""
+    builder = _make_runtime_with_polls(
+        tmp_path, http_client, "b-explicit", capabilities=[], max_empty_polls=3
+    )
+    assert builder._role == "builder"
+    assert builder._max_idle_polls == 3
 
 
 def test_invalid_poll_interval_raises(tmp_path, http_client):


### PR DESCRIPTION
## Summary
- Raise the builder role's default `max_empty_polls` from 5 (2.5min) to 20 (10min) so long missions amortize Claude Code subprocess and worktree setup cost across tasks and give the autoscaler time to propagate signals.
- Reviewer (10) and planner (0) defaults are unchanged. Explicit `--max-empty-polls` still overrides the role default.
- Bump version `0.6.9` -> `0.6.10`.

## Scope limitation (intentional)
This PR only bumps the idle-poll default. The two more invasive changes discussed in #321 are deferred:
- **Worktree reuse across tasks** — requires branch-management rework and is too invasive for a small patch.
- **Claude Code subprocess reuse** — blocked upstream; Claude Code doesn't support clean reset between tasks today.

Both will be tracked as follow-up work on the issue.

## Test Plan
- [x] `ruff check .` passes.
- [x] `pytest tests/ -x -q` passes locally (1201 passed).
- [x] New `test_builder_default_max_empty_polls_is_twenty` asserts the bumped default.
- [x] New `test_reviewer_default_unchanged` pins reviewer=10.
- [x] New `test_explicit_max_empty_polls_overrides_default` pins explicit-override semantics.
- [x] Updated `test_builder_polls_on_empty_queue` and `test_role_defaults_preserved_when_unset` to the new default.

Refs #321