### PR TITLE
feat(mission,soldier): auto-merge on review-pass + green CI (Closes #353)

### DIFF
--- a/antfarm/core/auto_merge.py
+++ b/antfarm/core/auto_merge.py
@@ -1,0 +1,254 @@
+"""Auto-merge decision engine (#353).
+
+Pure module. No I/O, no subprocess calls, no HTTP. Exists so the decision
+truth table can be unit-tested without mocking git, gh, or the colony.
+
+The mapping from ``(mode, verdict_passed, pr_state)`` to an
+:class:`AutoMergeOutcome` lives in :func:`decide`. The helper
+:func:`parse_pr_state` converts raw ``gh pr view --json ...`` output into a
+:class:`PRState` consumed by :func:`decide`.
+
+Consumers (the Soldier orchestrator) are responsible for performing the
+actual git/gh/colony side effects and for wiring the outcome back into the
+merge pipeline.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Literal
+
+AutoMergeAction = Literal[
+    "merge",
+    "rebase",
+    "wait_ci",
+    "kickback_ci",
+    "pause_mission",
+    "skip",
+]
+
+
+@dataclass
+class PRState:
+    """Snapshot of a GitHub PR's mergeability state.
+
+    Field names mirror the ``gh pr view --json`` keys so the adapter in
+    :func:`parse_pr_state` stays literal.
+    """
+
+    mergeStateStatus: str
+    mergeable: str
+    review_decision: str
+    ci_conclusion: str | None
+
+
+@dataclass
+class AutoMergeOutcome:
+    """Decision result from :func:`decide`.
+
+    ``merged`` is reserved for downstream helpers to mark after the merge
+    actually completes — :func:`decide` always returns ``merged=False``.
+    """
+
+    action: AutoMergeAction
+    pr: str
+    mode: str
+    reason: str
+    merged: bool = False
+
+
+_BLOCKED_CI_FAILING = "ci_failing"
+_BLOCKED_MISSING_REVIEWS = "missing_reviews"
+_BLOCKED_OTHER = "other"
+
+
+def _classify_blocked(pr_state: PRState) -> str:
+    """Classify a ``BLOCKED`` mergeStateStatus into a subtype.
+
+    Priority (per #353 plan):
+    1. ``reviewDecision == "REVIEW_REQUIRED"`` → missing_reviews
+    2. any status check entry with conclusion ``FAILURE`` → ci_failing
+    3. otherwise → other
+
+    ``pr_state.ci_conclusion`` carries the already-aggregated verdict from
+    :func:`parse_pr_state`. It is set to ``"FAILURE"`` only when at least
+    one ``statusCheckRollup`` entry reports ``conclusion == "FAILURE"``.
+    """
+    if (pr_state.review_decision or "").upper() == "REVIEW_REQUIRED":
+        return _BLOCKED_MISSING_REVIEWS
+    if (pr_state.ci_conclusion or "").upper() == "FAILURE":
+        return _BLOCKED_CI_FAILING
+    return _BLOCKED_OTHER
+
+
+def decide(
+    mode: str,
+    verdict_passed: bool,
+    pr_state: PRState | None,
+    pr: str,
+) -> AutoMergeOutcome:
+    """Map ``(mode, verdict, pr_state)`` to an :class:`AutoMergeOutcome`.
+
+    Truth table is documented in issue #353 and mirrored in
+    ``tests/test_auto_merge.py``. Kept deterministic: any unknown or
+    unexpected mergeStateStatus collapses to ``skip`` rather than guessing
+    an action.
+
+    Args:
+        mode: One of ``never``, ``on-review-pass``,
+            ``on-review-pass-and-ci-green``. Unknown modes collapse to
+            ``skip``.
+        verdict_passed: Whether the internal antfarm review verdict passed.
+        pr_state: Freshly fetched PR mergeability snapshot, or ``None`` when
+            the lookup failed.
+        pr: PR identifier (URL or number). Echoed back on the outcome.
+    """
+    if mode == "never":
+        return AutoMergeOutcome(action="skip", pr=pr, mode=mode, reason="auto_merge disabled")
+    if not verdict_passed:
+        return AutoMergeOutcome(action="skip", pr=pr, mode=mode, reason="internal verdict not pass")
+    if pr_state is None:
+        return AutoMergeOutcome(action="skip", pr=pr, mode=mode, reason="pr state unavailable")
+
+    status = (pr_state.mergeStateStatus or "").upper()
+
+    if mode == "on-review-pass":
+        if status == "CLEAN":
+            return AutoMergeOutcome(action="merge", pr=pr, mode=mode, reason="CLEAN")
+        if status == "UNSTABLE":
+            # CI-agnostic mode: proceed despite failing/pending checks.
+            return AutoMergeOutcome(action="merge", pr=pr, mode=mode, reason="UNSTABLE ci-agnostic")
+        if status in ("DIRTY", "BEHIND"):
+            return AutoMergeOutcome(
+                action="rebase", pr=pr, mode=mode, reason=f"{status} needs rebase"
+            )
+        if status == "BLOCKED":
+            subtype = _classify_blocked(pr_state)
+            if subtype == _BLOCKED_CI_FAILING:
+                return AutoMergeOutcome(
+                    action="kickback_ci", pr=pr, mode=mode, reason="BLOCKED ci_failing"
+                )
+            if subtype == _BLOCKED_MISSING_REVIEWS:
+                return AutoMergeOutcome(
+                    action="pause_mission",
+                    pr=pr,
+                    mode=mode,
+                    reason="BLOCKED missing_reviews",
+                )
+            return AutoMergeOutcome(
+                action="pause_mission",
+                pr=pr,
+                mode=mode,
+                reason="BLOCKED other",
+            )
+        # HAS_HOOKS, UNKNOWN, or anything else → conservative skip.
+        return AutoMergeOutcome(
+            action="skip", pr=pr, mode=mode, reason=f"unhandled mergeStateStatus={status}"
+        )
+
+    if mode == "on-review-pass-and-ci-green":
+        if status == "CLEAN":
+            return AutoMergeOutcome(action="merge", pr=pr, mode=mode, reason="CLEAN")
+        if status == "UNSTABLE":
+            return AutoMergeOutcome(
+                action="wait_ci", pr=pr, mode=mode, reason="UNSTABLE ci still pending"
+            )
+        if status == "PENDING":
+            return AutoMergeOutcome(action="wait_ci", pr=pr, mode=mode, reason="PENDING")
+        if status in ("DIRTY", "BEHIND"):
+            return AutoMergeOutcome(
+                action="rebase", pr=pr, mode=mode, reason=f"{status} needs rebase"
+            )
+        if status == "BLOCKED":
+            subtype = _classify_blocked(pr_state)
+            if subtype == _BLOCKED_CI_FAILING:
+                return AutoMergeOutcome(
+                    action="kickback_ci", pr=pr, mode=mode, reason="BLOCKED ci_failing"
+                )
+            if subtype == _BLOCKED_MISSING_REVIEWS:
+                return AutoMergeOutcome(
+                    action="pause_mission",
+                    pr=pr,
+                    mode=mode,
+                    reason="BLOCKED missing_reviews",
+                )
+            return AutoMergeOutcome(
+                action="pause_mission",
+                pr=pr,
+                mode=mode,
+                reason="BLOCKED other",
+            )
+        return AutoMergeOutcome(
+            action="skip", pr=pr, mode=mode, reason=f"unhandled mergeStateStatus={status}"
+        )
+
+    # Unknown mode — stay conservative.
+    return AutoMergeOutcome(action="skip", pr=pr, mode=mode, reason=f"unknown mode={mode}")
+
+
+def parse_pr_state(gh_json_output: str) -> PRState | None:
+    """Parse ``gh pr view --json mergeStateStatus,mergeable,reviewDecision,statusCheckRollup``.
+
+    Returns ``None`` when:
+    - the payload is empty / whitespace
+    - the payload is not valid JSON
+    - the top-level payload is not a JSON object
+
+    Missing fields are tolerated and coerced to empty strings so downstream
+    :func:`decide` sees a uniform shape. ``statusCheckRollup`` aggregates to
+    a single ``ci_conclusion`` using the following precedence (most severe
+    wins):
+
+    - any entry with ``conclusion == "FAILURE"`` → ``"FAILURE"``
+    - else any entry with ``conclusion == "PENDING"`` (or blank while
+      ``status == "IN_PROGRESS"`` / ``"QUEUED"``) → ``"PENDING"``
+    - else if every entry is ``SUCCESS`` → ``"SUCCESS"``
+    - else → ``None``
+    """
+    if not gh_json_output or not gh_json_output.strip():
+        return None
+    try:
+        data = json.loads(gh_json_output)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    rollup = data.get("statusCheckRollup") or []
+    ci_conclusion: str | None = _aggregate_ci(rollup) if isinstance(rollup, list) else None
+
+    return PRState(
+        mergeStateStatus=str(data.get("mergeStateStatus") or ""),
+        mergeable=str(data.get("mergeable") or ""),
+        review_decision=str(data.get("reviewDecision") or ""),
+        ci_conclusion=ci_conclusion,
+    )
+
+
+def _aggregate_ci(rollup: list) -> str | None:
+    """Reduce ``statusCheckRollup`` to a single overall conclusion.
+
+    See :func:`parse_pr_state` docstring for precedence rules.
+    """
+    if not rollup:
+        return None
+    saw_pending = False
+    saw_success = False
+    for entry in rollup:
+        if not isinstance(entry, dict):
+            continue
+        conclusion = str(entry.get("conclusion") or "").upper()
+        status = str(entry.get("status") or "").upper()
+        if conclusion == "FAILURE":
+            return "FAILURE"
+        if conclusion == "PENDING" or status in ("IN_PROGRESS", "QUEUED"):
+            saw_pending = True
+            continue
+        if conclusion == "SUCCESS":
+            saw_success = True
+    if saw_pending:
+        return "PENDING"
+    if saw_success:
+        return "SUCCESS"
+    return None

--- a/antfarm/core/backends/base.py
+++ b/antfarm/core/backends/base.py
@@ -193,7 +193,12 @@ class TaskBackend(ABC):
         ...
 
     @abstractmethod
-    def mark_merged(self, task_id: str, attempt_id: str) -> None:
+    def mark_merged(
+        self,
+        task_id: str,
+        attempt_id: str,
+        auto_merged: bool = False,
+    ) -> None:
         """Mark attempt as MERGED. Task stays DONE in done/ folder.
 
         Merged state is tracked on the attempt, not the task status.
@@ -201,6 +206,8 @@ class TaskBackend(ABC):
         Args:
             task_id: ID of the task.
             attempt_id: ID of the attempt that was merged.
+            auto_merged: If True, also record ``attempt["auto_merged"] = True``
+                so report.py can split merged counts into auto vs manual.
 
         Raises:
             ValueError: If attempt_id is not the current attempt.

--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -574,7 +574,12 @@ class FileBackend(TaskBackend):
             data["updated_at"] = _now_iso()
             self._write_json(done_path, data)
 
-    def mark_merged(self, task_id: str, attempt_id: str) -> None:
+    def mark_merged(
+        self,
+        task_id: str,
+        attempt_id: str,
+        auto_merged: bool = False,
+    ) -> None:
         """Update attempt status to MERGED in done/ task file. Task stays DONE.
 
         Raises:
@@ -598,6 +603,8 @@ class FileBackend(TaskBackend):
             for a in data["attempts"]:
                 if a["attempt_id"] == attempt_id:
                     a["status"] = AttemptStatus.MERGED.value
+                    if auto_merged:
+                        a["auto_merged"] = True
                     matched = True
                     break
 

--- a/antfarm/core/backends/github.py
+++ b/antfarm/core/backends/github.py
@@ -626,7 +626,12 @@ class GitHubBackend(TaskBackend):
         task["updated_at"] = _now_iso()
         self._update_task_body(issue_number, task)
 
-    def mark_merged(self, task_id: str, attempt_id: str) -> None:
+    def mark_merged(
+        self,
+        task_id: str,
+        attempt_id: str,
+        auto_merged: bool = False,
+    ) -> None:
         """Close the issue, add antfarm:merged label.
 
         Raises:
@@ -648,6 +653,8 @@ class GitHubBackend(TaskBackend):
         for a in task["attempts"]:
             if a["attempt_id"] == attempt_id:
                 a["status"] = AttemptStatus.MERGED.value
+                if auto_merged:
+                    a["auto_merged"] = True
                 matched = True
                 break
 

--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -16,6 +16,8 @@ import time
 import click
 import httpx
 
+from antfarm.core.missions import VALID_AUTO_MERGE_MODES
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -63,6 +65,14 @@ def _delete(
         f"{colony_url.rstrip('/')}{path}", params=params or {}, headers=_auth_headers(token)
     )
     r.raise_for_status()
+
+
+def _patch(colony_url: str, path: str, payload: dict, token: str | None = None) -> dict | None:
+    r = httpx.patch(f"{colony_url.rstrip('/')}{path}", json=payload, headers=_auth_headers(token))
+    r.raise_for_status()
+    if r.status_code == 204:
+        return None
+    return r.json()
 
 
 # ---------------------------------------------------------------------------
@@ -1374,6 +1384,18 @@ def mission():
 @click.option("--max-builders", type=int, default=None, help="Max parallel builder workers.")
 @click.option("--max-attempts", type=int, default=None, help="Max attempts per task.")
 @click.option("--integration-branch", default=None, help="Integration branch for this mission.")
+@click.option(
+    "--auto-merge",
+    type=click.Choice(list(VALID_AUTO_MERGE_MODES)),
+    default=None,
+    help="Auto-merge policy: never, on-review-pass, on-review-pass-and-ci-green.",
+)
+@click.option(
+    "--allow-auto-merge-on-external",
+    is_flag=True,
+    default=False,
+    help="Permit auto-merge even when the viewer is not an ADMIN of the target repo.",
+)
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def mission_create(
@@ -1383,6 +1405,8 @@ def mission_create(
     max_builders: int | None,
     max_attempts: int | None,
     integration_branch: str | None,
+    auto_merge: str | None,
+    allow_auto_merge_on_external: bool,
     colony_url: str,
     token: str | None,
 ):
@@ -1400,6 +1424,10 @@ def mission_create(
         config["max_attempts"] = max_attempts
     if integration_branch is not None:
         config["integration_branch"] = integration_branch
+    if auto_merge is not None:
+        config["auto_merge"] = auto_merge
+    if allow_auto_merge_on_external:
+        config["allow_auto_merge_on_external"] = True
     if config:
         payload["config"] = config
     if mission_id:
@@ -1426,6 +1454,9 @@ def mission_status(mission_id: str, colony_url: str, token: str | None):
         click.echo(f"Completion: {completion_mode} (treated as best_effort in v0.6.0)")
     else:
         click.echo(f"Completion: {completion_mode}")
+
+    auto_merge_mode = config.get("auto_merge", "never")
+    click.echo(f"Auto-merge: {auto_merge_mode}")
 
     task_ids = data.get("task_ids", [])
     click.echo(f"Tasks:      {len(task_ids)}")
@@ -1477,6 +1508,48 @@ def mission_report(mission_id: str, fmt: str, colony_url: str, token: str | None
                 title = t.get("title", t.get("id", "?"))[:28]
                 status = t.get("status", "unknown")
                 click.echo(f"{title:<30} {status:<12}")
+
+
+@mission.command("update")
+@click.argument("mission_id")
+@click.option(
+    "--auto-merge",
+    type=click.Choice(list(VALID_AUTO_MERGE_MODES)),
+    default=None,
+    help="Auto-merge policy: never, on-review-pass, on-review-pass-and-ci-green.",
+)
+@click.option(
+    "--allow-auto-merge-on-external",
+    is_flag=True,
+    default=None,
+    help="Permit auto-merge even when the viewer is not an ADMIN of the target repo.",
+)
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def mission_update(
+    mission_id: str,
+    auto_merge: str | None,
+    allow_auto_merge_on_external: bool | None,
+    colony_url: str,
+    token: str | None,
+):
+    """Update a mission's config in place. Only the provided fields are changed."""
+    partial: dict = {}
+    if auto_merge is not None:
+        partial["auto_merge"] = auto_merge
+    if allow_auto_merge_on_external is not None:
+        partial["allow_auto_merge_on_external"] = bool(allow_auto_merge_on_external)
+
+    if not partial:
+        click.echo("No updates specified. Use --auto-merge or --allow-auto-merge-on-external.")
+        return
+
+    # Fetch current config and shallow-merge so fields we did not touch are preserved.
+    current = _get(colony_url, f"/missions/{mission_id}", token=token)
+    merged = dict(current.get("config") or {})
+    merged.update(partial)
+    _patch(colony_url, f"/missions/{mission_id}", {"updates": {"config": merged}}, token=token)
+    click.echo(f"Mission {mission_id} updated: {partial}")
 
 
 @mission.command("cancel")

--- a/antfarm/core/colony_client.py
+++ b/antfarm/core/colony_client.py
@@ -1,6 +1,5 @@
 """Thin synchronous httpx wrapper for the Antfarm Colony API."""
 
-
 import httpx
 
 
@@ -24,9 +23,7 @@ class ColonyClient:
         headers = {}
         if token:
             headers["Authorization"] = f"Bearer {token}"
-        self._client = client or httpx.Client(
-            base_url=self.base_url, timeout=30.0, headers=headers
-        )
+        self._client = client or httpx.Client(base_url=self.base_url, timeout=30.0, headers=headers)
         self._owns_client = client is None  # only close if we created it
 
     def register_node(
@@ -68,13 +65,16 @@ class ColonyClient:
         workspace_root: str,
         capabilities: list[str] | None = None,
     ) -> dict:
-        r = self._client.post("/workers/register", json={
-            "worker_id": worker_id,
-            "node_id": node_id,
-            "agent_type": agent_type,
-            "workspace_root": workspace_root,
-            "capabilities": capabilities or [],
-        })
+        r = self._client.post(
+            "/workers/register",
+            json={
+                "worker_id": worker_id,
+                "node_id": node_id,
+                "agent_type": agent_type,
+                "workspace_root": workspace_root,
+                "capabilities": capabilities or [],
+            },
+        )
         r.raise_for_status()
         return r.json()
 
@@ -115,17 +115,23 @@ class ColonyClient:
         return r.json()
 
     def trail(self, task_id: str, worker_id: str, message: str) -> None:
-        r = self._client.post(f"/tasks/{task_id}/trail", json={
-            "worker_id": worker_id,
-            "message": message,
-        })
+        r = self._client.post(
+            f"/tasks/{task_id}/trail",
+            json={
+                "worker_id": worker_id,
+                "message": message,
+            },
+        )
         r.raise_for_status()
 
     def signal(self, task_id: str, worker_id: str, message: str) -> None:
-        r = self._client.post(f"/tasks/{task_id}/signal", json={
-            "worker_id": worker_id,
-            "message": message,
-        })
+        r = self._client.post(
+            f"/tasks/{task_id}/signal",
+            json={
+                "worker_id": worker_id,
+                "message": message,
+            },
+        )
         r.raise_for_status()
 
     def carry(
@@ -188,26 +194,30 @@ class ColonyClient:
         payload: dict = {"reason": reason}
         if max_attempts is not None:
             payload["max_attempts"] = max_attempts
-        r = self._client.post(
-            f"/tasks/{task_id}/kickback", json=payload
-        )
+        r = self._client.post(f"/tasks/{task_id}/kickback", json=payload)
         r.raise_for_status()
 
     def mark_harvest_pending(self, task_id: str, attempt_id: str) -> None:
         r = self._client.post(f"/tasks/{task_id}/harvest-pending", json={"attempt_id": attempt_id})
         r.raise_for_status()
 
-    def store_review_verdict(
-        self, task_id: str, attempt_id: str, verdict: dict
-    ) -> None:
+    def store_review_verdict(self, task_id: str, attempt_id: str, verdict: dict) -> None:
         r = self._client.post(
             f"/tasks/{task_id}/review-verdict",
             json={"attempt_id": attempt_id, "verdict": verdict},
         )
         r.raise_for_status()
 
-    def mark_merged(self, task_id: str, attempt_id: str) -> None:
-        r = self._client.post(f"/tasks/{task_id}/merge", json={"attempt_id": attempt_id})
+    def mark_merged(
+        self,
+        task_id: str,
+        attempt_id: str,
+        auto_merged: bool = False,
+    ) -> None:
+        payload: dict = {"attempt_id": attempt_id}
+        if auto_merged:
+            payload["auto_merged"] = True
+        r = self._client.post(f"/tasks/{task_id}/merge", json=payload)
         r.raise_for_status()
 
     def rereview(
@@ -280,6 +290,22 @@ class ColonyClient:
         """Apply shallow updates to a mission."""
         r = self._client.patch(f"/missions/{mission_id}", json={"updates": updates})
         r.raise_for_status()
+
+    def update_mission_config(self, mission_id: str, partial_config: dict) -> dict:
+        """Shallow-merge ``partial_config`` into an existing mission's config.
+
+        GET the current mission, merge the partial config over it, then PATCH
+        ``/missions/{id}`` with ``{"updates": {"config": merged}}``. Returns
+        the merged config dict actually sent. Raises if the mission does not
+        exist (404 bubbles up as an HTTPError).
+        """
+        current = self.get_mission(mission_id)
+        if current is None:
+            raise FileNotFoundError(f"mission '{mission_id}' not found")
+        merged = dict(current.get("config") or {})
+        merged.update(partial_config)
+        self.update_mission(mission_id, {"config": merged})
+        return merged
 
     def cancel_mission(self, mission_id: str) -> None:
         """Cancel a mission."""

--- a/antfarm/core/missions.py
+++ b/antfarm/core/missions.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 VALID_COMPLETION_MODES = ("best_effort", "all_or_nothing")
 VALID_BLOCKED_TIMEOUT_ACTIONS = ("wait", "fail")
+VALID_AUTO_MERGE_MODES = ("never", "on-review-pass", "on-review-pass-and-ci-green")
 
 
 # ---------------------------------------------------------------------------
@@ -52,6 +53,8 @@ class MissionConfig:
     integration_branch: str = "main"
     blocked_timeout_action: str = "wait"
     blocked_timeout_minutes: int = 120
+    auto_merge: str = "never"
+    allow_auto_merge_on_external: bool = False
 
     def __post_init__(self) -> None:
         if self.completion_mode not in VALID_COMPLETION_MODES:
@@ -60,6 +63,8 @@ class MissionConfig:
             raise ValueError(
                 f"blocked_timeout_action must be one of {VALID_BLOCKED_TIMEOUT_ACTIONS}"
             )
+        if self.auto_merge not in VALID_AUTO_MERGE_MODES:
+            raise ValueError(f"auto_merge must be one of {VALID_AUTO_MERGE_MODES}")
 
     def to_dict(self) -> dict:
         return {
@@ -72,6 +77,8 @@ class MissionConfig:
             "integration_branch": self.integration_branch,
             "blocked_timeout_action": self.blocked_timeout_action,
             "blocked_timeout_minutes": self.blocked_timeout_minutes,
+            "auto_merge": self.auto_merge,
+            "allow_auto_merge_on_external": self.allow_auto_merge_on_external,
         }
 
     @classmethod
@@ -88,6 +95,8 @@ class MissionConfig:
             integration_branch=data.get("integration_branch", "main"),
             blocked_timeout_action=data.get("blocked_timeout_action", "wait"),
             blocked_timeout_minutes=data.get("blocked_timeout_minutes", 120),
+            auto_merge=data.get("auto_merge", "never"),
+            allow_auto_merge_on_external=data.get("allow_auto_merge_on_external", False),
         )
 
 
@@ -221,6 +230,8 @@ class MissionReport:
     total_lines_removed: int = 0
     files_changed: list[str] = field(default_factory=list)
     generated_at: str = ""
+    auto_merged_tasks: int = 0
+    manual_merged_tasks: int = 0
 
     def to_dict(self) -> dict:
         return {
@@ -242,6 +253,8 @@ class MissionReport:
             "total_lines_removed": self.total_lines_removed,
             "files_changed": list(self.files_changed),
             "generated_at": self.generated_at,
+            "auto_merged_tasks": self.auto_merged_tasks,
+            "manual_merged_tasks": self.manual_merged_tasks,
         }
 
     @classmethod
@@ -265,6 +278,8 @@ class MissionReport:
             total_lines_removed=data.get("total_lines_removed", 0),
             files_changed=list(data.get("files_changed", [])),
             generated_at=data.get("generated_at", ""),
+            auto_merged_tasks=data.get("auto_merged_tasks", 0),
+            manual_merged_tasks=data.get("manual_merged_tasks", 0),
         )
 
 

--- a/antfarm/core/report.py
+++ b/antfarm/core/report.py
@@ -45,6 +45,8 @@ def build_report(mission: dict, tasks: list[dict]) -> MissionReport:
     total_lines_added = 0
     total_lines_removed = 0
     all_risks: list[str] = []
+    auto_merged_count = 0
+    manual_merged_count = 0
 
     for task in impl_tasks:
         attempts = task.get("attempts", [])
@@ -57,14 +59,20 @@ def build_report(mission: dict, tasks: list[dict]) -> MissionReport:
             files_changed = artifact.get("files_changed", [])
             risks = artifact.get("risks", [])
 
-            merged.append(MissionReportTask(
-                task_id=task["id"],
-                title=task.get("title", ""),
-                pr_url=pr_url,
-                lines_added=lines_added,
-                lines_removed=lines_removed,
-                files_changed=list(files_changed),
-            ))
+            merged.append(
+                MissionReportTask(
+                    task_id=task["id"],
+                    title=task.get("title", ""),
+                    pr_url=pr_url,
+                    lines_added=lines_added,
+                    lines_removed=lines_removed,
+                    files_changed=list(files_changed),
+                )
+            )
+            if merged_attempt.get("auto_merged", False):
+                auto_merged_count += 1
+            else:
+                manual_merged_count += 1
             if pr_url:
                 all_pr_urls.append(pr_url)
             branch = merged_attempt.get("branch")
@@ -79,13 +87,15 @@ def build_report(mission: dict, tasks: list[dict]) -> MissionReport:
             reason = _extract_blocked_reason(task)
             attempt_count = len(attempts)
             last_failure_type = _extract_last_failure_type(task)
-            blocked.append(MissionReportBlocked(
-                task_id=task["id"],
-                title=task.get("title", ""),
-                reason=reason,
-                attempt_count=attempt_count,
-                last_failure_type=last_failure_type,
-            ))
+            blocked.append(
+                MissionReportBlocked(
+                    task_id=task["id"],
+                    title=task.get("title", ""),
+                    reason=reason,
+                    attempt_count=attempt_count,
+                    last_failure_type=last_failure_type,
+                )
+            )
 
     # Failed reviews: review tasks with verdict needs_changes or blocked
     failed_reviews = 0
@@ -129,6 +139,8 @@ def build_report(mission: dict, tasks: list[dict]) -> MissionReport:
         total_lines_removed=total_lines_removed,
         files_changed=unique_files,
         generated_at=datetime.now(UTC).isoformat() + "Z",
+        auto_merged_tasks=auto_merged_count,
+        manual_merged_tasks=manual_merged_count,
     )
 
 
@@ -148,9 +160,7 @@ def render_terminal(report: MissionReport, use_rich: bool = False) -> str:
     Uses only ``textwrap`` from the stdlib. 80-column wrap by default.
     """
     if use_rich:
-        raise NotImplementedError(
-            "rich rendering is a v0.6.1+ opt-in; v0.6.0 is dependency-free"
-        )
+        raise NotImplementedError("rich rendering is a v0.6.1+ opt-in; v0.6.0 is dependency-free")
 
     lines: list[str] = []
     width = 80
@@ -170,9 +180,11 @@ def render_terminal(report: MissionReport, use_rich: bool = False) -> str:
     lines.append("")
 
     # Summary
-    lines.append(f"Tasks: {report.total_tasks} total, "
-                 f"{report.merged_tasks} merged, "
-                 f"{report.blocked_tasks} blocked")
+    lines.append(
+        f"Tasks: {report.total_tasks} total, "
+        f"{report.merged_tasks} merged, "
+        f"{report.blocked_tasks} blocked"
+    )
     if report.failed_reviews:
         lines.append(f"Failed reviews: {report.failed_reviews}")
     lines.append(f"Lines: +{report.total_lines_added} / -{report.total_lines_removed}")
@@ -194,8 +206,9 @@ def render_terminal(report: MissionReport, use_rich: bool = False) -> str:
         for mt in report.merged:
             pr_str = f"  PR: {mt.pr_url}" if mt.pr_url else ""
             lines.append(f"  [{mt.task_id}] {mt.title}{pr_str}")
-            lines.append(f"    +{mt.lines_added} / -{mt.lines_removed}, "
-                         f"{len(mt.files_changed)} files")
+            lines.append(
+                f"    +{mt.lines_added} / -{mt.lines_removed}, {len(mt.files_changed)} files"
+            )
         lines.append("")
 
     # Merged tasks (non-cancelled)
@@ -206,8 +219,9 @@ def render_terminal(report: MissionReport, use_rich: bool = False) -> str:
         for mt in report.merged:
             pr_str = f"  PR: {mt.pr_url}" if mt.pr_url else ""
             lines.append(f"  [{mt.task_id}] {mt.title}{pr_str}")
-            lines.append(f"    +{mt.lines_added} / -{mt.lines_removed}, "
-                         f"{len(mt.files_changed)} files")
+            lines.append(
+                f"    +{mt.lines_added} / -{mt.lines_removed}, {len(mt.files_changed)} files"
+            )
         lines.append("")
 
     # Blocked tasks
@@ -286,8 +300,9 @@ def render_markdown(report: MissionReport) -> str:
         for mt in report.merged:
             pr_link = f" ([PR]({mt.pr_url}))" if mt.pr_url else ""
             lines.append(f"- **{mt.task_id}**: {mt.title}{pr_link}")
-            lines.append(f"  - +{mt.lines_added} / -{mt.lines_removed}, "
-                         f"{len(mt.files_changed)} files")
+            lines.append(
+                f"  - +{mt.lines_added} / -{mt.lines_removed}, {len(mt.files_changed)} files"
+            )
         lines.append("")
 
     # Merged tasks (non-cancelled)
@@ -297,8 +312,9 @@ def render_markdown(report: MissionReport) -> str:
         for mt in report.merged:
             pr_link = f" ([PR]({mt.pr_url}))" if mt.pr_url else ""
             lines.append(f"- **{mt.task_id}**: {mt.title}{pr_link}")
-            lines.append(f"  - +{mt.lines_added} / -{mt.lines_removed}, "
-                         f"{len(mt.files_changed)} files")
+            lines.append(
+                f"  - +{mt.lines_added} / -{mt.lines_removed}, {len(mt.files_changed)} files"
+            )
         lines.append("")
 
     # Blocked tasks

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -367,6 +367,7 @@ class ReviewVerdictRequest(BaseModel):
 
 class MergeRequest(BaseModel):
     attempt_id: str
+    auto_merged: bool = False
 
 
 class RereviewRequest(BaseModel):
@@ -786,12 +787,15 @@ def get_app(
     def merge_task(task_id: str, req: MergeRequest):
         """Mark a task attempt as merged. Soldier only."""
         try:
-            _backend.mark_merged(task_id, req.attempt_id)
+            _backend.mark_merged(task_id, req.attempt_id, auto_merged=req.auto_merged)
         except ValueError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         except FileNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc)) from exc
-        _emit_event("merged", task_id, f"attempt={req.attempt_id}")
+        detail = f"attempt={req.attempt_id}"
+        if req.auto_merged:
+            detail += " auto_merged=1"
+        _emit_event("merged", task_id, detail)
         return {"ok": True}
 
     @app.post("/tasks/{task_id}/pause", status_code=200)

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -28,6 +28,7 @@ from enum import StrEnum
 
 import httpx
 
+from antfarm.core.auto_merge import AutoMergeOutcome, decide, parse_pr_state
 from antfarm.core.backends.base import TaskBackend
 from antfarm.core.colony_client import ColonyClient
 from antfarm.core.missions import is_infra_task
@@ -110,9 +111,37 @@ _MERGE_FAILED_REASONS = frozenset(
         "fetch_failed",  # git fetch origin failed
         "checkout_failed",  # could not checkout integration branch / temp
         "repo_dirty",  # soldier clone was dirty and recovery failed
+        "auto_merge_ci_failed",  # CI on PR reported FAILURE while mode gated on CI
+        "auto_merge_refused",  # security guard refused auto-merge on this repo
         "unknown",  # catch-all for unclassified failures
     }
 )
+
+
+# ---------------------------------------------------------------------------
+# Auto-merge event vocabulary (#353)
+#
+# When a mission's ``config.auto_merge`` is not ``never``, Soldier runs the
+# auto-merge pipeline on every passing-verdict task. The pipeline emits
+# these event types (actor=soldier) so operators can trace why a PR did or
+# did not auto-merge:
+#
+# - auto_merged: PR was successfully squash-merged via ``gh pr merge``.
+# - auto_merge_rebasing: PR needs ``git merge --ff-only`` / rebase before
+#   auto-merge can proceed. Usually followed by another auto_merge_* event
+#   on the next tick.
+# - auto_merge_waiting_ci: ``on-review-pass-and-ci-green`` mode, PR
+#   mergeStateStatus is UNSTABLE or PENDING. Soldier skips this tick.
+# - auto_merge_kickback: mergeStateStatus=BLOCKED with failing CI. Soldier
+#   kicks back the task with reason=auto_merge_ci_failed so the worker
+#   re-attempts with fixed code.
+# - auto_merge_blocked: mergeStateStatus=BLOCKED with missing reviews or
+#   other unresolved reason. Soldier pauses the parent mission (sets
+#   status=BLOCKED + stores ``auto_merge_pause_reason``).
+# - auto_merge_refused: security guard refused auto-merge (viewer lacks
+#   permission or main/master without ADMIN). Surfaces once per PR until
+#   the backoff window expires.
+# ---------------------------------------------------------------------------
 
 
 def _emit(event_type: str, task_id: str, detail: str = "") -> None:
@@ -199,6 +228,12 @@ class Soldier:
         # One-shot preflight validation of ``test_command`` — see #326. Fires
         # at most once per Soldier lifetime from ``run`` or ``run_once``.
         self._preflight_done: bool = False
+        # Auto-merge (#353): per-PR backoff (tick timestamp when we last
+        # polled that PR's mergeability) and a per-repo cache of
+        # ``gh repo view`` viewer permission (value, expires_ts).
+        self._auto_merge_last_checked: dict[str, float] = {}
+        self._repo_permission_cache: dict[str, tuple[str, float]] = {}
+        self.auto_merge_poll_backoff_seconds: float = 30.0
 
     # ------------------------------------------------------------------
     # Public API
@@ -379,20 +414,24 @@ class Soldier:
             if verdict_dict is not None:
                 passed, reason = self.check_review_verdict(task)
                 if passed:
-                    result = self.attempt_merge(task)
-                    if result == MergeResult.MERGED:
-                        self._safe_mark_merged(task_id, attempt_id)
+                    auto_outcome = self._attempt_auto_merge(task)
+                    if auto_outcome is None:
+                        result = self.attempt_merge(task)
+                        if result == MergeResult.MERGED:
+                            self._safe_mark_merged(task_id, attempt_id)
+                        else:
+                            try:
+                                self.kickback_with_cascade(task_id, self.last_failure_reason)
+                            except Exception as exc:
+                                logger.exception("kickback failed for %s", task_id)
+                                _emit(
+                                    "soldier_error",
+                                    task_id,
+                                    f"op=kickback_merge_failed type={type(exc).__name__} msg={exc}",
+                                )
+                                raise
                     else:
-                        try:
-                            self.kickback_with_cascade(task_id, self.last_failure_reason)
-                        except Exception as exc:
-                            logger.exception("kickback failed for %s", task_id)
-                            _emit(
-                                "soldier_error",
-                                task_id,
-                                f"op=kickback_merge_failed type={type(exc).__name__} msg={exc}",
-                            )
-                            raise
+                        result = self._handle_auto_merge_outcome(auto_outcome, task)
                     results.append((task_id, result))
                 else:
                     # Diagnostic skip before kickback: needs_changes verdict.
@@ -475,11 +514,15 @@ class Soldier:
                             continue
                         passed, reason = self.check_review_verdict(task_updated)
                         if passed:
-                            result = self.attempt_merge(task_updated)
-                            if result == MergeResult.MERGED:
-                                self._safe_mark_merged(task_id, attempt_id)
+                            auto_outcome = self._attempt_auto_merge(task_updated)
+                            if auto_outcome is None:
+                                result = self.attempt_merge(task_updated)
+                                if result == MergeResult.MERGED:
+                                    self._safe_mark_merged(task_id, attempt_id)
+                                else:
+                                    self.kickback_with_cascade(task_id, self.last_failure_reason)
                             else:
-                                self.kickback_with_cascade(task_id, self.last_failure_reason)
+                                result = self._handle_auto_merge_outcome(auto_outcome, task_updated)
                             results.append((task_id, result))
                         else:
                             _emit("merge_skipped", task_id, "reason=needs_changes")
@@ -540,11 +583,15 @@ class Soldier:
 
             passed, reason = self.check_review_verdict(task_updated)
             if passed:
-                result = self.attempt_merge(task_updated)
-                if result == MergeResult.MERGED:
-                    self._safe_mark_merged(task_id, attempt_id)
+                auto_outcome = self._attempt_auto_merge(task_updated)
+                if auto_outcome is None:
+                    result = self.attempt_merge(task_updated)
+                    if result == MergeResult.MERGED:
+                        self._safe_mark_merged(task_id, attempt_id)
+                    else:
+                        self.kickback_with_cascade(task_id, self.last_failure_reason)
                 else:
-                    self.kickback_with_cascade(task_id, self.last_failure_reason)
+                    result = self._handle_auto_merge_outcome(auto_outcome, task_updated)
                 results.append((task_id, result))
             else:
                 # Diagnostic skip before kickback: needs_changes verdict.
@@ -1984,6 +2031,385 @@ class Soldier:
             return None
 
     # ------------------------------------------------------------------
+    # Auto-merge (#353)
+    # ------------------------------------------------------------------
+
+    def _auto_merge_policy_for_task(self, task: dict) -> str:
+        """Resolve the auto-merge mode for ``task`` via its parent mission.
+
+        Returns the mode string — ``"never"`` when the task has no mission,
+        the mission cannot be fetched, or the mission's config does not set
+        the key.
+        """
+        mission_id = task.get("mission_id")
+        if not mission_id:
+            return "never"
+        try:
+            mission = self.colony.get_mission(mission_id)
+        except Exception:
+            logger.debug("auto-merge: get_mission(%s) raised", mission_id, exc_info=True)
+            return "never"
+        if not mission:
+            return "never"
+        config = mission.get("config") or {}
+        return str(config.get("auto_merge") or "never")
+
+    def _query_pr_state(self, pr: str):
+        """Run ``gh pr view <pr> --json ...`` and parse the output.
+
+        Returns a :class:`PRState` or None on any subprocess / parse error.
+        """
+        if not pr:
+            return None
+        try:
+            r = subprocess.run(
+                [
+                    "gh",
+                    "pr",
+                    "view",
+                    pr,
+                    "--json",
+                    "mergeStateStatus,mergeable,reviewDecision,statusCheckRollup",
+                ],
+                cwd=self.repo_path,
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+        if r.returncode != 0:
+            return None
+        return parse_pr_state(r.stdout or "")
+
+    def _gh_pr_merge_squash(self, pr: str) -> tuple[bool, str]:
+        """Run ``gh pr merge <pr> --squash --delete-branch``.
+
+        Returns (ok, stderr_tail). Never raises.
+        """
+        try:
+            r = subprocess.run(
+                ["gh", "pr", "merge", pr, "--squash", "--delete-branch"],
+                cwd=self.repo_path,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return False, f"gh pr merge exec error: {exc}"
+        if r.returncode == 0:
+            return True, ""
+        tail = (r.stderr or r.stdout or "").strip().splitlines()
+        return False, "\n".join(tail[-20:])
+
+    def _resolve_repo_slug(self) -> str | None:
+        """Return ``owner/name`` for the repo we're operating on, or None."""
+        try:
+            r = subprocess.run(
+                [
+                    "gh",
+                    "repo",
+                    "view",
+                    "--json",
+                    "owner,name",
+                    "-q",
+                    '.owner.login + "/" + .name',
+                ],
+                cwd=self.repo_path,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+        if r.returncode != 0:
+            return None
+        slug = (r.stdout or "").strip()
+        return slug or None
+
+    def _query_viewer_permission(self) -> str | None:
+        """Query viewer permission via ``gh repo view --json viewerPermission``."""
+        try:
+            r = subprocess.run(
+                ["gh", "repo", "view", "--json", "viewerPermission", "-q", ".viewerPermission"],
+                cwd=self.repo_path,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+        if r.returncode != 0:
+            return None
+        perm = (r.stdout or "").strip()
+        return perm or None
+
+    def _auto_merge_security_check(
+        self,
+        task: dict,
+        mission: dict,
+    ) -> tuple[bool, str]:
+        """Gate auto-merge on viewer permission + integration branch.
+
+        Returns (True, "") to allow; (False, reason) to refuse. Caches
+        viewer permission per-repo for 5 minutes.
+        """
+        del task  # kept in signature for symmetry with other hooks
+        slug = self._resolve_repo_slug() or self.repo_path
+        now = time.time()
+        cached = self._repo_permission_cache.get(slug)
+        if cached and cached[1] > now:
+            perm = cached[0]
+        else:
+            perm = self._query_viewer_permission() or ""
+            # Cache for 5 minutes regardless of success, so a transient gh
+            # outage doesn't hammer the API on every tick.
+            self._repo_permission_cache[slug] = (perm, now + 300.0)
+        perm_upper = perm.upper()
+        allow_external = bool(
+            (mission.get("config") or {}).get("allow_auto_merge_on_external", False)
+        )
+
+        if perm_upper not in {"ADMIN", "MAINTAIN", "WRITE"}:
+            if allow_external:
+                return True, ""
+            return False, f"insufficient repo permission: {perm or 'unknown'}"
+
+        # Extra guard: auto-merge to main/master requires ADMIN unless operator
+        # explicitly opted in via allow_auto_merge_on_external.
+        if self.integration_branch in ("main", "master") and perm_upper != "ADMIN":
+            if allow_external:
+                return True, ""
+            return (
+                False,
+                f"auto-merge to {self.integration_branch} requires ADMIN "
+                f"(viewer={perm or 'unknown'})",
+            )
+        return True, ""
+
+    def _sync_integration_branch_after_auto_merge(self) -> None:
+        """Re-align the local integration branch with origin after auto-merge.
+
+        GitHub squash-merged the PR on the remote; locally we still have the
+        pre-merge tip. Fetch + hard-reset brings us back in sync without
+        running any local tests (GitHub's branch protection already gated
+        the merge). Best-effort; subprocess errors are swallowed.
+        """
+        try:
+            subprocess.run(
+                ["git", "fetch", "origin"],
+                cwd=self.repo_path,
+                capture_output=True,
+                check=False,
+            )
+            subprocess.run(
+                ["git", "checkout", self.integration_branch],
+                cwd=self.repo_path,
+                capture_output=True,
+                check=False,
+            )
+            subprocess.run(
+                ["git", "reset", "--hard", f"origin/{self.integration_branch}"],
+                cwd=self.repo_path,
+                capture_output=True,
+                check=False,
+            )
+        except OSError:
+            logger.debug(
+                "auto-merge: post-merge sync raised for %s",
+                self.integration_branch,
+                exc_info=True,
+            )
+
+    def _rebase_pr_branch_for_auto_merge(self, task: dict, pr: str) -> None:
+        """Rebase the PR's branch onto origin/<integration_branch>.
+
+        Wraps the existing deterministic rebase helper. Any failure is
+        logged and surfaces as an ``auto_merge_rebasing`` event with
+        ``status=failed`` so the next tick re-evaluates.
+        """
+        branch = self._get_attempt_branch(task) or ""
+        task_id = task.get("id", "")
+        if not branch:
+            _emit("auto_merge_rebasing", task_id, f"pr={pr} status=failed reason=no_branch")
+            return
+        # Reuse the deterministic helper's rebase core — it aborts on conflict
+        # and returns FAILED without merging further. We don't care about the
+        # eventual merge here; we just want the rebase/force-push side effect.
+        outcome = self._rebase_and_retry_merge(
+            task_id=task_id,
+            branch=branch,
+            temp_branch="antfarm/temp-merge",
+            initial_conflict_stderr="auto-merge triggered rebase",
+        )
+        detail = f"pr={pr} branch={branch} result={outcome.value}"
+        _emit("auto_merge_rebasing", task_id, detail)
+
+    def _pause_mission_for_blocked_reviews(
+        self,
+        task: dict,
+        pr: str,
+        reason: str,
+    ) -> None:
+        """Mark the parent mission as BLOCKED with a human-readable reason."""
+        task_id = task.get("id", "")
+        mission_id = task.get("mission_id")
+        if not mission_id:
+            _emit("auto_merge_blocked", task_id, f"pr={pr} reason={reason} mission=none")
+            return
+        try:
+            self.colony.update_mission(
+                mission_id,
+                {
+                    "status": "blocked",
+                    "auto_merge_pause_reason": reason,
+                },
+            )
+        except Exception:
+            logger.exception(
+                "auto-merge: failed to pause mission %s for task %s", mission_id, task_id
+            )
+        _emit("auto_merge_blocked", task_id, f"pr={pr} reason={reason} mission={mission_id}")
+
+    def _attempt_auto_merge(self, task: dict) -> AutoMergeOutcome | None:
+        """Decide and perform auto-merge for ``task``.
+
+        Returns:
+            - None if auto-merge is disabled for this task (caller falls
+              through to the legacy ``attempt_merge`` path).
+            - AutoMergeOutcome (possibly with ``action='skip'``) otherwise.
+              The caller (``_handle_auto_merge_outcome``) translates the
+              outcome into the merge-pipeline result.
+        """
+        mode = self._auto_merge_policy_for_task(task)
+        if mode == "never":
+            return None
+
+        task_id = task.get("id", "")
+        pr = self._get_attempt_pr(task) or ""
+        if not pr:
+            return AutoMergeOutcome(action="skip", pr="", mode=mode, reason="no PR on attempt")
+
+        # Security check before we make any destructive call or poll gh.
+        mission = {}
+        mission_id = task.get("mission_id")
+        if mission_id:
+            try:
+                mission = self.colony.get_mission(mission_id) or {}
+            except Exception:
+                logger.debug(
+                    "auto-merge: get_mission(%s) raised during security check",
+                    mission_id,
+                    exc_info=True,
+                )
+                mission = {}
+
+        ok, refuse_reason = self._auto_merge_security_check(task, mission)
+        if not ok:
+            _emit("auto_merge_refused", task_id, f"pr={pr} reason={refuse_reason}")
+            return AutoMergeOutcome(
+                action="skip", pr=pr, mode=mode, reason=f"refused: {refuse_reason}"
+            )
+
+        # Backoff: don't re-poll the same PR within 30s.
+        now = time.time()
+        last = self._auto_merge_last_checked.get(pr, 0.0)
+        if now - last < self.auto_merge_poll_backoff_seconds:
+            return AutoMergeOutcome(
+                action="skip", pr=pr, mode=mode, reason="within poll backoff window"
+            )
+        self._auto_merge_last_checked[pr] = now
+
+        pr_state = self._query_pr_state(pr)
+        outcome = decide(mode, verdict_passed=True, pr_state=pr_state, pr=pr)
+        return outcome
+
+    def _handle_auto_merge_outcome(
+        self,
+        outcome: AutoMergeOutcome,
+        task: dict,
+    ) -> MergeResult:
+        """Translate an :class:`AutoMergeOutcome` into a :class:`MergeResult`.
+
+        - ``merge``: invoke ``gh pr merge --squash`` and mark the attempt
+          with ``auto_merged=True``. Returns MERGED on success, FAILED on
+          error (caller kicks back through the normal pipeline).
+        - ``rebase``: rebase the PR branch; signal NEEDS_REVIEW so the tick
+          exits without touching the attempt's review verdict.
+        - ``wait_ci`` / ``skip``: signal NEEDS_REVIEW — the PR stays done,
+          we'll re-evaluate next tick.
+        - ``kickback_ci``: kick back the task with an ``auto_merge_ci_failed``
+          reason code and emit ``auto_merge_kickback``.
+        - ``pause_mission``: pause the parent mission and signal NEEDS_REVIEW.
+        """
+        task_id = task.get("id", "")
+        attempt_id = task.get("current_attempt") or ""
+
+        if outcome.action == "merge":
+            ok, stderr_tail = self._gh_pr_merge_squash(outcome.pr)
+            if not ok:
+                self.last_failure_reason = f"auto_merge: gh pr merge failed: {stderr_tail}"
+                _emit(
+                    "merge_failed",
+                    task_id,
+                    f"reason=unknown: auto_merge gh pr merge failed: {stderr_tail}",
+                )
+                return MergeResult.FAILED
+            self._sync_integration_branch_after_auto_merge()
+            _emit(
+                "auto_merged",
+                task_id,
+                f"pr={outcome.pr} mode={outcome.mode} reason={outcome.reason}",
+            )
+            try:
+                self.colony.mark_merged(task_id, attempt_id, auto_merged=True)
+            except TypeError:
+                # Older colony/backends may not accept the kwarg — degrade gracefully.
+                self.colony.mark_merged(task_id, attempt_id)
+            return MergeResult.MERGED
+
+        if outcome.action == "rebase":
+            _emit(
+                "auto_merge_rebasing",
+                task_id,
+                f"pr={outcome.pr} mode={outcome.mode} reason={outcome.reason}",
+            )
+            self._rebase_pr_branch_for_auto_merge(task, outcome.pr)
+            return MergeResult.NEEDS_REVIEW
+
+        if outcome.action == "wait_ci":
+            _emit(
+                "auto_merge_waiting_ci",
+                task_id,
+                f"pr={outcome.pr} mode={outcome.mode} reason={outcome.reason}",
+            )
+            return MergeResult.NEEDS_REVIEW
+
+        if outcome.action == "kickback_ci":
+            _emit(
+                "auto_merge_kickback",
+                task_id,
+                f"pr={outcome.pr} mode={outcome.mode} reason={outcome.reason}",
+            )
+            self.last_failure_reason = f"auto_merge_ci_failed: {outcome.reason}"
+            try:
+                self.kickback_with_cascade(task_id, self.last_failure_reason)
+            except Exception:
+                logger.exception("auto-merge: kickback_with_cascade failed for %s", task_id)
+            return MergeResult.FAILED
+
+        if outcome.action == "pause_mission":
+            self._pause_mission_for_blocked_reviews(task, outcome.pr, outcome.reason)
+            return MergeResult.NEEDS_REVIEW
+
+        # skip — logged at caller scope; stay inert.
+        return MergeResult.NEEDS_REVIEW
+
+    # ------------------------------------------------------------------
     # from_backend: in-process Soldier (no HTTP round-trips)
     # ------------------------------------------------------------------
 
@@ -2019,6 +2445,9 @@ class Soldier:
         instance.last_failure_reason = ""
         instance._event_cursor = 0
         instance._preflight_done = False
+        instance._auto_merge_last_checked = {}
+        instance._repo_permission_cache = {}
+        instance.auto_merge_poll_backoff_seconds = 30.0
         return instance
 
 
@@ -2066,8 +2495,13 @@ class _BackendAdapter:
             task_id = self._backend.carry(task)
         return {"task_id": task_id}
 
-    def mark_merged(self, task_id: str, attempt_id: str) -> None:
-        self._backend.mark_merged(task_id, attempt_id)
+    def mark_merged(
+        self,
+        task_id: str,
+        attempt_id: str,
+        auto_merged: bool = False,
+    ) -> None:
+        self._backend.mark_merged(task_id, attempt_id, auto_merged=auto_merged)
 
     def kickback(self, task_id: str, reason: str, max_attempts: int = 3) -> None:
         self._backend.kickback(task_id, reason, max_attempts=max_attempts)

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -1,0 +1,291 @@
+"""Tests for antfarm.core.auto_merge — pure decision engine for #353."""
+
+from __future__ import annotations
+
+from antfarm.core.auto_merge import (
+    AutoMergeOutcome,
+    PRState,
+    decide,
+    parse_pr_state,
+)
+
+
+def _state(
+    mergeStateStatus: str = "CLEAN",
+    mergeable: str = "MERGEABLE",
+    review_decision: str = "APPROVED",
+    ci_conclusion: str | None = "SUCCESS",
+) -> PRState:
+    return PRState(
+        mergeStateStatus=mergeStateStatus,
+        mergeable=mergeable,
+        review_decision=review_decision,
+        ci_conclusion=ci_conclusion,
+    )
+
+
+# ---------------------------------------------------------------------------
+# decide() — truth table coverage
+# ---------------------------------------------------------------------------
+
+
+def test_decide_never_mode_always_skips():
+    out = decide("never", verdict_passed=True, pr_state=_state(), pr="https://gh/x/1")
+    assert isinstance(out, AutoMergeOutcome)
+    assert out.action == "skip"
+    assert out.pr == "https://gh/x/1"
+    assert out.mode == "never"
+    assert out.merged is False
+
+
+def test_decide_skip_when_verdict_not_passed():
+    out = decide("on-review-pass", verdict_passed=False, pr_state=_state(), pr="p")
+    assert out.action == "skip"
+
+
+def test_decide_skip_when_pr_state_missing():
+    out = decide("on-review-pass", verdict_passed=True, pr_state=None, pr="p")
+    assert out.action == "skip"
+
+
+def test_decide_on_review_pass_clean_merges():
+    out = decide(
+        "on-review-pass",
+        verdict_passed=True,
+        pr_state=_state(mergeStateStatus="CLEAN"),
+        pr="p",
+    )
+    assert out.action == "merge"
+
+
+def test_decide_on_review_pass_unstable_merges_ci_agnostic():
+    out = decide(
+        "on-review-pass",
+        verdict_passed=True,
+        pr_state=_state(mergeStateStatus="UNSTABLE"),
+        pr="p",
+    )
+    assert out.action == "merge"
+
+
+def test_decide_on_review_pass_dirty_rebase():
+    out = decide(
+        "on-review-pass",
+        verdict_passed=True,
+        pr_state=_state(mergeStateStatus="DIRTY"),
+        pr="p",
+    )
+    assert out.action == "rebase"
+
+
+def test_decide_on_review_pass_behind_rebase():
+    out = decide(
+        "on-review-pass",
+        verdict_passed=True,
+        pr_state=_state(mergeStateStatus="BEHIND"),
+        pr="p",
+    )
+    assert out.action == "rebase"
+
+
+def test_decide_on_review_pass_blocked_ci_failing_kicks_back():
+    out = decide(
+        "on-review-pass",
+        verdict_passed=True,
+        pr_state=_state(
+            mergeStateStatus="BLOCKED",
+            review_decision="APPROVED",
+            ci_conclusion="FAILURE",
+        ),
+        pr="p",
+    )
+    assert out.action == "kickback_ci"
+
+
+def test_decide_on_review_pass_blocked_missing_reviews_pauses():
+    out = decide(
+        "on-review-pass",
+        verdict_passed=True,
+        pr_state=_state(
+            mergeStateStatus="BLOCKED",
+            review_decision="REVIEW_REQUIRED",
+            ci_conclusion="SUCCESS",
+        ),
+        pr="p",
+    )
+    assert out.action == "pause_mission"
+    assert "missing_reviews" in out.reason
+
+
+def test_decide_on_review_pass_blocked_other_pauses():
+    out = decide(
+        "on-review-pass",
+        verdict_passed=True,
+        pr_state=_state(
+            mergeStateStatus="BLOCKED",
+            review_decision="APPROVED",
+            ci_conclusion=None,
+        ),
+        pr="p",
+    )
+    assert out.action == "pause_mission"
+
+
+def test_decide_on_review_pass_and_ci_green_clean_merges():
+    out = decide(
+        "on-review-pass-and-ci-green",
+        verdict_passed=True,
+        pr_state=_state(mergeStateStatus="CLEAN"),
+        pr="p",
+    )
+    assert out.action == "merge"
+
+
+def test_decide_on_review_pass_and_ci_green_unstable_waits():
+    out = decide(
+        "on-review-pass-and-ci-green",
+        verdict_passed=True,
+        pr_state=_state(mergeStateStatus="UNSTABLE"),
+        pr="p",
+    )
+    assert out.action == "wait_ci"
+
+
+def test_decide_on_review_pass_and_ci_green_pending_waits():
+    out = decide(
+        "on-review-pass-and-ci-green",
+        verdict_passed=True,
+        pr_state=_state(mergeStateStatus="PENDING", ci_conclusion="PENDING"),
+        pr="p",
+    )
+    assert out.action == "wait_ci"
+
+
+def test_decide_on_review_pass_and_ci_green_dirty_rebase():
+    out = decide(
+        "on-review-pass-and-ci-green",
+        verdict_passed=True,
+        pr_state=_state(mergeStateStatus="DIRTY"),
+        pr="p",
+    )
+    assert out.action == "rebase"
+
+
+def test_decide_on_review_pass_and_ci_green_blocked_ci_kicks_back():
+    out = decide(
+        "on-review-pass-and-ci-green",
+        verdict_passed=True,
+        pr_state=_state(
+            mergeStateStatus="BLOCKED",
+            ci_conclusion="FAILURE",
+        ),
+        pr="p",
+    )
+    assert out.action == "kickback_ci"
+
+
+def test_decide_on_review_pass_and_ci_green_blocked_missing_reviews_pauses():
+    out = decide(
+        "on-review-pass-and-ci-green",
+        verdict_passed=True,
+        pr_state=_state(
+            mergeStateStatus="BLOCKED",
+            review_decision="REVIEW_REQUIRED",
+        ),
+        pr="p",
+    )
+    assert out.action == "pause_mission"
+
+
+def test_decide_has_hooks_is_skip():
+    out = decide(
+        "on-review-pass",
+        verdict_passed=True,
+        pr_state=_state(mergeStateStatus="HAS_HOOKS"),
+        pr="p",
+    )
+    assert out.action == "skip"
+
+
+def test_decide_unknown_status_is_skip():
+    out = decide(
+        "on-review-pass-and-ci-green",
+        verdict_passed=True,
+        pr_state=_state(mergeStateStatus="WHATEVER"),
+        pr="p",
+    )
+    assert out.action == "skip"
+
+
+# ---------------------------------------------------------------------------
+# parse_pr_state()
+# ---------------------------------------------------------------------------
+
+
+def test_parse_pr_state_happy():
+    payload = """
+    {
+      "mergeStateStatus": "CLEAN",
+      "mergeable": "MERGEABLE",
+      "reviewDecision": "APPROVED",
+      "statusCheckRollup": [
+        {"conclusion": "SUCCESS", "status": "COMPLETED"}
+      ]
+    }
+    """
+    state = parse_pr_state(payload)
+    assert state is not None
+    assert state.mergeStateStatus == "CLEAN"
+    assert state.mergeable == "MERGEABLE"
+    assert state.review_decision == "APPROVED"
+    assert state.ci_conclusion == "SUCCESS"
+
+
+def test_parse_pr_state_failure_dominates():
+    payload = """
+    {
+      "mergeStateStatus": "BLOCKED",
+      "mergeable": "MERGEABLE",
+      "reviewDecision": "APPROVED",
+      "statusCheckRollup": [
+        {"conclusion": "SUCCESS", "status": "COMPLETED"},
+        {"conclusion": "FAILURE", "status": "COMPLETED"}
+      ]
+    }
+    """
+    state = parse_pr_state(payload)
+    assert state is not None
+    assert state.ci_conclusion == "FAILURE"
+
+
+def test_parse_pr_state_pending_without_failure():
+    payload = """
+    {
+      "mergeStateStatus": "UNSTABLE",
+      "mergeable": "MERGEABLE",
+      "reviewDecision": "APPROVED",
+      "statusCheckRollup": [
+        {"conclusion": "SUCCESS", "status": "COMPLETED"},
+        {"conclusion": "", "status": "IN_PROGRESS"}
+      ]
+    }
+    """
+    state = parse_pr_state(payload)
+    assert state is not None
+    assert state.ci_conclusion == "PENDING"
+
+
+def test_parse_pr_state_malformed_returns_none():
+    assert parse_pr_state("") is None
+    assert parse_pr_state("   ") is None
+    assert parse_pr_state("not json") is None
+    assert parse_pr_state("[1, 2, 3]") is None  # top-level array
+
+
+def test_parse_pr_state_missing_fields_coerced_to_empty():
+    state = parse_pr_state("{}")
+    assert state is not None
+    assert state.mergeStateStatus == ""
+    assert state.mergeable == ""
+    assert state.review_decision == ""
+    assert state.ci_conclusion is None

--- a/tests/test_mission_cli.py
+++ b/tests/test_mission_cli.py
@@ -31,9 +31,12 @@ def test_mission_create_reads_spec_file_and_posts(tmp_path: Path):
         result = runner.invoke(
             main,
             [
-                "mission", "create",
-                "--spec", str(spec_file),
-                "--colony-url", "http://localhost:7433",
+                "mission",
+                "create",
+                "--spec",
+                str(spec_file),
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 
@@ -60,10 +63,13 @@ def test_mission_create_no_plan_review_flag_sets_config(tmp_path: Path):
         result = runner.invoke(
             main,
             [
-                "mission", "create",
-                "--spec", str(spec_file),
+                "mission",
+                "create",
+                "--spec",
+                str(spec_file),
                 "--no-plan-review",
-                "--colony-url", "http://localhost:7433",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 
@@ -88,10 +94,14 @@ def test_mission_create_max_builders_overrides_config(tmp_path: Path):
         result = runner.invoke(
             main,
             [
-                "mission", "create",
-                "--spec", str(spec_file),
-                "--max-builders", "8",
-                "--colony-url", "http://localhost:7433",
+                "mission",
+                "create",
+                "--spec",
+                str(spec_file),
+                "--max-builders",
+                "8",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 
@@ -195,8 +205,11 @@ def test_mission_report_terminal_format():
         result = runner.invoke(
             main,
             [
-                "mission", "report", "mission-auth-123",
-                "--colony-url", "http://localhost:7433",
+                "mission",
+                "report",
+                "mission-auth-123",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 
@@ -219,9 +232,13 @@ def test_mission_report_markdown_format():
         result = runner.invoke(
             main,
             [
-                "mission", "report", "mission-auth-123",
-                "--format", "md",
-                "--colony-url", "http://localhost:7433",
+                "mission",
+                "report",
+                "mission-auth-123",
+                "--format",
+                "md",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 
@@ -244,9 +261,13 @@ def test_mission_report_json_format():
         result = runner.invoke(
             main,
             [
-                "mission", "report", "mission-auth-123",
-                "--format", "json",
-                "--colony-url", "http://localhost:7433",
+                "mission",
+                "report",
+                "mission-auth-123",
+                "--format",
+                "json",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 
@@ -304,9 +325,12 @@ def test_mission_list_filters_by_status():
         result = runner.invoke(
             main,
             [
-                "mission", "list",
-                "--status", "building",
-                "--colony-url", "http://localhost:7433",
+                "mission",
+                "list",
+                "--status",
+                "building",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 
@@ -337,6 +361,154 @@ def test_mission_list_empty():
 
 
 # ---------------------------------------------------------------------------
+# mission create --auto-merge (#353)
+# ---------------------------------------------------------------------------
+
+
+def test_mission_create_auto_merge_flag_sets_config(tmp_path: Path):
+    """--auto-merge sets auto_merge in config."""
+    spec_file = tmp_path / "spec.md"
+    spec_file.write_text("spec")
+
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"mission_id": "m1"}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission",
+                "create",
+                "--spec",
+                str(spec_file),
+                "--auto-merge",
+                "on-review-pass-and-ci-green",
+                "--allow-auto-merge-on-external",
+                "--colony-url",
+                "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+        assert payload["config"]["auto_merge"] == "on-review-pass-and-ci-green"
+        assert payload["config"]["allow_auto_merge_on_external"] is True
+
+
+def test_mission_create_rejects_invalid_auto_merge(tmp_path: Path):
+    """Click choice validation rejects unknown auto-merge modes."""
+    spec_file = tmp_path / "spec.md"
+    spec_file.write_text("spec")
+
+    runner = CliRunner()
+
+    result = runner.invoke(
+        main,
+        [
+            "mission",
+            "create",
+            "--spec",
+            str(spec_file),
+            "--auto-merge",
+            "bogus-mode",
+            "--colony-url",
+            "http://localhost:7433",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "bogus-mode" in result.output or "Invalid value" in result.output
+
+
+def test_mission_update_patches_config_preserving_other_fields():
+    """mission update --auto-merge GETs, merges, then PATCHes config."""
+    runner = CliRunner()
+
+    current_mission = {
+        "mission_id": "m1",
+        "status": "building",
+        "config": {
+            "completion_mode": "best_effort",
+            "max_parallel_builders": 4,
+            "auto_merge": "never",
+        },
+        "task_ids": [],
+        "created_at": "2026-04-20T00:00:00Z",
+    }
+
+    with (
+        patch("antfarm.core.cli.httpx.get") as mock_get,
+        patch("antfarm.core.cli.httpx.patch") as mock_patch,
+    ):
+        mock_get_resp = MagicMock()
+        mock_get_resp.status_code = 200
+        mock_get_resp.json.return_value = current_mission
+        mock_get.return_value = mock_get_resp
+
+        mock_patch_resp = MagicMock()
+        mock_patch_resp.status_code = 200
+        mock_patch_resp.json.return_value = {"ok": True}
+        mock_patch.return_value = mock_patch_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission",
+                "update",
+                "m1",
+                "--auto-merge",
+                "on-review-pass",
+                "--colony-url",
+                "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = mock_patch.call_args.kwargs.get("json") or mock_patch.call_args[1]["json"]
+        merged_config = payload["updates"]["config"]
+        # Existing fields preserved
+        assert merged_config["completion_mode"] == "best_effort"
+        assert merged_config["max_parallel_builders"] == 4
+        # New value applied
+        assert merged_config["auto_merge"] == "on-review-pass"
+
+
+def test_mission_status_prints_auto_merge_line():
+    """mission status output includes Auto-merge: line."""
+    runner = CliRunner()
+
+    mission_data = {
+        "mission_id": "m1",
+        "status": "building",
+        "config": {
+            "completion_mode": "best_effort",
+            "auto_merge": "on-review-pass",
+        },
+        "task_ids": [],
+        "created_at": "2026-04-20T00:00:00Z",
+    }
+
+    with patch("antfarm.core.cli.httpx.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mission_data
+        mock_get.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            ["mission", "status", "m1", "--colony-url", "http://localhost:7433"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Auto-merge:" in result.output
+        assert "on-review-pass" in result.output
+
+
+# ---------------------------------------------------------------------------
 # carry --mission
 # ---------------------------------------------------------------------------
 
@@ -355,10 +527,14 @@ def test_carry_with_mission_option():
             main,
             [
                 "carry",
-                "--title", "Auth endpoint",
-                "--spec", "Build the auth endpoint",
-                "--mission", "mission-auth-123",
-                "--colony-url", "http://localhost:7433",
+                "--title",
+                "Auth endpoint",
+                "--spec",
+                "Build the auth endpoint",
+                "--mission",
+                "mission-auth-123",
+                "--colony-url",
+                "http://localhost:7433",
             ],
         )
 

--- a/tests/test_missions_model.py
+++ b/tests/test_missions_model.py
@@ -219,3 +219,58 @@ def test_is_infra_task_review_prefix():
 def test_is_infra_task_builder():
     assert is_infra_task({"id": "task-001", "capabilities_required": ["build"]}) is False
     assert is_infra_task({"id": "task-001"}) is False
+
+
+# ---------------------------------------------------------------------------
+# Auto-merge config (#353)
+# ---------------------------------------------------------------------------
+
+
+def test_mission_config_default_auto_merge_never():
+    config = MissionConfig()
+    assert config.auto_merge == "never"
+    assert config.allow_auto_merge_on_external is False
+
+
+def test_mission_config_accepts_valid_auto_merge_modes():
+    for mode in ("never", "on-review-pass", "on-review-pass-and-ci-green"):
+        config = MissionConfig(auto_merge=mode)
+        assert config.auto_merge == mode
+
+
+def test_mission_config_rejects_invalid_auto_merge():
+    with pytest.raises(ValueError, match="auto_merge must be one of"):
+        MissionConfig(auto_merge="on-friday")
+
+
+def test_mission_config_roundtrip_includes_auto_merge_fields():
+    config = MissionConfig(
+        auto_merge="on-review-pass-and-ci-green",
+        allow_auto_merge_on_external=True,
+    )
+    d = config.to_dict()
+    assert d["auto_merge"] == "on-review-pass-and-ci-green"
+    assert d["allow_auto_merge_on_external"] is True
+    restored = MissionConfig.from_dict(d)
+    assert restored.auto_merge == "on-review-pass-and-ci-green"
+    assert restored.allow_auto_merge_on_external is True
+    assert restored == config
+
+
+def test_mission_report_roundtrip_includes_auto_merge_counts():
+    report = _make_mission_report()
+    report.auto_merged_tasks = 2
+    report.manual_merged_tasks = 1
+    d = report.to_dict()
+    assert d["auto_merged_tasks"] == 2
+    assert d["manual_merged_tasks"] == 1
+    restored = MissionReport.from_dict(d)
+    assert restored.auto_merged_tasks == 2
+    assert restored.manual_merged_tasks == 1
+    assert restored == report
+
+
+def test_mission_report_defaults_auto_merge_counts_zero():
+    report = _make_mission_report()
+    assert report.auto_merged_tasks == 0
+    assert report.manual_merged_tasks == 0

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -137,15 +137,17 @@ def test_build_report_all_merged():
         _make_task(
             "task-002",
             title="Widget B",
-            attempts=[_make_attempt(
-                attempt_id="att-002",
-                artifact=_make_artifact(
-                    pr_url="https://github.com/org/repo/pull/2",
-                    lines_added=30,
-                    lines_removed=5,
-                    files_changed=["src/other.py"],
-                ),
-            )],
+            attempts=[
+                _make_attempt(
+                    attempt_id="att-002",
+                    artifact=_make_artifact(
+                        pr_url="https://github.com/org/repo/pull/2",
+                        lines_added=30,
+                        lines_removed=5,
+                        files_changed=["src/other.py"],
+                    ),
+                )
+            ],
         ),
     ]
     mission = _make_mission(task_ids=["task-001", "task-002"])
@@ -219,10 +221,12 @@ def test_build_report_aggregates_lines_added_removed():
         ),
         _make_task(
             "task-002",
-            attempts=[_make_attempt(
-                attempt_id="att-002",
-                artifact=_make_artifact(lines_added=200, lines_removed=50),
-            )],
+            attempts=[
+                _make_attempt(
+                    attempt_id="att-002",
+                    artifact=_make_artifact(lines_added=200, lines_removed=50),
+                )
+            ],
         ),
     ]
     mission = _make_mission(task_ids=["task-001", "task-002"])
@@ -240,16 +244,22 @@ def test_build_report_collects_pr_urls_from_artifacts():
     tasks = [
         _make_task(
             "task-001",
-            attempts=[_make_attempt(artifact=_make_artifact(
-                pr_url="https://github.com/org/repo/pull/1",
-            ))],
+            attempts=[
+                _make_attempt(
+                    artifact=_make_artifact(
+                        pr_url="https://github.com/org/repo/pull/1",
+                    )
+                )
+            ],
         ),
         _make_task(
             "task-002",
-            attempts=[_make_attempt(
-                attempt_id="att-002",
-                artifact=_make_artifact(pr_url="https://github.com/org/repo/pull/2"),
-            )],
+            attempts=[
+                _make_attempt(
+                    attempt_id="att-002",
+                    artifact=_make_artifact(pr_url="https://github.com/org/repo/pull/2"),
+                )
+            ],
         ),
     ]
     mission = _make_mission(task_ids=["task-001", "task-002"])
@@ -375,8 +385,7 @@ def test_render_terminal_no_rich_import():
         [
             sys.executable,
             "-c",
-            "import antfarm.core.report; import sys; "
-            "sys.exit(1 if 'rich' in sys.modules else 0)",
+            "import antfarm.core.report; import sys; sys.exit(1 if 'rich' in sys.modules else 0)",
         ],
         capture_output=True,
         text=True,
@@ -478,10 +487,12 @@ def test_cancelled_mission_report_includes_completed_tasks():
         _make_task(
             f"task-{i:03d}",
             title=f"Task {i}",
-            attempts=[_make_attempt(
-                attempt_id=f"att-{i:03d}",
-                artifact=_make_artifact(pr_url=f"https://github.com/pr/{i}"),
-            )],
+            attempts=[
+                _make_attempt(
+                    attempt_id=f"att-{i:03d}",
+                    artifact=_make_artifact(pr_url=f"https://github.com/pr/{i}"),
+                )
+            ],
         )
         for i in range(1, 4)  # 3 merged
     ] + [
@@ -563,3 +574,62 @@ def test_report_distinguishes_system_vs_review_prefix():
     reasons = [b.reason for b in report.blocked]
     assert any(r.startswith("system: ") for r in reasons)
     assert any(r.startswith("review: ") for r in reasons)
+
+
+# ---------------------------------------------------------------------------
+# Auto-merged vs manual-merged counts (#353)
+# ---------------------------------------------------------------------------
+
+
+def test_build_report_counts_auto_and_manual_merges_separately():
+    tasks = [
+        _make_task(
+            "task-001",
+            title="Auto-merged work",
+            attempts=[
+                {
+                    "attempt_id": "att-001",
+                    "worker_id": "w1",
+                    "status": "merged",
+                    "branch": "feat/task-001",
+                    "pr": None,
+                    "started_at": "2026-04-01T00:00:00Z",
+                    "completed_at": "2026-04-01T00:30:00Z",
+                    "artifact": _make_artifact(lines_added=20, lines_removed=5),
+                    "auto_merged": True,
+                }
+            ],
+        ),
+        _make_task(
+            "task-002",
+            title="Manual-merged work",
+            attempts=[
+                _make_attempt(
+                    attempt_id="att-002",
+                    artifact=_make_artifact(
+                        pr_url="https://github.com/org/repo/pull/2",
+                        lines_added=10,
+                        lines_removed=3,
+                    ),
+                )
+            ],
+        ),
+    ]
+    mission = _make_mission(task_ids=["task-001", "task-002"])
+    report = build_report(mission, tasks)
+    assert report.merged_tasks == 2
+    assert report.auto_merged_tasks == 1
+    assert report.manual_merged_tasks == 1
+
+
+def test_build_report_all_manual_when_no_auto_merged_flag():
+    tasks = [
+        _make_task(
+            "task-001",
+            attempts=[_make_attempt(artifact=_make_artifact())],
+        ),
+    ]
+    mission = _make_mission(task_ids=["task-001"])
+    report = build_report(mission, tasks)
+    assert report.auto_merged_tasks == 0
+    assert report.manual_merged_tasks == 1

--- a/tests/test_soldier_auto_merge.py
+++ b/tests/test_soldier_auto_merge.py
@@ -1,0 +1,537 @@
+"""Tests for Soldier auto-merge integration (#353).
+
+All subprocess calls (``git``, ``gh``) are mocked via monkeypatched
+``subprocess.run``. The colony is a plain MagicMock — we exercise the
+Soldier's decision/dispatch wiring, not the colony API.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from antfarm.core.auto_merge import PRState
+from antfarm.core.soldier import MergeResult, Soldier
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_soldier(integration_branch: str = "main", monkeypatch=None) -> Soldier:
+    """Construct a Soldier with a bypassed __init__ so we can drop in mocks.
+
+    Avoids any real HTTP, git, or backend calls during construction.
+    """
+    s = Soldier.__new__(Soldier)
+    s.colony = MagicMock()
+    s.colony_url = ""
+    s.repo_path = "/fake/repo"
+    s.integration_branch = integration_branch
+    s.test_command = ["true"]
+    s.poll_interval = 0.0
+    s.require_review = True
+    s.poll_external_merges = False
+    s.data_dir_name = ".antfarm"
+    s.last_failure_reason = ""
+    s._event_cursor = 0
+    s._preflight_done = True
+    s._auto_merge_last_checked = {}
+    s._repo_permission_cache = {}
+    s.auto_merge_poll_backoff_seconds = 30.0
+    return s
+
+
+def _task(
+    task_id: str = "task-1",
+    mission_id: str | None = "mission-a",
+    pr: str | None = "https://github.com/org/repo/pull/1",
+    branch: str | None = "feat/task-1",
+) -> dict:
+    return {
+        "id": task_id,
+        "mission_id": mission_id,
+        "current_attempt": "att-1",
+        "attempts": [
+            {
+                "attempt_id": "att-1",
+                "worker_id": "w1",
+                "status": "done",
+                "branch": branch,
+                "pr": pr,
+            }
+        ],
+    }
+
+
+def _mission(auto_merge: str = "on-review-pass", allow_external: bool = False) -> dict:
+    return {
+        "mission_id": "mission-a",
+        "status": "building",
+        "config": {
+            "auto_merge": auto_merge,
+            "allow_auto_merge_on_external": allow_external,
+            "completion_mode": "best_effort",
+        },
+        "task_ids": ["task-1"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. never-mode regression: _attempt_auto_merge returns None, no gh calls
+# ---------------------------------------------------------------------------
+
+
+def test_never_mode_returns_none_and_makes_no_gh_call(monkeypatch):
+    s = _make_soldier()
+    s.colony.get_mission.return_value = _mission(auto_merge="never")
+
+    calls = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    outcome = s._attempt_auto_merge(_task())
+    assert outcome is None
+    # No subprocess was invoked — permission check / gh calls suppressed.
+    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# 2. on-review-pass CLEAN => merge dispatches gh pr merge + mark_merged(auto)
+# ---------------------------------------------------------------------------
+
+
+def test_on_review_pass_clean_triggers_gh_merge(monkeypatch):
+    s = _make_soldier()
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass")
+
+    # Pretend PR state is CLEAN. We mock the whole query helper.
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: PRState("CLEAN", "MERGEABLE", "APPROVED", "SUCCESS"),
+    )
+    # Auto-merge security gate: simulate ADMIN on main.
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+    merge_calls: list[str] = []
+
+    def fake_merge(pr: str):
+        merge_calls.append(pr)
+        return True, ""
+
+    monkeypatch.setattr(s, "_gh_pr_merge_squash", fake_merge)
+    monkeypatch.setattr(s, "_sync_integration_branch_after_auto_merge", lambda: None)
+
+    task = _task()
+    outcome = s._attempt_auto_merge(task)
+    assert outcome is not None
+    assert outcome.action == "merge"
+
+    result = s._handle_auto_merge_outcome(outcome, task)
+    assert result == MergeResult.MERGED
+    assert merge_calls == ["https://github.com/org/repo/pull/1"]
+    # mark_merged should receive auto_merged=True
+    s.colony.mark_merged.assert_called_once_with("task-1", "att-1", auto_merged=True)
+
+
+# ---------------------------------------------------------------------------
+# 3. on-review-pass UNSTABLE => merge (CI-agnostic)
+# ---------------------------------------------------------------------------
+
+
+def test_on_review_pass_unstable_merges_ci_agnostic(monkeypatch):
+    s = _make_soldier()
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass")
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: PRState("UNSTABLE", "MERGEABLE", "APPROVED", "FAILURE"),
+    )
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+    monkeypatch.setattr(s, "_gh_pr_merge_squash", lambda pr: (True, ""))
+    monkeypatch.setattr(s, "_sync_integration_branch_after_auto_merge", lambda: None)
+
+    outcome = s._attempt_auto_merge(_task())
+    assert outcome.action == "merge"
+
+
+# ---------------------------------------------------------------------------
+# 4. on-review-pass-and-ci-green UNSTABLE => wait_ci, no merge, no kickback
+# ---------------------------------------------------------------------------
+
+
+def test_ci_green_mode_unstable_waits(monkeypatch):
+    s = _make_soldier()
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass-and-ci-green")
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: PRState("UNSTABLE", "MERGEABLE", "APPROVED", "PENDING"),
+    )
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+
+    task = _task()
+    outcome = s._attempt_auto_merge(task)
+    assert outcome.action == "wait_ci"
+    result = s._handle_auto_merge_outcome(outcome, task)
+    assert result == MergeResult.NEEDS_REVIEW
+    s.colony.mark_merged.assert_not_called()
+    s.colony.kickback.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 5. BLOCKED with CI failing => kickback_ci => kickback_with_cascade called
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_ci_failing_kicks_back(monkeypatch):
+    s = _make_soldier()
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass")
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: PRState("BLOCKED", "MERGEABLE", "APPROVED", "FAILURE"),
+    )
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+    kickback_calls = []
+
+    def fake_kickback(task_id, reason, **kw):
+        kickback_calls.append((task_id, reason))
+
+    monkeypatch.setattr(s, "kickback_with_cascade", fake_kickback)
+
+    task = _task()
+    outcome = s._attempt_auto_merge(task)
+    assert outcome.action == "kickback_ci"
+    result = s._handle_auto_merge_outcome(outcome, task)
+    assert result == MergeResult.FAILED
+    assert kickback_calls and kickback_calls[0][0] == "task-1"
+    assert "auto_merge_ci_failed" in kickback_calls[0][1]
+
+
+# ---------------------------------------------------------------------------
+# 6. BLOCKED missing_reviews => pause_mission (BLOCKED status)
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_missing_reviews_pauses_mission(monkeypatch):
+    s = _make_soldier()
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass")
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: PRState("BLOCKED", "MERGEABLE", "REVIEW_REQUIRED", "SUCCESS"),
+    )
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+
+    task = _task()
+    outcome = s._attempt_auto_merge(task)
+    assert outcome.action == "pause_mission"
+    result = s._handle_auto_merge_outcome(outcome, task)
+    assert result == MergeResult.NEEDS_REVIEW
+    # update_mission should be called with status=blocked + reason
+    assert s.colony.update_mission.called
+    call_args = s.colony.update_mission.call_args
+    assert call_args.args[0] == "mission-a"
+    updates = call_args.args[1]
+    assert updates["status"] == "blocked"
+    assert "auto_merge_pause_reason" in updates
+
+
+# ---------------------------------------------------------------------------
+# 7. DIRTY => rebase dispatch (rebase helper invoked once)
+# ---------------------------------------------------------------------------
+
+
+def test_dirty_triggers_rebase(monkeypatch):
+    s = _make_soldier()
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass")
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: PRState("DIRTY", "CONFLICTING", "APPROVED", "SUCCESS"),
+    )
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+    rebase_called = []
+    monkeypatch.setattr(
+        s,
+        "_rebase_pr_branch_for_auto_merge",
+        lambda task, pr: rebase_called.append((task["id"], pr)),
+    )
+
+    task = _task()
+    outcome = s._attempt_auto_merge(task)
+    assert outcome.action == "rebase"
+    result = s._handle_auto_merge_outcome(outcome, task)
+    assert result == MergeResult.NEEDS_REVIEW
+    assert rebase_called == [("task-1", "https://github.com/org/repo/pull/1")]
+
+
+# ---------------------------------------------------------------------------
+# 8. Security guard: non-WRITE permission refuses auto-merge
+# ---------------------------------------------------------------------------
+
+
+def test_security_guard_refuses_low_permission(monkeypatch):
+    s = _make_soldier()
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass")
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "READ")
+    # _query_pr_state should NEVER be called — short-circuited by guard.
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: (_ for _ in ()).throw(AssertionError("should not be called")),
+    )
+
+    outcome = s._attempt_auto_merge(_task())
+    assert outcome.action == "skip"
+    assert "refused" in outcome.reason
+
+
+# ---------------------------------------------------------------------------
+# 9. Security guard EXTRA: WRITE permission on main requires explicit opt-in
+# ---------------------------------------------------------------------------
+
+
+def test_security_guard_write_on_main_requires_opt_in(monkeypatch):
+    s = _make_soldier(integration_branch="main")
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass", allow_external=False)
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "WRITE")
+
+    outcome = s._attempt_auto_merge(_task())
+    assert outcome.action == "skip"
+    assert "refused" in outcome.reason
+
+
+def test_security_guard_write_on_main_allowed_with_opt_in(monkeypatch):
+    s = _make_soldier(integration_branch="main")
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass", allow_external=True)
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "WRITE")
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: PRState("CLEAN", "MERGEABLE", "APPROVED", "SUCCESS"),
+    )
+
+    outcome = s._attempt_auto_merge(_task())
+    assert outcome.action == "merge"
+
+
+# ---------------------------------------------------------------------------
+# 10. Poll backoff: second call within 30s returns skip without gh
+# ---------------------------------------------------------------------------
+
+
+def test_poll_backoff_suppresses_redundant_polls(monkeypatch):
+    s = _make_soldier()
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass")
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+
+    state_calls = []
+
+    def fake_state(pr):
+        state_calls.append(pr)
+        return PRState("UNSTABLE", "MERGEABLE", "APPROVED", "PENDING")
+
+    monkeypatch.setattr(s, "_query_pr_state", fake_state)
+
+    # First call: hits gh.
+    s._attempt_auto_merge(_task())
+    assert len(state_calls) == 1
+    # Second call within the 30s window: returns skip, no gh call.
+    out2 = s._attempt_auto_merge(_task())
+    assert len(state_calls) == 1
+    assert out2.action == "skip"
+    assert "backoff" in out2.reason
+
+
+# ---------------------------------------------------------------------------
+# 11. Emits `auto_merged` event on successful merge
+# ---------------------------------------------------------------------------
+
+
+def test_emits_auto_merged_event_on_success(monkeypatch):
+    s = _make_soldier()
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass")
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: PRState("CLEAN", "MERGEABLE", "APPROVED", "SUCCESS"),
+    )
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+    monkeypatch.setattr(s, "_gh_pr_merge_squash", lambda pr: (True, ""))
+    monkeypatch.setattr(s, "_sync_integration_branch_after_auto_merge", lambda: None)
+
+    emitted = []
+
+    def fake_emit(event_type, task_id, detail="", actor="soldier"):
+        emitted.append((event_type, task_id, detail))
+
+    # Patch the _emit_event dispatcher used by the soldier._emit shim.
+    with patch("antfarm.core.serve._emit_event", side_effect=fake_emit):
+        task = _task()
+        outcome = s._attempt_auto_merge(task)
+        result = s._handle_auto_merge_outcome(outcome, task)
+        assert result == MergeResult.MERGED
+
+    event_types = [e[0] for e in emitted]
+    assert "auto_merged" in event_types
+
+
+# ---------------------------------------------------------------------------
+# 12. Emits `auto_merge_refused` when security guard blocks
+# ---------------------------------------------------------------------------
+
+
+def test_emits_auto_merge_refused_event(monkeypatch):
+    s = _make_soldier()
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass")
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "READ")
+
+    emitted = []
+
+    def fake_emit(event_type, task_id, detail="", actor="soldier"):
+        emitted.append((event_type, task_id, detail))
+
+    with patch("antfarm.core.serve._emit_event", side_effect=fake_emit):
+        s._attempt_auto_merge(_task())
+
+    event_types = [e[0] for e in emitted]
+    assert "auto_merge_refused" in event_types
+
+
+# ---------------------------------------------------------------------------
+# 13. gh pr merge failure => FAILED, no mark_merged
+# ---------------------------------------------------------------------------
+
+
+def test_gh_pr_merge_failure_returns_failed(monkeypatch):
+    s = _make_soldier()
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass")
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: PRState("CLEAN", "MERGEABLE", "APPROVED", "SUCCESS"),
+    )
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+    monkeypatch.setattr(s, "_gh_pr_merge_squash", lambda pr: (False, "remote rejected"))
+
+    task = _task()
+    outcome = s._attempt_auto_merge(task)
+    assert outcome.action == "merge"
+    result = s._handle_auto_merge_outcome(outcome, task)
+    assert result == MergeResult.FAILED
+    s.colony.mark_merged.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 14. Race condition: gh pr view returns None (network error) => skip
+# ---------------------------------------------------------------------------
+
+
+def test_pr_state_none_returns_skip(monkeypatch):
+    s = _make_soldier()
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass")
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+    monkeypatch.setattr(s, "_query_pr_state", lambda pr: None)
+
+    outcome = s._attempt_auto_merge(_task())
+    assert outcome.action == "skip"
+
+
+# ---------------------------------------------------------------------------
+# 15. No PR on attempt => skip outcome (no merge attempted)
+# ---------------------------------------------------------------------------
+
+
+def test_no_pr_on_attempt_returns_skip(monkeypatch):
+    s = _make_soldier()
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass")
+    task = _task(pr=None)
+    task["attempts"][0]["pr"] = None
+    # Even so, _get_attempt_pr looks at pr field; empty → "".
+    outcome = s._attempt_auto_merge(task)
+    assert outcome is not None
+    assert outcome.action == "skip"
+
+
+# ---------------------------------------------------------------------------
+# 16. Dependent task rebase: when outcome.action=='rebase', rebase helper fires
+# ---------------------------------------------------------------------------
+
+
+def test_rebase_helper_invokes_existing_rebase_infrastructure(monkeypatch):
+    s = _make_soldier()
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass")
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: PRState("BEHIND", "MERGEABLE", "APPROVED", "SUCCESS"),
+    )
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+
+    rebased = []
+
+    def fake_rebase(task_id, branch, temp_branch, initial_conflict_stderr):
+        rebased.append((task_id, branch, temp_branch))
+        return MergeResult.NEEDS_REVIEW
+
+    monkeypatch.setattr(s, "_rebase_and_retry_merge", fake_rebase)
+
+    task = _task()
+    outcome = s._attempt_auto_merge(task)
+    assert outcome.action == "rebase"
+    result = s._handle_auto_merge_outcome(outcome, task)
+    assert result == MergeResult.NEEDS_REVIEW
+    assert rebased, "expected _rebase_and_retry_merge to be invoked"
+
+
+# ---------------------------------------------------------------------------
+# 17. Task with no mission_id resolves to never-mode (skips auto-merge)
+# ---------------------------------------------------------------------------
+
+
+def test_task_without_mission_id_returns_none():
+    s = _make_soldier()
+    task = _task(mission_id=None)
+    task.pop("mission_id", None)
+    outcome = s._attempt_auto_merge(task)
+    assert outcome is None
+
+
+# ---------------------------------------------------------------------------
+# 18. Mission without auto_merge key defaults to never
+# ---------------------------------------------------------------------------
+
+
+def test_mission_without_auto_merge_key_is_never():
+    s = _make_soldier()
+    s.colony.get_mission.return_value = {"mission_id": "m", "status": "building", "config": {}}
+    outcome = s._attempt_auto_merge(_task())
+    assert outcome is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-x", "-q"])


### PR DESCRIPTION
## Summary
- Adds opt-in auto-merge pipeline gated by `MissionConfig.auto_merge` (`never` / `on-review-pass` / `on-review-pass-and-ci-green`).
- New pure module `antfarm/core/auto_merge.py` implements the #353 truth table (CLEAN/UNSTABLE/PENDING/DIRTY/BEHIND/BLOCKED) with zero I/O so the decision is fully unit-testable.
- Soldier owns side effects: `gh pr view`, `gh pr merge --squash --delete-branch`, rebase dispatch, wait-ci, kickback with `reason=auto_merge_ci_failed`, and mission-pause on blocked reviews. Hardcoded security guards refuse auto-merge without WRITE+ permission and require ADMIN on `main`/`master` unless `allow_auto_merge_on_external=True`.
- Provenance plumbing: `mark_merged(... auto_merged=True)` threads through backends, HTTP endpoint, and `report.py` so `MissionReport` now exposes `auto_merged_tasks` / `manual_merged_tasks`. CLI `mission create/update` gain `--auto-merge` and `--allow-auto-merge-on-external`; `mission status` prints the mode.

## Test plan
- [x] `pytest tests/ -x -q` — 1299 passing (42 new).
- [x] `ruff check antfarm/ tests/` — clean.
- [x] `ruff format --check` on all touched files — clean.
- [x] `tests/test_auto_merge.py` covers every row of the #353 truth table + `parse_pr_state` happy/malformed.
- [x] `tests/test_soldier_auto_merge.py` covers never-mode regression, each mode/state combo, security guards (low perm, WRITE on main, opt-in escape hatch), poll backoff, `auto_merged` flag propagation, SSE event emission, `gh pr merge` failure paths, and rebase dispatch wiring.

Per the plan I did NOT touch `CHANGELOG.md` — it will be bundled separately.

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)