### PR TITLE
fix(worker,server): set worker status=active on forage (Closes #340)

### DIFF
--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -11,6 +11,7 @@ Mutation-critical paths (pull, guard, trail, signal) are protected by _lock.
 from __future__ import annotations
 
 import collections
+import contextlib
 import json
 import logging
 import os
@@ -683,6 +684,11 @@ def get_app(
         """Pull the next eligible task for a worker. Returns 204 if queue is empty."""
         with _lock:
             task = _backend.pull(req.worker_id)
+            if task is not None:
+                # Atomically mark the worker active so the autoscaler does not
+                # retire it between task claim and the worker's next heartbeat.
+                with contextlib.suppress(Exception):
+                    _backend.heartbeat(req.worker_id, {"status": "active"})
         if task is None:
             response.status_code = 204
             return None

--- a/antfarm/core/worker.py
+++ b/antfarm/core/worker.py
@@ -395,252 +395,271 @@ class WorkerRuntime:
         if task is None:
             return False
 
+        # Defense-in-depth: mark self active immediately so the autoscaler sees
+        # the transition even if the forage endpoint's status update raced or
+        # failed. The forage endpoint also flips status under _lock, but a
+        # second heartbeat here closes any window where the colony hasn't yet
+        # reflected the change.
+        with contextlib.suppress(Exception):
+            self.colony.heartbeat(self.worker_id, status={"status": "active"})
+
         task_id = task["id"]
         attempt_id = task["current_attempt"]
         self._last_task_id = task_id
         logger.info("task claimed task_id=%s attempt_id=%s", task_id, attempt_id)
         _emit("task_claimed", task_id, task.get("title", ""))
 
-        with contextlib.suppress(Exception):
-            self.colony.trail(task_id, self.worker_id, "task claimed, creating workspace")
+        try:
+            with contextlib.suppress(Exception):
+                self.colony.trail(task_id, self.worker_id, "task claimed, creating workspace")
 
-        dep_branches = self._resolve_dep_branches(task)
-        workspace = self.workspace_mgr.create(task_id, attempt_id, dep_branches=dep_branches)
-        logger.info("workspace created path=%s", workspace)
-        _emit("workspace_created", task_id, workspace)
+            dep_branches = self._resolve_dep_branches(task)
+            workspace = self.workspace_mgr.create(task_id, attempt_id, dep_branches=dep_branches)
+            logger.info("workspace created path=%s", workspace)
+            _emit("workspace_created", task_id, workspace)
 
-        with contextlib.suppress(Exception):
-            self.colony.trail(task_id, self.worker_id, "workspace ready, launching agent")
+            with contextlib.suppress(Exception):
+                self.colony.trail(task_id, self.worker_id, "workspace ready, launching agent")
 
-        # Heartbeat thread is managed by run() (issue #333) — coverage now
-        # spans the whole worker lifetime, not just the agent subprocess.
-        _emit("agent_launched", task_id, self.agent_type)
-        result = self._launch_agent(task, workspace)
+            # Heartbeat thread is managed by run() (issue #333) — coverage now
+            # spans the whole worker lifetime, not just the agent subprocess.
+            _emit("agent_launched", task_id, self.agent_type)
+            result = self._launch_agent(task, workspace)
 
-        is_silent = (
-            result.returncode == 0 and not result.stdout.strip() and not result.stderr.strip()
-        )
-
-        if result.returncode != 0 or is_silent:
-            if is_silent:
-                logger.warning(
-                    "silent agent failure detected task_id=%s attempt_id=%s "
-                    "worker_id=%s — returncode=0 with empty stdout+stderr",
-                    task_id,
-                    attempt_id,
-                    self.worker_id,
-                )
-                with contextlib.suppress(Exception):
-                    self.colony.trail(
-                        task_id,
-                        self.worker_id,
-                        "silent_failure: agent exited 0 with empty stdout+stderr "
-                        "— likely missing agent definition or adapter misconfiguration",
-                    )
-            else:
-                with contextlib.suppress(Exception):
-                    self.colony.trail(
-                        task_id,
-                        self.worker_id,
-                        f"agent failed (exit {result.returncode})",
-                    )
-            # Agent failed — classify, record, and trail the failure.
-            failure = build_failure_record(
-                task_id=task_id,
-                attempt_id=attempt_id,
-                worker_id=self.worker_id,
-                returncode=result.returncode,
-                stderr=result.stderr,
-                stdout=result.stdout,
+            is_silent = (
+                result.returncode == 0 and not result.stdout.strip() and not result.stderr.strip()
             )
-            logger.warning(
-                "agent failed task_id=%s type=%s retryable=%s returncode=%d",
-                task_id,
-                failure.failure_type.value,
-                failure.retryable,
-                result.returncode,
-            )
-            self.colony.trail(
-                task_id,
-                self.worker_id,
-                f"[{failure.failure_type.value}] {failure.message}: {result.stderr[:200]}",
-            )
-            # Persist structured failure record in trail for downstream consumers
-            self.colony.trail(
-                task_id,
-                self.worker_id,
-                f"[FAILURE_RECORD] {_json.dumps(failure.to_dict())}",
-            )
-            return True
 
-        with contextlib.suppress(Exception):
-            self.colony.trail(task_id, self.worker_id, "agent completed, building artifact")
-
-        # Plan task: parse output, validate, carry children, harvest with plan artifact
-        caps_req = set(task.get("capabilities_required", []))
-        is_plan = "plan" in caps_req
-        if is_plan:
-            plan_result = self._process_plan_output(task, attempt_id, result.stdout + result.stderr)
-            if plan_result:
-                is_mission_mode = plan_result.get("mission_mode", False)
-                if is_mission_mode:
-                    artifact = {
-                        "plan_task_id": task_id,
-                        "plan_artifact": plan_result["plan_artifact"],
-                        "task_count": plan_result["plan_artifact"]["task_count"],
-                        "warnings": plan_result["warnings"],
-                        "dependency_summary": plan_result["dep_summary"],
-                    }
-                    trail_msg = (
-                        f"plan complete (mission mode): "
-                        f"{plan_result['plan_artifact']['task_count']} tasks proposed"
-                    )
-                else:
-                    artifact = {
-                        "plan_task_id": task_id,
-                        "created_task_ids": plan_result["created_ids"],
-                        "task_count": len(plan_result["created_ids"]),
-                        "warnings": plan_result["warnings"],
-                        "dependency_summary": plan_result["dep_summary"],
-                    }
-                    trail_msg = f"plan complete: created {len(plan_result['created_ids'])} tasks"
-                try:
-                    self.colony.mark_harvest_pending(task_id, attempt_id)
-                except Exception as exc:
+            if result.returncode != 0 or is_silent:
+                if is_silent:
                     logger.warning(
-                        "mark_harvest_pending failed task_id=%s attempt_id=%s: %s",
+                        "silent agent failure detected task_id=%s attempt_id=%s "
+                        "worker_id=%s — returncode=0 with empty stdout+stderr",
                         task_id,
                         attempt_id,
-                        exc,
-                    )
-                try:
-                    self.colony.harvest(
-                        task_id,
-                        attempt_id,
-                        pr="",
-                        branch="",
-                        artifact=artifact,
-                    )
-                    logger.info("plan harvested task_id=%s", task_id)
-                except Exception as exc:
-                    logger.error(
-                        "plan harvest FAILED task_id=%s attempt_id=%s: %s",
-                        task_id,
-                        attempt_id,
-                        exc,
+                        self.worker_id,
                     )
                     with contextlib.suppress(Exception):
                         self.colony.trail(
                             task_id,
                             self.worker_id,
-                            f"plan harvest failed: {exc}",
+                            "silent_failure: agent exited 0 with empty stdout+stderr "
+                            "— likely missing agent definition or adapter misconfiguration",
                         )
-                with contextlib.suppress(Exception):
-                    self.colony.trail(task_id, self.worker_id, trail_msg)
-                return True
-
-            # Plan parsing failed — trail the error
-            with contextlib.suppress(Exception):
+                else:
+                    with contextlib.suppress(Exception):
+                        self.colony.trail(
+                            task_id,
+                            self.worker_id,
+                            f"agent failed (exit {result.returncode})",
+                        )
+                # Agent failed — classify, record, and trail the failure.
+                failure = build_failure_record(
+                    task_id=task_id,
+                    attempt_id=attempt_id,
+                    worker_id=self.worker_id,
+                    returncode=result.returncode,
+                    stderr=result.stderr,
+                    stdout=result.stdout,
+                )
+                logger.warning(
+                    "agent failed task_id=%s type=%s retryable=%s returncode=%d",
+                    task_id,
+                    failure.failure_type.value,
+                    failure.retryable,
+                    result.returncode,
+                )
                 self.colony.trail(
                     task_id,
                     self.worker_id,
-                    "plan failed: could not parse agent output into tasks",
+                    f"[{failure.failure_type.value}] {failure.message}: {result.stderr[:200]}",
                 )
-            return True
+                # Persist structured failure record in trail for downstream consumers
+                self.colony.trail(
+                    task_id,
+                    self.worker_id,
+                    f"[FAILURE_RECORD] {_json.dumps(failure.to_dict())}",
+                )
+                return True
 
-        # Set harvest_pending before writing result (best-effort)
-        with contextlib.suppress(Exception):
-            self.colony.mark_harvest_pending(task_id, attempt_id)
-
-        # Build artifact and create PR
-        artifact = self._build_artifact(task, attempt_id, workspace, result.branch)
-        pr_url = self._create_pr(task, result.branch, workspace)
-        if pr_url:
-            artifact["pr_url"] = pr_url
-
-        # Successful agent — harvest the task.
-        try:
-            self.colony.harvest(
-                task_id, attempt_id, pr=pr_url, branch=result.branch, artifact=artifact
-            )
-            logger.info("task harvested task_id=%s branch=%s", task_id, result.branch)
             with contextlib.suppress(Exception):
-                self.colony.trail(task_id, self.worker_id, "harvested successfully")
-        except Exception as exc:
-            # 409 = ownership loss (another worker claimed this attempt).
-            # Log a warning and continue to next task — not fatal.
-            logger.warning(
-                "harvest failed task_id=%s attempt_id=%s error=%s",
-                task_id,
-                attempt_id,
-                exc,
-            )
+                self.colony.trail(task_id, self.worker_id, "agent completed, building artifact")
 
-        # For review tasks: parse verdict from output and store on original task
-        is_review_task = "review" in set(
-            task.get("capabilities_required", [])
-        ) or task_id.startswith("review-")
-        if is_review_task and result.returncode == 0:
-            original_task_id = task_id.removeprefix("review-")
-            verdict = _parse_review_verdict(result.stdout + result.stderr)
-            if verdict:
-                try:
-                    original = self.colony.get_task(original_task_id)
-                    if original and original.get("current_attempt"):
-                        self.colony.store_review_verdict(
-                            original_task_id,
-                            original["current_attempt"],
-                            verdict,
+            # Plan task: parse output, validate, carry children, harvest with plan artifact
+            caps_req = set(task.get("capabilities_required", []))
+            is_plan = "plan" in caps_req
+            if is_plan:
+                plan_result = self._process_plan_output(
+                    task, attempt_id, result.stdout + result.stderr
+                )
+                if plan_result:
+                    is_mission_mode = plan_result.get("mission_mode", False)
+                    if is_mission_mode:
+                        artifact = {
+                            "plan_task_id": task_id,
+                            "plan_artifact": plan_result["plan_artifact"],
+                            "task_count": plan_result["plan_artifact"]["task_count"],
+                            "warnings": plan_result["warnings"],
+                            "dependency_summary": plan_result["dep_summary"],
+                        }
+                        trail_msg = (
+                            f"plan complete (mission mode): "
+                            f"{plan_result['plan_artifact']['task_count']} tasks proposed"
                         )
-                        logger.info(
-                            "stored review verdict on %s verdict=%s",
-                            original_task_id,
-                            verdict.get("verdict"),
+                    else:
+                        artifact = {
+                            "plan_task_id": task_id,
+                            "created_task_ids": plan_result["created_ids"],
+                            "task_count": len(plan_result["created_ids"]),
+                            "warnings": plan_result["warnings"],
+                            "dependency_summary": plan_result["dep_summary"],
+                        }
+                        trail_msg = (
+                            f"plan complete: created {len(plan_result['created_ids'])} tasks"
                         )
-                except Exception as exc:
-                    logger.warning(
-                        "failed to store review verdict for %s: %s",
-                        original_task_id,
-                        exc,
-                    )
-            else:
-                # Agent didn't produce parseable [REVIEW_VERDICT] tags.
-                # Trail a warning, then kickback the review task itself so
-                # another reviewer attempt runs. The kickback budget (2 total
-                # attempts) is enforced by FileBackend.kickback via
-                # max_attempts — once exhausted, the review task moves to
-                # blocked and Soldier.run_once_with_review kicks back the
-                # *original* task with a clear reason.
-                logger.warning("reviewer produced no verdict for %s", original_task_id)
+                    try:
+                        self.colony.mark_harvest_pending(task_id, attempt_id)
+                    except Exception as exc:
+                        logger.warning(
+                            "mark_harvest_pending failed task_id=%s attempt_id=%s: %s",
+                            task_id,
+                            attempt_id,
+                            exc,
+                        )
+                    try:
+                        self.colony.harvest(
+                            task_id,
+                            attempt_id,
+                            pr="",
+                            branch="",
+                            artifact=artifact,
+                        )
+                        logger.info("plan harvested task_id=%s", task_id)
+                    except Exception as exc:
+                        logger.error(
+                            "plan harvest FAILED task_id=%s attempt_id=%s: %s",
+                            task_id,
+                            attempt_id,
+                            exc,
+                        )
+                        with contextlib.suppress(Exception):
+                            self.colony.trail(
+                                task_id,
+                                self.worker_id,
+                                f"plan harvest failed: {exc}",
+                            )
+                    with contextlib.suppress(Exception):
+                        self.colony.trail(task_id, self.worker_id, trail_msg)
+                    return True
+
+                # Plan parsing failed — trail the error
                 with contextlib.suppress(Exception):
                     self.colony.trail(
                         task_id,
                         self.worker_id,
-                        f"WARNING: no [REVIEW_VERDICT] tags in output for {original_task_id}",
+                        "plan failed: could not parse agent output into tasks",
                     )
-                review_attempt_count = len(task.get("attempts", []))
-                retry_budget = 2
-                if review_attempt_count < retry_budget:
-                    logger.info(
-                        "retrying review task %s (attempt %d/%d)",
-                        task_id,
-                        review_attempt_count,
-                        retry_budget,
-                    )
-                else:
-                    logger.warning(
-                        "review task %s exhausted retry budget (%d attempts)",
-                        task_id,
-                        review_attempt_count,
-                    )
-                with contextlib.suppress(Exception):
-                    self.colony.kickback(
-                        task_id,
-                        reason="reviewer produced no [REVIEW_VERDICT] tags",
-                        max_attempts=retry_budget,
-                    )
+                return True
 
-        return True
+            # Set harvest_pending before writing result (best-effort)
+            with contextlib.suppress(Exception):
+                self.colony.mark_harvest_pending(task_id, attempt_id)
+
+            # Build artifact and create PR
+            artifact = self._build_artifact(task, attempt_id, workspace, result.branch)
+            pr_url = self._create_pr(task, result.branch, workspace)
+            if pr_url:
+                artifact["pr_url"] = pr_url
+
+            # Successful agent — harvest the task.
+            try:
+                self.colony.harvest(
+                    task_id, attempt_id, pr=pr_url, branch=result.branch, artifact=artifact
+                )
+                logger.info("task harvested task_id=%s branch=%s", task_id, result.branch)
+                with contextlib.suppress(Exception):
+                    self.colony.trail(task_id, self.worker_id, "harvested successfully")
+            except Exception as exc:
+                # 409 = ownership loss (another worker claimed this attempt).
+                # Log a warning and continue to next task — not fatal.
+                logger.warning(
+                    "harvest failed task_id=%s attempt_id=%s error=%s",
+                    task_id,
+                    attempt_id,
+                    exc,
+                )
+
+            # For review tasks: parse verdict from output and store on original task
+            is_review_task = "review" in set(
+                task.get("capabilities_required", [])
+            ) or task_id.startswith("review-")
+            if is_review_task and result.returncode == 0:
+                original_task_id = task_id.removeprefix("review-")
+                verdict = _parse_review_verdict(result.stdout + result.stderr)
+                if verdict:
+                    try:
+                        original = self.colony.get_task(original_task_id)
+                        if original and original.get("current_attempt"):
+                            self.colony.store_review_verdict(
+                                original_task_id,
+                                original["current_attempt"],
+                                verdict,
+                            )
+                            logger.info(
+                                "stored review verdict on %s verdict=%s",
+                                original_task_id,
+                                verdict.get("verdict"),
+                            )
+                    except Exception as exc:
+                        logger.warning(
+                            "failed to store review verdict for %s: %s",
+                            original_task_id,
+                            exc,
+                        )
+                else:
+                    # Agent didn't produce parseable [REVIEW_VERDICT] tags.
+                    # Trail a warning, then kickback the review task itself so
+                    # another reviewer attempt runs. The kickback budget (2 total
+                    # attempts) is enforced by FileBackend.kickback via
+                    # max_attempts — once exhausted, the review task moves to
+                    # blocked and Soldier.run_once_with_review kicks back the
+                    # *original* task with a clear reason.
+                    logger.warning("reviewer produced no verdict for %s", original_task_id)
+                    with contextlib.suppress(Exception):
+                        self.colony.trail(
+                            task_id,
+                            self.worker_id,
+                            f"WARNING: no [REVIEW_VERDICT] tags in output for {original_task_id}",
+                        )
+                    review_attempt_count = len(task.get("attempts", []))
+                    retry_budget = 2
+                    if review_attempt_count < retry_budget:
+                        logger.info(
+                            "retrying review task %s (attempt %d/%d)",
+                            task_id,
+                            review_attempt_count,
+                            retry_budget,
+                        )
+                    else:
+                        logger.warning(
+                            "review task %s exhausted retry budget (%d attempts)",
+                            task_id,
+                            review_attempt_count,
+                        )
+                    with contextlib.suppress(Exception):
+                        self.colony.kickback(
+                            task_id,
+                            reason="reviewer produced no [REVIEW_VERDICT] tags",
+                            max_attempts=retry_budget,
+                        )
+
+            return True
+        finally:
+            # Reset to idle so the autoscaler can reap this worker when the
+            # queue empties. Without this, status stays "active" forever and
+            # the worker is never retired even when no tasks remain.
+            with contextlib.suppress(Exception):
+                self.colony.heartbeat(self.worker_id, status={"status": "idle"})
 
     # ------------------------------------------------------------------
     # Dependency branch resolution

--- a/tests/test_autoscaler.py
+++ b/tests/test_autoscaler.py
@@ -950,3 +950,100 @@ class TestInfraExcludedFromDepth:
         assert count_ready_unblocked(tasks) == 0
         config = AutoscalerConfig(max_builders=5, builder_depth_factor=0.5)
         assert compute_depth_aware_target(count_ready_unblocked(tasks), config) == 0
+
+
+# ---------------------------------------------------------------------------
+# Active builder protection (#340)
+# ---------------------------------------------------------------------------
+
+
+class TestActiveBuilderNotRetired:
+    def test_active_builder_idle_since_stays_none(self):
+        """A builder whose colony-side status=='active' must NEVER be marked
+        confirmed-idle. ``idle_since`` must remain None even with an aged
+        heartbeat — otherwise _retire_one_idle_builder() would kill a worker
+        that is currently mid-task (root cause of issue #340).
+        """
+        pm = _mock_pm()
+        a = _make_autoscaler(_pm=pm, builder_scale_down_idle_seconds=30.0)
+        a.managed["auto-builder-1"] = ManagedWorker(
+            name="auto-builder-1",
+            role="builder",
+            worker_id="local/auto-builder-1",
+        )
+        # Worker is active with an aged heartbeat (which would otherwise
+        # qualify it as confirmed-idle if status were "idle").
+        colony_workers = [
+            _worker(
+                "local/auto-builder-1",
+                status="active",
+                last_heartbeat=_aged_hb(120),
+            )
+        ]
+
+        a._update_builder_idle_tracking(colony_workers)
+
+        assert a.managed["auto-builder-1"].idle_since is None
+
+    def test_active_builder_resets_existing_idle_since(self):
+        """If a builder was previously confirmed-idle and then transitioned
+        to active, _update_builder_idle_tracking must reset idle_since to None.
+        """
+        pm = _mock_pm()
+        a = _make_autoscaler(_pm=pm, builder_scale_down_idle_seconds=30.0)
+        mw = ManagedWorker(
+            name="auto-builder-1",
+            role="builder",
+            worker_id="local/auto-builder-1",
+        )
+        # Pre-existing idle_since (worker was idle in a prior tick)
+        mw.idle_since = datetime.now(UTC) - timedelta(seconds=10)
+        a.managed["auto-builder-1"] = mw
+
+        # Now the worker is active
+        colony_workers = [
+            _worker(
+                "local/auto-builder-1",
+                status="active",
+                last_heartbeat=_aged_hb(120),
+            )
+        ]
+        a._update_builder_idle_tracking(colony_workers)
+
+        assert a.managed["auto-builder-1"].idle_since is None
+
+    def test_active_builder_not_retired_even_when_desired_zero(self):
+        """End-to-end: a builder with status=active is not retired by
+        _retire_one_idle_builder, even when the scale-down loop would
+        otherwise want to drop the count to zero.
+        """
+        pm = _mock_pm()
+        pm.is_alive.return_value = True
+
+        a = _make_autoscaler(
+            _pm=pm,
+            builder_scale_down_idle_seconds=30.0,
+            poll_interval=30.0,
+        )
+        a.managed["auto-builder-1"] = ManagedWorker(
+            name="auto-builder-1",
+            role="builder",
+            worker_id="local/auto-builder-1",
+        )
+
+        # Active worker with an aged heartbeat
+        colony_workers = [
+            _worker(
+                "local/auto-builder-1",
+                status="active",
+                last_heartbeat=_aged_hb(120),
+            )
+        ]
+        a._update_builder_idle_tracking(colony_workers)
+
+        # Even if the scale-down path runs, no builder should be retired:
+        # idle_since is None (active → not confirmed-idle).
+        retired = a._retire_one_idle_builder()
+        assert retired is False
+        pm.stop.assert_not_called()
+        assert "auto-builder-1" in a.managed

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -100,6 +100,21 @@ def test_forage_creates_attempt(client):
     assert data["attempts"][0]["status"] == "active"
 
 
+def test_forage_sets_worker_active(client):
+    """Forage transitions the claiming worker's status to 'active'."""
+    _register_worker(client, worker_id="worker-1")
+    _carry(client, task_id="task-001")
+
+    r = _forage(client, worker_id="worker-1")
+    assert r.status_code == 200
+
+    r = client.get("/workers")
+    assert r.status_code == 200
+    workers = r.json()
+    worker = next(w for w in workers if w["worker_id"] == "worker-1")
+    assert worker["status"] == "active"
+
+
 def test_trail_appends(client):
     _carry(client)
     task = _forage(client).json()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -2247,3 +2247,43 @@ def test_heartbeat_running_during_full_run_lifetime(tc, runtime, monkeypatch):
     assert alive_at_agent == [True], "heartbeat thread must be alive during agent run"
     # After run() exits, the thread is stopped.
     assert runtime._heartbeat_thread is None
+
+
+# ---------------------------------------------------------------------------
+# Worker status active_and_idle transitions (#340)
+# ---------------------------------------------------------------------------
+
+
+def test_process_one_task_sets_active_and_idle_status(tc, runtime):
+    """_process_one_task must heartbeat status='active' immediately after
+    forage and reset to status='idle' when processing finishes.
+
+    Without this, the autoscaler sees status='idle' for a worker that's
+    currently mid-task and (when count_ready_unblocked drops to 0) retires
+    it via tmux kill-session — the root cause of issue #340.
+    """
+    _carry(tc, task_id="task-status-001")
+
+    captured: list[dict] = []
+    original_heartbeat = runtime.colony.heartbeat
+
+    def tracking_heartbeat(worker_id, status=None, **kwargs):
+        captured.append(dict(status) if status else {})
+        return original_heartbeat(worker_id, status=status, **kwargs)
+
+    runtime.colony.heartbeat = tracking_heartbeat
+    runtime._launch_agent = _good_agent
+    runtime._build_artifact = lambda task, attempt_id, workspace, branch: {}
+    runtime._create_pr = lambda task, branch, workspace: ""
+
+    had_task = runtime._process_one_task()
+    assert had_task is True
+
+    statuses = [s.get("status") for s in captured if "status" in s]
+    # The first status update during the task must be "active".
+    assert "active" in statuses, (
+        f"expected an 'active' status heartbeat during _process_one_task, got: {statuses}"
+    )
+    assert statuses[0] == "active"
+    # The last status update must be "idle" (set in the finally block).
+    assert statuses[-1] == "idle"


### PR DESCRIPTION
## Summary
- Forage endpoint now atomically marks the claiming worker's status as `active` inside the same `_lock` that claims the task, so the autoscaler observes the transition before its next poll.
- `WorkerRuntime._process_one_task()` sends a defense-in-depth `active` heartbeat immediately after a successful forage and resets to `idle` in a `try/finally` when the task completes or fails.

## Root cause (issue #340)
Workers never updated their colony-side status from `idle` to `active` when claiming a task. The autoscaler's `_update_builder_idle_tracking()` saw `status=idle` for every running worker; when `count_ready_unblocked()` dropped to 0 (all ready tasks claimed), `desired_builders` dropped to 0, and `_retire_one_idle_builder()` killed workers mid-task via `tmux kill-session`.

## Test Plan
- [x] New `tests/test_serve.py::test_forage_sets_worker_active` — `/tasks/pull` flips the worker's status to `active`.
- [x] New `tests/test_autoscaler.py::TestActiveBuilderNotRetired` (3 tests) — `_update_builder_idle_tracking` keeps `idle_since=None` when status is `active`, resets a stale `idle_since` back to `None` on transition, and `_retire_one_idle_builder` refuses to retire active builders.
- [x] New `tests/test_worker.py::test_process_one_task_sets_active_and_idle_status` — `_process_one_task` heartbeats `status=active` after forage and `status=idle` in the `finally` block.
- [x] `pytest tests/ -x -q` — 1213 passed.
- [x] `ruff check .` — clean.

## Related Issues
Closes #340