### PR TITLE
feat(queen): instruct planner to maximize parallelizable task count

### DIFF
--- a/antfarm/core/queen.py
+++ b/antfarm/core/queen.py
@@ -36,6 +36,40 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
+def _planner_parallelism_directives(max_parallel_builders: int) -> str:
+    """Shared directives that steer the planner toward parallelizable plans.
+
+    The default planner decomposition tends to produce sequential chains
+    (task-02 depends on task-01, task-03 on task-02, etc.) even when feature
+    parts are loosely coupled. That clamps wall-clock throughput to the
+    critical path — observed in mission M1 where 3 builders ended up
+    serialized. These directives explicitly reframe the goal as MAXIMIZING
+    the number of independent first-wave tasks so the autoscaler can fan out.
+
+    See issue #322 for the motivating data.
+    """
+    return (
+        "PARALLELISM IS A FIRST-CLASS GOAL.\n"
+        f"- The colony can run up to {max_parallel_builders} builders in "
+        "parallel (max_parallel_builders). Plan for that.\n"
+        "- Prefer MANY SMALL INDEPENDENT tasks over a few large sequential "
+        "ones. When a feature has loosely-coupled parts (e.g. helper + CLI "
+        "flags + tests + docs), split them if they can be completed without "
+        "sharing branches or stepping on the same files.\n"
+        f"- Target: the first wave (tasks with empty depends_on) should "
+        f"contain at least {max_parallel_builders} tasks whenever the spec "
+        "allows. If fewer tasks can run in the first wave, explain why in "
+        "the plan summary / warnings (e.g. 'scaffolding must land first').\n"
+        "- Only add a dependency when the downstream task cannot start "
+        "without the upstream output. Shared final integration or review is "
+        "NOT a reason to chain tasks.\n"
+        "- LOWER BOUND on task size: no task should be smaller than ~15-30 "
+        "minutes of expected work. Use the `complexity` field (S/M/L) as "
+        "the signal — S = 15-30 min, M = 30-90 min, L = 90+ min. Do not "
+        "split work so fine that tasks become trivial."
+    )
+
+
 def _parse_iso(ts: str) -> float:
     """Parse an ISO 8601 timestamp to a Unix timestamp."""
     try:
@@ -373,13 +407,15 @@ class Queen:
         """Create the plan task for a mission. Returns the task ID."""
         mission_id = mission["mission_id"]
         plan_task_id = f"plan-{mission_id}"
+        max_parallel = int(mission["config"].get("max_parallel_builders", 4))
 
         now = _now_iso()
         task = {
             "id": plan_task_id,
             "title": f"Plan mission {mission_id}",
             "spec": (
-                "You are a planner. Decompose the following spec into tasks.\n"
+                "You are a planner. Decompose the following spec into tasks.\n\n"
+                f"{_planner_parallelism_directives(max_parallel)}\n\n"
                 "Output a JSON array of tasks with max 10 tasks.\n\n"
                 "---\n\n"
                 f"{mission['spec']}"
@@ -464,6 +500,7 @@ class Queen:
 
         summary = verdict.get("summary", "")
         feedback = verdict.get("feedback", "")
+        max_parallel = int(mission["config"].get("max_parallel_builders", 4))
 
         now = _now_iso()
         task = {
@@ -472,6 +509,7 @@ class Queen:
             "spec": (
                 "You are a planner. The previous plan was rejected.\n\n"
                 f"Reviewer feedback:\n{summary}\n{feedback}\n\n"
+                f"{_planner_parallelism_directives(max_parallel)}\n\n"
                 "Original spec:\n"
                 f"{mission['spec']}\n\n"
                 "Revise the plan and output a JSON array of tasks with max 10 tasks.\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antfarm"
-version = "0.6.10"
+version = "0.6.11"
 description = "Lightweight orchestration layer for distributing coding work across multiple AI coding agents"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_queen.py
+++ b/tests/test_queen.py
@@ -1447,3 +1447,101 @@ def test_queen_does_not_emit_mission_complete_on_failed_transition(env, event_bu
 
     assert backend.get_mission(mission["mission_id"])["status"] == "failed"
     assert _find_events(event_bus, type_="mission_complete") == []
+
+
+# ---------------------------------------------------------------------------
+# Planner prompt parallelism directives (issue #322)
+# ---------------------------------------------------------------------------
+
+
+def test_planner_directives_helper_includes_parallelism_guidance():
+    """The shared directive string must name parallelism explicitly and cite
+    the concrete builder cap so the planner can target the first wave size.
+
+    Prompt text is the product here — regressing any of these substrings
+    regresses the fix for issue #322.
+    """
+    from antfarm.core.queen import _planner_parallelism_directives
+
+    text = _planner_parallelism_directives(4)
+
+    assert "PARALLELISM" in text
+    assert "max_parallel_builders" in text
+    assert "4" in text  # the cap is interpolated verbatim
+    assert "first wave" in text.lower()
+    assert "MANY SMALL INDEPENDENT" in text
+    # Lower-bound guardrail
+    assert "15-30" in text
+    assert "complexity" in text.lower()
+    # Explicitly asks the planner to explain when fewer tasks are possible
+    assert "explain why" in text.lower()
+
+
+def test_plan_task_spec_embeds_parallelism_directives(env):
+    """The plan task spec handed to the planner worker must contain the new
+    parallelism directives and the mission's configured builder cap.
+    """
+    backend = env["backend"]
+    queen = env["queen"]
+
+    mission = _create_mission(backend, config_overrides={"max_parallel_builders": 6})
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)
+
+    plan_task = backend.get_task(f"plan-{mission['mission_id']}")
+    spec = plan_task["spec"]
+
+    assert "PARALLELISM" in spec
+    assert "MANY SMALL INDEPENDENT" in spec
+    # The configured cap (6) must be present, not just the default (4).
+    assert "6" in spec
+    assert "15-30" in spec
+    # Original instruction is still there.
+    assert "JSON array of tasks" in spec
+    # Mission spec body is still appended after the directives.
+    assert mission["spec"] in spec
+
+
+def test_re_plan_task_spec_embeds_parallelism_directives(env):
+    """Re-plan tasks created after a needs_changes verdict must also carry
+    the parallelism directives — the bug is just as likely to reappear on
+    the second pass.
+    """
+    backend = env["backend"]
+    queen = env["queen"]
+
+    mission = _create_mission(
+        backend,
+        config_overrides={"max_parallel_builders": 3, "require_plan_review": True},
+    )
+
+    # Drive mission: PLANNING → REVIEWING_PLAN → PLANNING (via needs_changes)
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)  # create plan task
+
+    artifact = _make_plan_artifact(plan_task_id=f"plan-{mission['mission_id']}")
+    _harvest_plan_task_with_artifact(backend, f"plan-{mission['mission_id']}", artifact)
+
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)  # → REVIEWING_PLAN (creates review task)
+
+    review_task_id = f"review-plan-{mission['mission_id']}"
+    _set_review_verdict_on_task(
+        backend,
+        review_task_id,
+        _make_review_verdict(verdict="needs_changes", summary="split more"),
+    )
+
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)  # consume needs_changes → back to PLANNING, creates re-plan task
+
+    m = backend.get_mission(mission["mission_id"])
+    re_plan_task_id = f"plan-{mission['mission_id']}-re1"
+    re_plan_task = backend.get_task(re_plan_task_id)
+
+    assert re_plan_task is not None, "re-plan task should have been created"
+    spec = re_plan_task["spec"]
+    assert "PARALLELISM" in spec
+    assert "MANY SMALL INDEPENDENT" in spec
+    assert "3" in spec  # configured cap survives into the re-plan prompt
+    assert "split more" in spec  # reviewer feedback preserved


### PR DESCRIPTION
## Summary
- Reshape the Queen's planner prompt around parallelism: explicitly prefer MANY SMALL INDEPENDENT tasks over sequential chains, interpolate the mission's `max_parallel_builders` as the first-wave target, and require the planner to justify smaller first waves.
- Add a lower-bound guardrail (~15-30 min per task, signaled via the `complexity` S/M/L field) so the "split everything" directive doesn't collapse into trivial shards.
- Factor directives into a shared `_planner_parallelism_directives(max_parallel_builders)` helper used by both the initial plan task and re-plan tasks (they regressed identically before).
- Bump version `0.6.10` -> `0.6.11`.

## Why
From issue #322: M1 ran ~45min wall-clock with 3 builders because the planner produced `task-02 depends on task-01, task-03 on task-02, ...` even for loosely-coupled work. Throughput was clamped to the critical path. This PR is prompt-engineering only — no schema change, no downstream processing change.

## Validation
Prompt effectiveness is empirical (planner output is non-deterministic). No regression test can guarantee the Queen's output parallelizes — the prompt is the best lever we have. What the tests DO assert:

- `test_planner_directives_helper_includes_parallelism_guidance` — the new directive string carries the load-bearing substrings (PARALLELISM, MANY SMALL INDEPENDENT, 15-30, complexity, first wave, explain why, `max_parallel_builders`).
- `test_plan_task_spec_embeds_parallelism_directives` — the plan task spec handed to the planner worker interpolates the mission's configured cap (e.g. 6) rather than a hardcoded default.
- `test_re_plan_task_spec_embeds_parallelism_directives` — re-plan tasks after `needs_changes` verdicts also carry the directives and the cap, and preserve reviewer feedback.

Real effectiveness will be validated by re-running a loosely-coupled mission and measuring first-wave task count + wall-clock time.

## Test Plan
- [x] `ruff check .` clean
- [x] `ruff format` touched files
- [x] `pytest tests/test_queen.py -x -q` — 38 passed (3 new)
- [x] `pytest tests/ -x -q` — 1204 passed

## Related Issues
Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)