### PR TITLE
fix(autoscaler,doctor): proportional max_reviewers default + saturated-queue warning (Closes #347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+- feat(doctor): warn when review queue saturates (awaiting > max_reviewers*2 for 2min+) (#347)
+
 ### Fixed
 - fix(soldier): reclaim blocking antfarm worktree when rebase checkout collides (#349)
+- fix(autoscaler): default max_reviewers now derives from max_builders (ceil(0.75x), floor 2) (#347)
 
 ## [0.6.13] - 2026-04-21
 

--- a/antfarm/core/autoscaler.py
+++ b/antfarm/core/autoscaler.py
@@ -219,7 +219,11 @@ class AutoscalerConfig:
     integration_branch: str = "main"
     workspace_root: str = "./.antfarm/workspaces"
     max_builders: int = 4
-    max_reviewers: int = 2
+    # When None, derived from max_builders in __post_init__:
+    #   max_reviewers = max(2, ceil(max_builders * 0.75))
+    # See issue #347 — a fixed default of 2 starved review capacity on busy
+    # colonies.
+    max_reviewers: int | None = None
     token: str | None = None
     poll_interval: float = 30.0
     colony_url: str = "http://127.0.0.1:7433"
@@ -234,6 +238,10 @@ class AutoscalerConfig:
     # Seconds a builder must be idle before it is eligible for retirement.
     # Lazy scale-down: retire at most one idle builder per reconcile tick.
     builder_scale_down_idle_seconds: float = 30.0
+
+    def __post_init__(self) -> None:
+        if self.max_reviewers is None:
+            self.max_reviewers = max(2, math.ceil(self.max_builders * 0.75))
 
 
 @dataclass

--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -239,24 +239,32 @@ def colony(
             _existing = {}
     _existing["repo_path"] = repo_path
     _existing["integration_branch"] = integration_branch
-    with open(_config_path, "w") as _f:
-        json.dump(_existing, _f, indent=2)
 
     autoscaler_cfg = None
     if autoscaler:
         from antfarm.core.autoscaler import AutoscalerConfig
 
-        autoscaler_cfg = AutoscalerConfig(
-            enabled=True,
-            data_dir=data_dir,
-            colony_url=f"http://127.0.0.1:{port}",
-        )
+        # Pass tuning values at construction time so ``__post_init__`` derives
+        # ``max_reviewers`` from the final ``max_builders`` (issue #347).
+        autoscaler_kwargs: dict = {
+            "enabled": True,
+            "data_dir": data_dir,
+            "colony_url": f"http://127.0.0.1:{port}",
+        }
         if max_builders is not None:
-            autoscaler_cfg.max_builders = max_builders
+            autoscaler_kwargs["max_builders"] = max_builders
         if max_reviewers is not None:
-            autoscaler_cfg.max_reviewers = max_reviewers
+            autoscaler_kwargs["max_reviewers"] = max_reviewers
+        autoscaler_cfg = AutoscalerConfig(**autoscaler_kwargs)
         if auth_token:
             autoscaler_cfg.token = auth_token
+        # Persist autoscaler sizing so daemons reading config.json (doctor,
+        # etc.) see the same effective defaults.
+        _existing["max_builders"] = autoscaler_cfg.max_builders
+        _existing["max_reviewers"] = autoscaler_cfg.max_reviewers
+
+    with open(_config_path, "w") as _f:
+        json.dump(_existing, _f, indent=2)
 
     if multi_node and autoscaler:
         click.echo("Multi-node autoscaler mode enabled (requires remote Runners on each node).")
@@ -852,6 +860,10 @@ def doctor(fix: bool, data_dir: str, sweep_legacy_tmux: bool, yes: bool):
         except (json.JSONDecodeError, OSError):
             config = {}
     config["data_dir"] = data_dir
+    # Default autoscaler sizing used by review_queue_saturated (#347). The
+    # colony command persists these; older colonies won't have them yet.
+    config.setdefault("max_reviewers", 2)
+    config.setdefault("max_builders", 4)
     findings = run_doctor(backend, config, fix=fix)
 
     if not findings:

--- a/antfarm/core/doctor.py
+++ b/antfarm/core/doctor.py
@@ -11,6 +11,7 @@ Usage:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
@@ -77,6 +78,7 @@ def run_doctor(
     findings.extend(check_stuck_workers(backend, config, fix))
     findings.extend(check_stale_tasks(backend, config, fix))
     findings.extend(check_retry_patterns(backend, config))
+    findings.extend(check_review_queue_saturated(backend, config))
     findings.extend(check_no_reviewer_capacity(backend, config))
     findings.extend(check_stale_guards(backend, config, fix))
     findings.extend(check_workspace_conflicts(backend))
@@ -642,6 +644,92 @@ def check_retry_patterns(backend, config: dict) -> list[Finding]:
 # ---------------------------------------------------------------------------
 # Check 5b: No reviewer capacity
 # ---------------------------------------------------------------------------
+
+
+def check_review_queue_saturated(backend, config: dict) -> list[Finding]:
+    """Warn when awaiting-review tasks exceed ``max_reviewers * 2`` for ≥2 minutes.
+
+    Detects the saturation pattern from issue #347: builders keep producing
+    work faster than reviewers can clear it, so the "awaiting review" queue
+    grows unbounded. The dwell window prevents false positives during bursts.
+
+    Sidecar state at ``{data_dir}/doctor_state/review_saturation.json`` tracks
+    when the queue first became saturated so we only fire once the condition
+    has held continuously for ``dwell_seconds``. Healthy state clears the
+    sidecar.
+
+    No auto-fix — operator must re-tune autoscaler sizing.
+
+    Args:
+        backend: TaskBackend instance.
+        config: Doctor config dict; reads ``max_reviewers`` (default 2) and
+            ``data_dir``.
+
+    Returns:
+        List of findings (at most one).
+    """
+    from antfarm.core.warnings import detect_review_queue_saturated
+
+    try:
+        tasks = backend.list_tasks()
+    except Exception:
+        return []
+
+    max_reviewers = int(config.get("max_reviewers", 2))
+    data_dir = config.get("data_dir", ".antfarm")
+    sidecar_dir = os.path.join(data_dir, "doctor_state")
+    sidecar_path = os.path.join(sidecar_dir, "review_saturation.json")
+
+    # Compute awaiting count using the same logic as the warning helper so we
+    # don't double-count. We rely on the helper returning None below-threshold
+    # and use a probe-with-far-past-timestamp to distinguish "below threshold"
+    # from "above but within dwell".
+    from antfarm.core.warnings import _count_awaiting_review
+
+    now = datetime.now(UTC)
+    awaiting_count = _count_awaiting_review(tasks)
+    threshold = max_reviewers * 2
+
+    if awaiting_count <= threshold:
+        # Healthy — clear any prior sidecar.
+        if os.path.exists(sidecar_path):
+            with contextlib.suppress(OSError):
+                os.unlink(sidecar_path)
+        return []
+
+    # Saturated — ensure sidecar records first_seen.
+    first_seen_at: str | None = None
+    if os.path.exists(sidecar_path):
+        try:
+            with open(sidecar_path) as f:
+                first_seen_at = json.load(f).get("first_seen_at")
+        except (json.JSONDecodeError, OSError):
+            first_seen_at = None
+
+    if first_seen_at is None:
+        with contextlib.suppress(OSError):
+            os.makedirs(sidecar_dir, exist_ok=True)
+            with open(sidecar_path, "w") as f:
+                json.dump({"first_seen_at": now.isoformat()}, f)
+        return []
+
+    warning = detect_review_queue_saturated(
+        tasks=tasks,
+        max_reviewers=max_reviewers,
+        awaiting_first_seen_at=first_seen_at,
+        now=now,
+    )
+    if warning is None:
+        return []
+
+    return [
+        Finding(
+            severity="warning",
+            check="review_queue_saturated",
+            message=warning["message"],
+            auto_fixable=False,
+        )
+    ]
 
 
 def check_no_reviewer_capacity(backend, config: dict) -> list[Finding]:  # noqa: ARG001

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -189,6 +189,8 @@ def _start_doctor_thread(backend: TaskBackend, data_dir: str, interval: float = 
             colony_cfg = json.load(f)
         doctor_config["worker_ttl"] = colony_cfg.get("worker_ttl", 300)
         doctor_config["guard_ttl"] = colony_cfg.get("guard_ttl", 300)
+        doctor_config["max_reviewers"] = colony_cfg.get("max_reviewers", 2)
+        doctor_config["max_builders"] = colony_cfg.get("max_builders", 4)
         interval = colony_cfg.get("doctor_interval", interval)
 
     def _doctor_loop():

--- a/antfarm/core/warnings.py
+++ b/antfarm/core/warnings.py
@@ -7,6 +7,8 @@ tasks and workers and returns structured warning dicts suitable for the
 
 from __future__ import annotations
 
+from datetime import datetime
+
 
 def detect_no_reviewer_capacity(tasks: list[dict], workers: list[dict]) -> dict | None:
     """Return a warning dict if ready review tasks exist but no worker has the review capability.
@@ -38,4 +40,98 @@ def detect_no_reviewer_capacity(tasks: list[dict], workers: list[dict]) -> dict 
         ),
         "hint": "Start one: antfarm worker start --agent reviewer",
         "count": ready_review_count,
+    }
+
+
+def _has_merged_attempt(task: dict) -> bool:
+    return any(attempt.get("status") == "merged" for attempt in task.get("attempts", []))
+
+
+def _get_current_verdict(task: dict) -> dict | None:
+    current_id = task.get("current_attempt")
+    if not current_id:
+        return None
+    for attempt in task.get("attempts", []):
+        if attempt.get("attempt_id") == current_id:
+            return attempt.get("review_verdict")
+    return None
+
+
+def _is_infra_task(task: dict) -> bool:
+    caps = task.get("capabilities_required", []) or []
+    return "plan" in caps or "review" in caps or task.get("id", "").startswith("review-")
+
+
+def _count_awaiting_review(tasks: list[dict]) -> int:
+    """Count tasks awaiting review right now.
+
+    Matches TUI's ``awaiting_review`` bucket (``tui.py:410-424``) plus review
+    tasks still sitting in ``ready`` (not yet picked up by a reviewer):
+
+      * status ``done``, not cancelled, not merged, not an infra container,
+        with no passing review verdict on the current attempt.
+      * status ``ready`` with ``review`` in ``capabilities_required`` or an
+        ``id`` starting with ``review-``.
+    """
+    count = 0
+    for task in tasks:
+        status = task.get("status")
+        if status == "ready":
+            caps = task.get("capabilities_required", []) or []
+            if "review" in caps or task.get("id", "").startswith("review-"):
+                count += 1
+            continue
+        if status != "done":
+            continue
+        if task.get("cancelled_at"):
+            continue
+        if _has_merged_attempt(task):
+            continue
+        if _is_infra_task(task):
+            continue
+        verdict = _get_current_verdict(task)
+        if verdict and verdict.get("verdict") == "pass":
+            continue
+        count += 1
+    return count
+
+
+def detect_review_queue_saturated(
+    tasks: list[dict],
+    max_reviewers: int,
+    awaiting_first_seen_at: str | None,
+    now: datetime,
+    dwell_seconds: float = 120.0,
+) -> dict | None:
+    """Return a warning if the review queue has been saturated for ``dwell_seconds``.
+
+    Saturation fires when ``awaiting_review_count > max_reviewers * 2``.
+    The caller is responsible for persisting ``awaiting_first_seen_at`` across
+    ticks; this function is pure. When ``awaiting_first_seen_at`` is None,
+    saturation is treated as "just observed" and no warning is returned yet —
+    the caller should record ``now`` and try again on the next tick.
+
+    See issue #347.
+    """
+    awaiting_review_count = _count_awaiting_review(tasks)
+    threshold = max_reviewers * 2
+    if awaiting_review_count <= threshold:
+        return None
+    if awaiting_first_seen_at is None:
+        return None
+    try:
+        first_seen = datetime.fromisoformat(awaiting_first_seen_at)
+    except ValueError:
+        return None
+    elapsed = (now - first_seen).total_seconds()
+    if elapsed < dwell_seconds:
+        return None
+    return {
+        "code": "review_queue_saturated",
+        "message": (
+            f"{awaiting_review_count} task(s) awaiting review with max_reviewers="
+            f"{max_reviewers} (threshold {threshold}); review capacity is saturated."
+        ),
+        "hint": "Increase --max-reviewers or reduce --max-builders. See issue #347.",
+        "count": awaiting_review_count,
     }

--- a/tests/test_autoscaler.py
+++ b/tests/test_autoscaler.py
@@ -1047,3 +1047,30 @@ class TestActiveBuilderNotRetired:
         assert retired is False
         pm.stop.assert_not_called()
         assert "auto-builder-1" in a.managed
+
+
+# ---------------------------------------------------------------------------
+# Derived max_reviewers default (#347)
+# ---------------------------------------------------------------------------
+
+
+class TestDerivedMaxReviewers:
+    def test_config_derives_max_reviewers_from_max_builders(self):
+        """max_builders=4 -> max_reviewers = max(2, ceil(4*0.75)) = 3."""
+        config = AutoscalerConfig(max_builders=4)
+        assert config.max_reviewers == 3
+
+    def test_config_explicit_max_reviewers_respected(self):
+        """Explicit max_reviewers overrides derivation."""
+        config = AutoscalerConfig(max_builders=4, max_reviewers=1)
+        assert config.max_reviewers == 1
+
+    def test_config_derive_floor_is_two(self):
+        """max_builders=1 -> max_reviewers = max(2, ceil(1*0.75)) = 2 (floor)."""
+        config = AutoscalerConfig(max_builders=1)
+        assert config.max_reviewers == 2
+
+    def test_config_derive_max_builders_eight(self):
+        """max_builders=8 -> max_reviewers = max(2, ceil(8*0.75)) = 6."""
+        config = AutoscalerConfig(max_builders=8)
+        assert config.max_reviewers == 6

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1117,6 +1117,80 @@ def test_cli_colony_multi_node_flag():
 
 
 # ---------------------------------------------------------------------------
+# colony persists autoscaler sizing to config.json (#347)
+# ---------------------------------------------------------------------------
+
+
+def test_colony_persists_autoscaler_config(tmp_path: Path):
+    """colony --autoscaler --max-builders 6 → config.json has max_builders=6, max_reviewers=5."""
+    runner = CliRunner()
+    data_dir = tmp_path / ".antfarm"
+
+    with (
+        patch("uvicorn.run"),
+        patch("antfarm.core.backends.file.FileBackend"),
+        patch("antfarm.core.serve.get_app") as mock_get_app,
+    ):
+        mock_get_app.return_value = MagicMock()
+
+        result = runner.invoke(
+            main,
+            [
+                "colony",
+                "--autoscaler",
+                "--max-builders",
+                "6",
+                "--port",
+                "9002",
+                "--data-dir",
+                str(data_dir),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+    config_path = data_dir / "config.json"
+    assert config_path.exists(), "colony should write config.json"
+    config = json.loads(config_path.read_text())
+    assert config["max_builders"] == 6
+    # ceil(6 * 0.75) = 5, floor 2 → 5
+    assert config["max_reviewers"] == 5
+
+
+def test_colony_persists_explicit_max_reviewers(tmp_path: Path):
+    """Explicit --max-reviewers overrides derivation."""
+    runner = CliRunner()
+    data_dir = tmp_path / ".antfarm"
+
+    with (
+        patch("uvicorn.run"),
+        patch("antfarm.core.backends.file.FileBackend"),
+        patch("antfarm.core.serve.get_app") as mock_get_app,
+    ):
+        mock_get_app.return_value = MagicMock()
+
+        result = runner.invoke(
+            main,
+            [
+                "colony",
+                "--autoscaler",
+                "--max-builders",
+                "6",
+                "--max-reviewers",
+                "2",
+                "--port",
+                "9003",
+                "--data-dir",
+                str(data_dir),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+
+    config = json.loads((data_dir / "config.json").read_text())
+    assert config["max_builders"] == 6
+    assert config["max_reviewers"] == 2
+
+
+# ---------------------------------------------------------------------------
 # plan --carry dependency resolution (#93)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1979,3 +1979,96 @@ def test_retry_patterns_extracts_last_failure_reason(setup):
     retry = [f for f in findings if f.check == "retry_ceiling"]
     assert len(retry) == 1
     assert "tests failed: ImportError while loading conftest" in retry[0].message
+
+
+# ---------------------------------------------------------------------------
+# check_review_queue_saturated (#347)
+# ---------------------------------------------------------------------------
+
+
+def _seed_done_unreviewed(data_dir: Path, count: int) -> None:
+    """Seed ``count`` done-unreviewed tasks (no merge, no verdict, not infra)."""
+    for i in range(count):
+        _write_task_file(
+            data_dir,
+            "done",
+            f"awaiting-{i}",
+            status="done",
+            attempts=[_att(f"att-{i}", "done")],
+        )
+
+
+def test_check_review_queue_saturated_fires_after_dwell(setup):
+    """5 done-unreviewed, max_reviewers=2 (threshold=4), sidecar 130s old → fires."""
+    from datetime import timedelta
+
+    backend, config = setup
+    data_dir = Path(config["data_dir"])
+    config["max_reviewers"] = 2
+
+    _seed_done_unreviewed(data_dir, 5)
+
+    # Pre-populate sidecar with a first_seen_at 130s in the past.
+    sidecar_dir = data_dir / "doctor_state"
+    sidecar_dir.mkdir(parents=True, exist_ok=True)
+    past = (datetime.now(UTC) - timedelta(seconds=130)).isoformat()
+    (sidecar_dir / "review_saturation.json").write_text(json.dumps({"first_seen_at": past}))
+
+    findings = run_doctor(backend, config, fix=False)
+    saturated = [f for f in findings if f.check == "review_queue_saturated"]
+    assert len(saturated) == 1
+    assert saturated[0].severity == "warning"
+    assert "awaiting review" in saturated[0].message
+
+
+def test_check_review_queue_saturated_silent_below_threshold(setup):
+    """4 done-unreviewed with max_reviewers=2 (threshold=4); 4 !> 4 → no finding."""
+    backend, config = setup
+    data_dir = Path(config["data_dir"])
+    config["max_reviewers"] = 2
+
+    _seed_done_unreviewed(data_dir, 4)
+
+    findings = run_doctor(backend, config, fix=False)
+    saturated = [f for f in findings if f.check == "review_queue_saturated"]
+    assert saturated == []
+
+
+def test_check_review_queue_saturated_silent_within_dwell(setup):
+    """Above threshold but first_seen_at only 30s ago → no finding yet."""
+    from datetime import timedelta
+
+    backend, config = setup
+    data_dir = Path(config["data_dir"])
+    config["max_reviewers"] = 2
+
+    _seed_done_unreviewed(data_dir, 5)
+
+    sidecar_dir = data_dir / "doctor_state"
+    sidecar_dir.mkdir(parents=True, exist_ok=True)
+    recent = (datetime.now(UTC) - timedelta(seconds=30)).isoformat()
+    (sidecar_dir / "review_saturation.json").write_text(json.dumps({"first_seen_at": recent}))
+
+    findings = run_doctor(backend, config, fix=False)
+    saturated = [f for f in findings if f.check == "review_queue_saturated"]
+    assert saturated == []
+
+
+def test_check_review_queue_saturated_clears_sidecar_when_healthy(setup):
+    """Sidecar exists but current state is below threshold → sidecar is removed."""
+    from datetime import timedelta
+
+    backend, config = setup
+    data_dir = Path(config["data_dir"])
+    config["max_reviewers"] = 2
+
+    # No tasks — below threshold.
+    sidecar_dir = data_dir / "doctor_state"
+    sidecar_dir.mkdir(parents=True, exist_ok=True)
+    past = (datetime.now(UTC) - timedelta(seconds=300)).isoformat()
+    sidecar_path = sidecar_dir / "review_saturation.json"
+    sidecar_path.write_text(json.dumps({"first_seen_at": past}))
+    assert sidecar_path.exists()
+
+    run_doctor(backend, config, fix=False)
+    assert not sidecar_path.exists()

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -1,0 +1,226 @@
+"""Tests for antfarm.core.warnings — pure warning-detection helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from antfarm.core.warnings import (
+    _count_awaiting_review,
+    detect_no_reviewer_capacity,
+    detect_review_queue_saturated,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _done_unreviewed(task_id: str) -> dict:
+    return {
+        "id": task_id,
+        "status": "done",
+        "attempts": [{"attempt_id": "att-1", "status": "done"}],
+        "current_attempt": "att-1",
+        "capabilities_required": [],
+    }
+
+
+def _done_merged(task_id: str) -> dict:
+    return {
+        "id": task_id,
+        "status": "done",
+        "attempts": [{"attempt_id": "att-1", "status": "merged"}],
+        "current_attempt": "att-1",
+        "capabilities_required": [],
+    }
+
+
+def _done_cancelled(task_id: str) -> dict:
+    return {
+        "id": task_id,
+        "status": "done",
+        "attempts": [{"attempt_id": "att-1", "status": "done"}],
+        "current_attempt": "att-1",
+        "cancelled_at": datetime.now(UTC).isoformat(),
+        "capabilities_required": [],
+    }
+
+
+def _done_passed_review(task_id: str) -> dict:
+    return {
+        "id": task_id,
+        "status": "done",
+        "attempts": [
+            {
+                "attempt_id": "att-1",
+                "status": "done",
+                "review_verdict": {"verdict": "pass"},
+            }
+        ],
+        "current_attempt": "att-1",
+        "capabilities_required": [],
+    }
+
+
+def _done_infra(task_id: str) -> dict:
+    return {
+        "id": task_id,
+        "status": "done",
+        "attempts": [{"attempt_id": "att-1", "status": "done"}],
+        "current_attempt": "att-1",
+        "capabilities_required": ["review"],
+    }
+
+
+def _ready_review(task_id: str = "review-1") -> dict:
+    return {
+        "id": task_id,
+        "status": "ready",
+        "attempts": [],
+        "current_attempt": None,
+        "capabilities_required": ["review"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# _count_awaiting_review
+# ---------------------------------------------------------------------------
+
+
+class TestCountAwaitingReview:
+    def test_counts_done_unreviewed(self):
+        assert _count_awaiting_review([_done_unreviewed("t1"), _done_unreviewed("t2")]) == 2
+
+    def test_excludes_merged(self):
+        assert _count_awaiting_review([_done_merged("t1")]) == 0
+
+    def test_excludes_cancelled(self):
+        assert _count_awaiting_review([_done_cancelled("t1")]) == 0
+
+    def test_excludes_passed_review(self):
+        assert _count_awaiting_review([_done_passed_review("t1")]) == 0
+
+    def test_excludes_infra(self):
+        assert _count_awaiting_review([_done_infra("t1")]) == 0
+
+    def test_counts_ready_review_tasks(self):
+        assert _count_awaiting_review([_ready_review("review-1")]) == 1
+
+    def test_sum_of_done_and_ready(self):
+        tasks = [
+            _done_unreviewed("t1"),
+            _done_unreviewed("t2"),
+            _ready_review("review-1"),
+        ]
+        assert _count_awaiting_review(tasks) == 3
+
+
+# ---------------------------------------------------------------------------
+# detect_review_queue_saturated
+# ---------------------------------------------------------------------------
+
+
+class TestDetectReviewQueueSaturated:
+    def test_below_threshold_returns_none(self):
+        tasks = [_done_unreviewed(f"t{i}") for i in range(4)]  # threshold is 4
+        result = detect_review_queue_saturated(
+            tasks=tasks,
+            max_reviewers=2,
+            awaiting_first_seen_at=None,
+            now=datetime.now(UTC),
+        )
+        assert result is None
+
+    def test_above_threshold_no_sidecar_returns_none(self):
+        tasks = [_done_unreviewed(f"t{i}") for i in range(5)]
+        result = detect_review_queue_saturated(
+            tasks=tasks,
+            max_reviewers=2,
+            awaiting_first_seen_at=None,
+            now=datetime.now(UTC),
+        )
+        assert result is None  # Just-observed; caller should persist now and retry.
+
+    def test_above_threshold_within_dwell_returns_none(self):
+        tasks = [_done_unreviewed(f"t{i}") for i in range(5)]
+        now = datetime.now(UTC)
+        first_seen = (now - timedelta(seconds=30)).isoformat()
+        result = detect_review_queue_saturated(
+            tasks=tasks,
+            max_reviewers=2,
+            awaiting_first_seen_at=first_seen,
+            now=now,
+        )
+        assert result is None
+
+    def test_above_threshold_past_dwell_fires(self):
+        tasks = [_done_unreviewed(f"t{i}") for i in range(5)]
+        now = datetime.now(UTC)
+        first_seen = (now - timedelta(seconds=130)).isoformat()
+        result = detect_review_queue_saturated(
+            tasks=tasks,
+            max_reviewers=2,
+            awaiting_first_seen_at=first_seen,
+            now=now,
+        )
+        assert result is not None
+        assert result["code"] == "review_queue_saturated"
+        assert result["count"] == 5
+        assert "Increase --max-reviewers" in result["hint"]
+        assert "#347" in result["hint"]
+
+    def test_threshold_scales_with_max_reviewers(self):
+        """max_reviewers=3 → threshold=6; 6 awaiting is NOT saturation."""
+        tasks = [_done_unreviewed(f"t{i}") for i in range(6)]
+        now = datetime.now(UTC)
+        first_seen = (now - timedelta(seconds=600)).isoformat()
+        result = detect_review_queue_saturated(
+            tasks=tasks,
+            max_reviewers=3,
+            awaiting_first_seen_at=first_seen,
+            now=now,
+        )
+        assert result is None  # 6 !> 6
+
+        # 7 does fire.
+        tasks.append(_done_unreviewed("t7"))
+        result = detect_review_queue_saturated(
+            tasks=tasks,
+            max_reviewers=3,
+            awaiting_first_seen_at=first_seen,
+            now=now,
+        )
+        assert result is not None
+        assert result["count"] == 7
+
+    def test_malformed_first_seen_returns_none(self):
+        tasks = [_done_unreviewed(f"t{i}") for i in range(5)]
+        result = detect_review_queue_saturated(
+            tasks=tasks,
+            max_reviewers=2,
+            awaiting_first_seen_at="not-an-iso-string",
+            now=datetime.now(UTC),
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# detect_no_reviewer_capacity — regression smoke tests
+# ---------------------------------------------------------------------------
+
+
+class TestDetectNoReviewerCapacity:
+    def test_no_ready_review_returns_none(self):
+        assert detect_no_reviewer_capacity([], []) is None
+
+    def test_ready_review_without_reviewer_fires(self):
+        tasks = [_ready_review("review-1")]
+        workers: list[dict] = []
+        result = detect_no_reviewer_capacity(tasks, workers)
+        assert result is not None
+        assert result["code"] == "no_reviewer_capacity"
+
+    def test_ready_review_with_reviewer_worker_silent(self):
+        tasks = [_ready_review("review-1")]
+        workers = [{"worker_id": "w1", "capabilities": ["review"]}]
+        assert detect_no_reviewer_capacity(tasks, workers) is None


### PR DESCRIPTION
## Summary

Fixes #347.

- **`AutoscalerConfig.max_reviewers` derives from `max_builders`** — default is now `max(2, ceil(max_builders * 0.75))` instead of a fixed `2`. Operators running with larger builder pools no longer silently starve review capacity. Explicit `--max-reviewers` still overrides. CLI `colony` command constructs `AutoscalerConfig` via kwargs so `__post_init__` sees the final `max_builders`, and persists both values to `config.json` so doctor and other daemons can read them.
- **Doctor `check_review_queue_saturated`** — fires when awaiting-review tasks (done-unreviewed + ready review tasks, matching TUI's `awaiting review` bucket) exceed `max_reviewers * 2` continuously for ≥2 minutes. Sidecar state at `{data_dir}/doctor_state/review_saturation.json` tracks the dwell window; healthy state clears the sidecar. No auto-fix — operator re-tunes sizing.

## Changes

- `antfarm/core/autoscaler.py` — `max_reviewers: int | None = None` with derivation in `__post_init__` using the existing module-level `math` import.
- `antfarm/core/cli.py` — rewrite autoscaler construction to pass kwargs; persist `max_builders` / `max_reviewers` to `config.json`; set defaults in doctor CLI.
- `antfarm/core/warnings.py` — pure `detect_review_queue_saturated(...)` plus shared `_count_awaiting_review` helper matching TUI's bucket logic.
- `antfarm/core/doctor.py` — `check_review_queue_saturated` with sidecar dwell tracking, registered in `run_doctor` before `check_no_reviewer_capacity`.
- `antfarm/core/serve.py` — passes `max_reviewers` / `max_builders` through to the doctor daemon config.
- `CHANGELOG.md` — unreleased entries.

## Test plan

- [x] `pytest tests/ -x -q` → 1239 passed (full suite)
- [x] `ruff check antfarm/ tests/` → all checks passed
- [x] New unit tests: `TestDerivedMaxReviewers` in `test_autoscaler.py` (4 cases: derive, explicit override, floor 2, max_builders=8)
- [x] New detection tests in `test_warnings.py`: `_count_awaiting_review` filters (merged, cancelled, passed, infra), `detect_review_queue_saturated` (below/within-dwell/past-dwell/scaling-threshold/malformed)
- [x] New doctor tests in `test_doctor.py`: fires after dwell, silent below threshold, silent within dwell, clears sidecar when healthy
- [x] New CLI tests in `test_cli.py`: `colony` persists both config keys; explicit `--max-reviewers` respected

Closes #347.

🤖 Generated with [Claude Code](https://claude.com/claude-code)