### PR TITLE
fix(soldier,cli): untracked-safe dirty check + doctor reads config.json

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -839,7 +839,19 @@ def doctor(fix: bool, data_dir: str, sweep_legacy_tmux: bool, yes: bool):
         return
 
     backend = FileBackend(data_dir)
-    config = {"data_dir": data_dir}
+    # Start from the colony's persisted config so checks like
+    # ``check_stale_tasks`` honor operator-configured values (e.g.
+    # ``max_attempts``). Missing or malformed config.json falls back to
+    # defaults silently — doctor is diagnostic, not authoritative. See #344.
+    config: dict = {}
+    _config_path = os.path.join(data_dir, "config.json")
+    if os.path.exists(_config_path):
+        try:
+            with open(_config_path) as _f:
+                config = json.load(_f)
+        except (json.JSONDecodeError, OSError):
+            config = {}
+    config["data_dir"] = data_dir
     findings = run_doctor(backend, config, fix=fix)
 
     if not findings:

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -1136,8 +1136,15 @@ class Soldier:
 
         Returns True iff all three are simultaneously true:
         1. HEAD is attached and points at ``self.integration_branch``.
-        2. Working tree is clean (``git status --porcelain`` empty).
+        2. Tracked files are clean (``git diff-index --quiet HEAD``).
         3. No ``antfarm/temp-merge`` branch exists.
+
+        Untracked files are intentionally ignored: the soldier repo commonly
+        carries untracked artifacts (e.g. ``.claude/`` worktrees, test
+        scratch) that are orthogonal to merge safety. ``git status
+        --porcelain`` treats these as "dirty" and produced spurious
+        ``cleanup_incomplete`` events during #338 dogfood; the tracked-state
+        check via ``git diff-index`` is the correct primitive here.
 
         Any subprocess error is treated as "not clean" — the caller is
         expected to recover via ``_force_clean_repo``. Never raises.
@@ -1155,15 +1162,16 @@ class Soldier:
             if head != self.integration_branch:
                 return False
 
+            # diff-index --quiet exits 0 when tracked files are clean against
+            # HEAD, 1 when they have modifications. Untracked files are
+            # invisible to this check — that is the point.
             r = subprocess.run(
-                ["git", "status", "--porcelain"],
+                ["git", "diff-index", "--quiet", "HEAD", "--"],
                 cwd=self.repo_path,
                 capture_output=True,
                 check=False,
             )
             if r.returncode != 0:
-                return False
-            if r.stdout.decode().strip() != "":
                 return False
 
             r = subprocess.run(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "antfarm"
-version = "0.6.11"
+version = "0.6.12"
 description = "Lightweight orchestration layer for distributing coding work across multiple AI coding agents"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -412,6 +412,54 @@ def test_cli_doctor_fix(tmp_path: Path):
     assert result.exit_code == 0, result.output
 
 
+def test_doctor_cli_reads_config_json_max_attempts(tmp_path: Path):
+    """#344: antfarm doctor must load <data_dir>/config.json and honor
+    max_attempts. Without this, stale-task recovery silently uses the
+    default of 3 no matter what the colony was started with."""
+    data_dir = tmp_path / ".antfarm"
+    data_dir.mkdir()
+    (data_dir / "config.json").write_text(json.dumps({"max_attempts": 7}))
+
+    captured: dict = {}
+
+    def _spy(backend, config, fix=False):
+        captured["config"] = config
+        return []
+
+    runner = CliRunner()
+    with patch("antfarm.core.doctor.run_doctor", side_effect=_spy):
+        result = runner.invoke(main, ["doctor", "--data-dir", str(data_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert captured["config"].get("max_attempts") == 7
+    # data_dir must still be present so downstream checks that need it
+    # (e.g. filesystem, orphan workspaces) continue to work.
+    assert captured["config"].get("data_dir") == str(data_dir)
+
+
+def test_doctor_cli_falls_back_when_no_config_json(tmp_path: Path):
+    """No config.json present — doctor still runs and passes only
+    data_dir through. max_attempts stays absent so callees apply their
+    default (3)."""
+    data_dir = tmp_path / ".antfarm"
+    data_dir.mkdir()
+    assert not (data_dir / "config.json").exists()
+
+    captured: dict = {}
+
+    def _spy(backend, config, fix=False):
+        captured["config"] = config
+        return []
+
+    runner = CliRunner()
+    with patch("antfarm.core.doctor.run_doctor", side_effect=_spy):
+        result = runner.invoke(main, ["doctor", "--data-dir", str(data_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert captured["config"].get("data_dir") == str(data_dir)
+    assert "max_attempts" not in captured["config"]
+
+
 def test_cli_doctor_sweep_no_legacy_sessions(tmp_path: Path):
     """--sweep-legacy-tmux with no matches prints the no-op message and exits."""
     runner = CliRunner()
@@ -970,11 +1018,16 @@ def test_worker_start_agent_timeout_flag_propagates():
         result = runner.invoke(
             main,
             [
-                "worker", "start",
-                "--agent", "claude-code",
-                "--node", "n1",
-                "--agent-timeout", "60",
-                "--colony-url", "http://localhost:7433",
+                "worker",
+                "start",
+                "--agent",
+                "claude-code",
+                "--node",
+                "n1",
+                "--agent-timeout",
+                "60",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
     assert result.exit_code == 0, result.output
@@ -987,16 +1040,18 @@ def test_worker_start_agent_timeout_flag_propagates():
         captured_default.update(kwargs)
         return MagicMock()
 
-    with patch(
-        "antfarm.core.worker.WorkerRuntime", side_effect=fake_worker_runtime_default
-    ):
+    with patch("antfarm.core.worker.WorkerRuntime", side_effect=fake_worker_runtime_default):
         result = runner.invoke(
             main,
             [
-                "worker", "start",
-                "--agent", "claude-code",
-                "--node", "n1",
-                "--colony-url", "http://localhost:7433",
+                "worker",
+                "start",
+                "--agent",
+                "claude-code",
+                "--node",
+                "n1",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
     assert result.exit_code == 0, result.output
@@ -1146,8 +1201,9 @@ def test_render_scout_prints_warnings():
         msg = args[0] if args else ""
         output_lines.append(str(msg))
 
-    with patch("antfarm.core.cli.click.echo", side_effect=capturing_echo), patch(
-        "antfarm.core.cli.click.secho", side_effect=capturing_echo
+    with (
+        patch("antfarm.core.cli.click.echo", side_effect=capturing_echo),
+        patch("antfarm.core.cli.click.secho", side_effect=capturing_echo),
     ):
         status2 = {
             "tasks": {"ready": 1, "active": 0, "done": 0},

--- a/tests/test_soldier.py
+++ b/tests/test_soldier.py
@@ -3136,6 +3136,35 @@ def test_assert_clean_repo_temp_branch_survives(soldier_env):
     assert soldier._assert_clean_repo() is False
 
 
+def test_assert_clean_repo_ignores_untracked_files(soldier_env):
+    """#338: untracked files (e.g. .claude/ worktrees) do not mark the
+    repo dirty. The tracked-state check uses ``git diff-index`` and
+    deliberately ignores anything git has never seen."""
+    soldier = soldier_env["soldier"]
+    repo = soldier_env["repo_path"]
+    with open(f"{repo}/only-untracked.txt", "w") as f:
+        f.write("noise\n")
+    # A directory of untracked files — mirrors the .claude/ worktree
+    # pattern that triggered the original spurious cleanup_incomplete.
+    import os
+
+    os.makedirs(f"{repo}/.claude/worktrees/scratch", exist_ok=True)
+    with open(f"{repo}/.claude/worktrees/scratch/junk.txt", "w") as f:
+        f.write("more noise\n")
+    assert soldier._assert_clean_repo() is True
+
+
+def test_assert_clean_repo_still_detects_tracked_modifications(soldier_env):
+    """Modifications to tracked files (no commit) still fail the check,
+    even though the switch to ``git diff-index`` drops the untracked
+    signal. Tracked-state correctness is the whole point."""
+    soldier = soldier_env["soldier"]
+    repo = soldier_env["repo_path"]
+    with open(f"{repo}/README.md", "w") as f:
+        f.write("tracked file mutated in place\n")
+    assert soldier._assert_clean_repo() is False
+
+
 def test_force_clean_repo_recovers_dirty(soldier_env):
     """Destructive recovery fixes dirty tree + untracked file + on temp-merge."""
     soldier = soldier_env["soldier"]


### PR DESCRIPTION
## Summary

Two small, independent fixes bundled in one PR.

**Fix A — #338: Soldier dirty-repo check treats untracked files as dirty.**
`_assert_clean_repo` used `git status --porcelain`, which reports untracked files. The soldier clone routinely carries untracked artifacts (`.claude/` worktrees, scratch files); these were flagged as dirty and emitted spurious `cleanup_incomplete: branch=main dirty=yes` events during #325 dogfood. Switches to `git diff-index --quiet HEAD --`, which is sensitive to tracked-file modifications only. Tracked-state is the invariant that matters for merge safety.

**Fix B — #344: `antfarm doctor` ignores `config.json`.**
The CLI built `config = {"data_dir": data_dir}` from scratch, never loading `<data_dir>/config.json`, so `check_stale_tasks` silently defaulted to `max_attempts=3` even when the colony was started with a different value. Flagged during review of PR #334. The doctor command now loads `config.json` when present, merges it, and overlays `data_dir` on top. Malformed/missing file falls back to defaults silently.

Bumps version 0.6.11 -> 0.6.12.

## Test Plan

- [x] `ruff check .` clean
- [x] `pytest tests/ -x -q` — all 1208 tests pass
- [x] New tests:
  - `test_assert_clean_repo_ignores_untracked_files` — untracked files + untracked dirs (simulating `.claude/`) do not mark dirty
  - `test_assert_clean_repo_still_detects_tracked_modifications` — tracked-file modifications still fail the check
  - Existing `test_assert_clean_repo_wrong_branch`, `test_assert_clean_repo_temp_branch_survives`, `test_force_clean_repo_recovers_dirty` still pass
  - `test_doctor_cli_reads_config_json_max_attempts` — value flows through via spy on `run_doctor`
  - `test_doctor_cli_falls_back_when_no_config_json` — missing config still runs, default applies

## Related Issues

Closes #338
Closes #344