### PR TITLE
feat(mission,queen): cost/token tripwire with pause/cancel actions (Closes #354)

### DIFF
--- a/antfarm/adapters/claude_code/hooks/stop.sh
+++ b/antfarm/adapters/claude_code/hooks/stop.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Stop hook: report the final assistant message's usage block to the colony.
+#
+# Claude Code invokes Stop hooks when the conversation ends. The transcript
+# path is passed in $CLAUDE_TRANSCRIPT_PATH; the last assistant message
+# carries a `usage` object with input_tokens / output_tokens / cache_*_tokens.
+#
+# This is best-effort — every failure path falls through to `|| true`, so a
+# broken jq install or a missing transcript never blocks Claude. We POST to
+# /workers/<id>/usage; the colony computes cost and aggregates per mission.
+
+set -u
+
+: "${ANTFARM_URL:=}"
+: "${WORKER_ID:=}"
+: "${CLAUDE_TRANSCRIPT_PATH:=}"
+
+# If any required input is missing, do nothing. Do not error — Claude stops
+# anyway and the hook must stay out of the way.
+if [ -z "${ANTFARM_URL}" ] || [ -z "${WORKER_ID}" ] || [ -z "${CLAUDE_TRANSCRIPT_PATH}" ]; then
+  exit 0
+fi
+
+if [ ! -f "${CLAUDE_TRANSCRIPT_PATH}" ]; then
+  exit 0
+fi
+
+# Require jq for JSON extraction. If jq isn't installed, skip silently —
+# antfarm will warn about it elsewhere.
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Transcript is JSONL. Walk backward to find the last message with a usage
+# block. We accept either `message.usage` (nested under `message`) or a
+# top-level `usage` — the Claude Code format has evolved.
+USAGE_JSON="$(tac "${CLAUDE_TRANSCRIPT_PATH}" 2>/dev/null \
+  | jq -c 'select(.message?.usage? != null) | .message.usage' 2>/dev/null \
+  | head -n 1)"
+
+if [ -z "${USAGE_JSON}" ]; then
+  USAGE_JSON="$(tac "${CLAUDE_TRANSCRIPT_PATH}" 2>/dev/null \
+    | jq -c 'select(.usage? != null) | .usage' 2>/dev/null \
+    | head -n 1)"
+fi
+
+if [ -z "${USAGE_JSON}" ]; then
+  exit 0
+fi
+
+# Walk again for the model name. Either message.model or top-level model.
+MODEL="$(tac "${CLAUDE_TRANSCRIPT_PATH}" 2>/dev/null \
+  | jq -r 'select(.message?.model? != null) | .message.model' 2>/dev/null \
+  | head -n 1)"
+if [ -z "${MODEL}" ] || [ "${MODEL}" = "null" ]; then
+  MODEL="$(tac "${CLAUDE_TRANSCRIPT_PATH}" 2>/dev/null \
+    | jq -r 'select(.model? != null) | .model' 2>/dev/null \
+    | head -n 1)"
+fi
+if [ -z "${MODEL}" ] || [ "${MODEL}" = "null" ]; then
+  MODEL="unknown"
+fi
+
+INPUT_TOK=$(echo "${USAGE_JSON}" | jq -r '.input_tokens // 0')
+OUTPUT_TOK=$(echo "${USAGE_JSON}" | jq -r '.output_tokens // 0')
+CACHE_READ=$(echo "${USAGE_JSON}" | jq -r '.cache_read_input_tokens // 0')
+CACHE_CREATE=$(echo "${USAGE_JSON}" | jq -r '.cache_creation_input_tokens // 0')
+
+# Generate a stable event_id per (transcript, line-hash) so retries dedupe.
+if command -v shasum >/dev/null 2>&1; then
+  EVENT_ID="stop-$(echo -n "${CLAUDE_TRANSCRIPT_PATH}${USAGE_JSON}" | shasum | awk '{print $1}')"
+elif command -v sha1sum >/dev/null 2>&1; then
+  EVENT_ID="stop-$(echo -n "${CLAUDE_TRANSCRIPT_PATH}${USAGE_JSON}" | sha1sum | awk '{print $1}')"
+else
+  EVENT_ID="stop-$(date +%s%N)-$$"
+fi
+
+TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+PAYLOAD=$(cat <<EOF
+{
+  "event_id": "${EVENT_ID}",
+  "ts": "${TS}",
+  "model": "${MODEL}",
+  "input_tokens": ${INPUT_TOK},
+  "output_tokens": ${OUTPUT_TOK},
+  "cache_read_tokens": ${CACHE_READ},
+  "cache_creation_tokens": ${CACHE_CREATE},
+  "source": "claude_stop_hook"
+}
+EOF
+)
+
+curl -s -m 2 "${ANTFARM_URL}/workers/${WORKER_ID}/usage" \
+  -X POST -H "Content-Type: application/json" -d "${PAYLOAD}" >/dev/null 2>&1 || true

--- a/antfarm/adapters/claude_code/setup.sh
+++ b/antfarm/adapters/claude_code/setup.sh
@@ -45,9 +45,10 @@ done
 HEARTBEAT_CMD="${ADAPTER_DIR}/hooks/heartbeat.sh"
 PRE_TOOL_CMD="${ADAPTER_DIR}/hooks/pre_tool.sh"
 POST_TOOL_CMD="${ADAPTER_DIR}/hooks/post_tool.sh"
+STOP_CMD="${ADAPTER_DIR}/hooks/stop.sh"
 
 if [ ! -f "${SETTINGS_FILE}" ]; then
-  # Create a minimal settings.json with heartbeat + activity hooks
+  # Create a minimal settings.json with heartbeat + activity + stop hooks
   cat > "${SETTINGS_FILE}" <<EOF
 {
   "hooks": {
@@ -76,11 +77,22 @@ if [ ! -f "${SETTINGS_FILE}" ]; then
           }
         ]
       }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${STOP_CMD}"
+          }
+        ]
+      }
     ]
   }
 }
 EOF
-  echo "[created] ${SETTINGS_FILE} with heartbeat + activity hooks"
+  echo "[created] ${SETTINGS_FILE} with heartbeat + activity + stop hooks"
 else
   # Heartbeat already present?
   if grep -q "heartbeat.sh" "${SETTINGS_FILE}" 2>/dev/null; then
@@ -107,6 +119,17 @@ else
     echo "          and an additional PostToolUse entry pointing to ${POST_TOOL_CMD}."
     echo ""
   fi
+
+  # Stop hook already present?
+  if grep -q "stop.sh" "${SETTINGS_FILE}" 2>/dev/null; then
+    echo "[exists]  stop hook already in ${SETTINGS_FILE}"
+  else
+    echo ""
+    echo "[manual]  stop hook NOT added automatically — settings.json already exists."
+    echo "          Add a Stop entry pointing to ${STOP_CMD} so cost/usage"
+    echo "          from the final assistant message is reported to the colony."
+    echo ""
+  fi
 fi
 
 echo ""
@@ -116,6 +139,7 @@ echo "  .claude/agents/soldier.md  — v0.2 placeholder (conflict resolution)"
 echo "  .claude/agents/queen.md    — example: AI-driven task decomposition"
 echo "  PostToolUse heartbeat hook — keeps worker slot alive automatically"
 echo "  PreToolUse/PostToolUse activity hooks — surface current worker action in TUI"
+echo "  Stop hook                   — reports token usage + cost to the colony"
 echo ""
 echo "Set environment variables before starting a worker session:"
 echo "  export ANTFARM_URL=http://localhost:8000"

--- a/antfarm/core/backends/base.py
+++ b/antfarm/core/backends/base.py
@@ -16,6 +16,7 @@ Superseded-PR hygiene:
 """
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 
 
 class TaskBackend(ABC):
@@ -576,6 +577,41 @@ class TaskBackend(ABC):
     @abstractmethod
     def update_mission(self, mission_id: str, updates: dict) -> None:
         """Shallow-merge ``updates`` into the mission JSON. Atomic write."""
+        ...
+
+    @abstractmethod
+    def get_mission_usage(self, mission_id: str) -> dict | None:
+        """Return the MissionUsage sidecar for a mission, or None.
+
+        Args:
+            mission_id: ID of the mission.
+
+        Returns:
+            MissionUsage.to_dict() output, or None if no usage has been
+            recorded (or the mission does not exist).
+        """
+        ...
+
+    @abstractmethod
+    def update_mission_usage(self, mission_id: str, updater: Callable[[dict], dict]) -> dict:
+        """Atomic read-modify-write on the MissionUsage sidecar.
+
+        The implementation calls ``updater(current_dict)`` under the backend
+        lock and persists the returned dict atomically. If no usage file
+        exists yet, the updater is called with a freshly-initialized
+        ``MissionUsage(mission_id=...).to_dict()``.
+
+        Callers are responsible for idempotency (e.g. dedup by event_id).
+
+        Args:
+            mission_id: ID of the mission.
+            updater: Callable that takes the current usage dict and returns
+                the new usage dict. Must be pure (no I/O) — it runs inside
+                the backend lock.
+
+        Returns:
+            The new usage dict after persistence.
+        """
         ...
 
     @abstractmethod

--- a/antfarm/core/backends/file.py
+++ b/antfarm/core/backends/file.py
@@ -1235,6 +1235,47 @@ class FileBackend(TaskBackend):
             data["updated_at"] = _now_iso()
             self._write_json(path, data)
 
+    # --- mission usage sidecar (v0.6.14 cost tripwire) -------------------
+
+    def _mission_usage_path(self, mission_id: str) -> Path:
+        return self._missions_dir() / f"{mission_id}_usage.json"
+
+    def get_mission_usage(self, mission_id: str) -> dict | None:
+        """Return the MissionUsage sidecar dict for a mission, or None."""
+        path = self._mission_usage_path(mission_id)
+        if not path.exists():
+            return None
+        try:
+            return self._read_json(path)
+        except (json.JSONDecodeError, KeyError):
+            return None
+
+    def update_mission_usage(self, mission_id: str, updater) -> dict:
+        """Atomic read-modify-write on the MissionUsage sidecar.
+
+        Takes a callable that transforms the current usage dict to the next
+        one. Called under self._lock so two concurrent POST /workers/.../usage
+        requests cannot clobber each other's aggregates.
+        """
+        from antfarm.core.missions import MissionUsage
+
+        with self._lock:
+            self._missions_dir().mkdir(parents=True, exist_ok=True)
+            path = self._mission_usage_path(mission_id)
+            if path.exists():
+                try:
+                    current = self._read_json(path)
+                except (json.JSONDecodeError, KeyError):
+                    current = MissionUsage(mission_id=mission_id).to_dict()
+            else:
+                current = MissionUsage(mission_id=mission_id).to_dict()
+
+            new_state = updater(current)
+            if not isinstance(new_state, dict):
+                raise TypeError("update_mission_usage updater must return a dict")
+            self._write_json(path, new_state)
+            return new_state
+
     def cancel_mission_tasks(self, mission_id: str, reason: str) -> list[str]:
         """Purge all non-terminal tasks for this mission into done/ and cancel the mission.
 

--- a/antfarm/core/backends/github.py
+++ b/antfarm/core/backends/github.py
@@ -1079,3 +1079,9 @@ class GitHubBackend(TaskBackend):
 
     def cancel_mission_tasks(self, mission_id: str, reason: str) -> list[str]:
         raise NotImplementedError(_GITHUB_BACKEND_MSG)
+
+    def get_mission_usage(self, mission_id: str) -> dict | None:
+        raise NotImplementedError(_GITHUB_BACKEND_MSG)
+
+    def update_mission_usage(self, mission_id: str, updater) -> dict:
+        raise NotImplementedError(_GITHUB_BACKEND_MSG)

--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -745,6 +745,7 @@ def inbox(colony_url: str, token: str | None):
     items = collect_inbox_items(
         tasks=data.get("tasks", []),
         workers=data.get("workers", []),
+        missions=data.get("missions", []),
     )
     if not items:
         click.echo("Inbox empty — everything healthy.")
@@ -1396,6 +1397,25 @@ def mission():
     default=False,
     help="Permit auto-merge even when the viewer is not an ADMIN of the target repo.",
 )
+@click.option(
+    "--max-cost-usd",
+    type=float,
+    default=None,
+    help="Cost budget in USD. Mission pauses or cancels at this ceiling.",
+)
+@click.option(
+    "--max-tokens",
+    type=int,
+    default=None,
+    help="Token budget (input+output). Mission pauses or cancels at this ceiling.",
+)
+@click.option(
+    "--budget-action",
+    type=click.Choice(["pause", "cancel"]),
+    default="pause",
+    show_default=True,
+    help="Action taken when the budget is exceeded.",
+)
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def mission_create(
@@ -1407,6 +1427,9 @@ def mission_create(
     integration_branch: str | None,
     auto_merge: str | None,
     allow_auto_merge_on_external: bool,
+    max_cost_usd: float | None,
+    max_tokens: int | None,
+    budget_action: str,
     colony_url: str,
     token: str | None,
 ):
@@ -1428,6 +1451,13 @@ def mission_create(
         config["auto_merge"] = auto_merge
     if allow_auto_merge_on_external:
         config["allow_auto_merge_on_external"] = True
+    if max_cost_usd is not None:
+        config["max_cost_usd"] = max_cost_usd
+    if max_tokens is not None:
+        config["max_tokens"] = max_tokens
+    # Always thread budget_action — even when budgets are unset it's harmless
+    # and keeps round-trips deterministic.
+    config["budget_action"] = budget_action
     if config:
         payload["config"] = config
     if mission_id:
@@ -1466,6 +1496,76 @@ def mission_status(mission_id: str, colony_url: str, token: str | None):
         click.echo(f"Plan task:  {data['plan_task_id']}")
     if data.get("spec_file"):
         click.echo(f"Spec file:  {data['spec_file']}")
+
+    # Budget block — only rendered when a budget was set on the mission.
+    max_cost = config.get("max_cost_usd")
+    max_tokens = config.get("max_tokens")
+    if max_cost is not None or max_tokens is not None:
+        try:
+            usage = _get(colony_url, f"/missions/{mission_id}/usage", token=token)
+        except Exception:
+            usage = {}
+        cost = float(usage.get("total_cost_usd", 0.0) or 0.0)
+        tokens = int(usage.get("total_input_tokens", 0) or 0) + int(
+            usage.get("total_output_tokens", 0) or 0
+        )
+        if max_cost is not None:
+            pct = (cost / max_cost * 100.0) if max_cost else 0.0
+            click.echo(f"Budget:    ${cost:.4f} / ${float(max_cost):.4f} ({pct:.1f}%)")
+        else:
+            click.echo(f"Budget:    ${cost:.4f} / —")
+        if max_tokens is not None:
+            click.echo(f"Tokens:    {tokens} / {max_tokens}")
+        else:
+            click.echo(f"Tokens:    {tokens} / —")
+
+        per_task = usage.get("per_task") or {}
+        if per_task:
+            top = max(
+                per_task.items(),
+                key=lambda kv: float(kv[1].get("cost_usd", 0.0) or 0.0),
+            )
+            top_task_id, top_entry = top
+            click.echo(f"Top spend: {top_task_id} ${float(top_entry.get('cost_usd', 0.0)):.4f}")
+
+
+@mission.command("extend")
+@click.argument("mission_id")
+@click.option(
+    "--additional-usd",
+    type=float,
+    default=None,
+    help="Add this many USD to the mission's cost budget.",
+)
+@click.option(
+    "--additional-tokens",
+    type=int,
+    default=None,
+    help="Add this many tokens to the mission's token budget.",
+)
+@COLONY_URL_OPTION
+@TOKEN_OPTION
+def mission_extend(
+    mission_id: str,
+    additional_usd: float | None,
+    additional_tokens: int | None,
+    colony_url: str,
+    token: str | None,
+):
+    """Bump a mission's budget ceiling and resume it if paused."""
+    payload = {
+        "additional_usd": additional_usd,
+        "additional_tokens": additional_tokens,
+    }
+    result = _post(colony_url, f"/missions/{mission_id}/extend", payload, token=token)
+    if not result:
+        click.echo("Mission extend failed.", err=True)
+        return
+    cfg = result.get("config", {})
+    click.echo(f"Mission:    {result.get('mission_id', mission_id)}")
+    click.echo(f"Status:     {result.get('status', 'unknown')}")
+    click.echo(f"Budget:     ${cfg.get('max_cost_usd', '—')}")
+    click.echo(f"Tokens:     {cfg.get('max_tokens', '—')}")
 
 
 @mission.command("report")

--- a/antfarm/core/inbox.py
+++ b/antfarm/core/inbox.py
@@ -48,6 +48,7 @@ def collect_inbox_items(
     tasks: list[dict],
     workers: list[dict],
     *,
+    missions: list[dict] | None = None,
     stale_worker_ttl: float = 300.0,
     long_running_threshold: float = 3600.0,
     max_attempts_default: int = 3,
@@ -57,6 +58,8 @@ def collect_inbox_items(
     Args:
         tasks: List of task dicts from the colony.
         workers: List of worker dicts from the colony.
+        missions: Optional list of mission dicts — used to surface
+            budget-exceeded (paused) missions for operator attention.
         stale_worker_ttl: Seconds after which a worker heartbeat is stale.
         long_running_threshold: Seconds after which an active task is flagged.
         max_attempts_default: Default attempt ceiling when a task has no
@@ -69,9 +72,35 @@ def collect_inbox_items(
         - type: category string
         - message: human-readable explanation
         - action: recommended action
-        - task_id or worker_id: relevant entity
+        - task_id or worker_id or mission_id: relevant entity
     """
     items: list[dict] = []
+
+    # --- Missions paused on budget ---
+    for m in missions or []:
+        if m.get("status") != "paused":
+            continue
+        cfg = m.get("config") or {}
+        # Only treat pause as a budget tripwire when a budget was configured.
+        if cfg.get("max_cost_usd") is None and cfg.get("max_tokens") is None:
+            continue
+        mid = m.get("mission_id", "")
+        items.append(
+            {
+                "severity": "warning",
+                "type": "mission_budget_exceeded",
+                "message": (
+                    f"Mission '{mid}' paused — budget exceeded "
+                    f"(max_cost_usd={cfg.get('max_cost_usd')}, "
+                    f"max_tokens={cfg.get('max_tokens')})"
+                ),
+                "action": (
+                    f"Run: antfarm mission extend {mid} --additional-usd <N> "
+                    "(or cancel the mission)"
+                ),
+                "mission_id": mid,
+            }
+        )
 
     # --- Stale workers ---
     live_worker_ids: set[str] = set()
@@ -80,16 +109,18 @@ def collect_inbox_items(
         hb = w.get("last_heartbeat", "")
         age = _age_seconds(hb)
         if age > stale_worker_ttl:
-            items.append({
-                "severity": "error",
-                "type": "stale_worker",
-                "message": (
-                    f"Worker '{wid}' last heartbeat {int(age)}s ago "
-                    f"(TTL={int(stale_worker_ttl)}s)"
-                ),
-                "action": f"Run: antfarm doctor --fix (deregisters stale worker '{wid}')",
-                "worker_id": wid,
-            })
+            items.append(
+                {
+                    "severity": "error",
+                    "type": "stale_worker",
+                    "message": (
+                        f"Worker '{wid}' last heartbeat {int(age)}s ago "
+                        f"(TTL={int(stale_worker_ttl)}s)"
+                    ),
+                    "action": f"Run: antfarm doctor --fix (deregisters stale worker '{wid}')",
+                    "worker_id": wid,
+                }
+            )
         else:
             live_worker_ids.add(wid)
 
@@ -118,39 +149,44 @@ def collect_inbox_items(
             # Check trail for failure type
             trail = t.get("trail", [])
             last_msg = trail[-1].get("message", "") if trail else "unknown"
-            items.append({
-                "severity": "error",
-                "type": "failed_task",
-                "message": f"Task '{tid}' failed: {last_msg[:100]}",
-                "action": "Review failure, fix, and requeue or escalate",
-                "task_id": tid,
-            })
+            items.append(
+                {
+                    "severity": "error",
+                    "type": "failed_task",
+                    "message": f"Task '{tid}' failed: {last_msg[:100]}",
+                    "action": "Review failure, fix, and requeue or escalate",
+                    "task_id": tid,
+                }
+            )
 
         # --- Harvest-pending tasks (interrupted harvest) ---
         elif status == "harvest_pending":
-            items.append({
-                "severity": "error",
-                "type": "harvest_interrupted",
-                "message": (
-                    f"Task '{tid}' stuck in harvest_pending "
-                    "(worker may have died mid-harvest)"
-                ),
-                "action": "Run: antfarm doctor --fix or manually retry harvest",
-                "task_id": tid,
-            })
+            items.append(
+                {
+                    "severity": "error",
+                    "type": "harvest_interrupted",
+                    "message": (
+                        f"Task '{tid}' stuck in harvest_pending (worker may have died mid-harvest)"
+                    ),
+                    "action": "Run: antfarm doctor --fix or manually retry harvest",
+                    "task_id": tid,
+                }
+            )
 
         # --- Blocked tasks with unmet deps ---
         elif status in ("blocked", "ready"):
             deps = t.get("depends_on", [])
             unmet = [d for d in deps if d not in done_task_ids and d not in merged_task_ids]
             if unmet:
-                items.append({
-                    "severity": "warning",
-                    "type": "blocked_by_deps",
-                    "message": f"Task '{tid}' blocked by unmet deps: {', '.join(unmet)}",
-                    "action": f"Complete or unblock: {', '.join(unmet)}",
-                    "task_id": tid,
-                })
+                items.append(
+                    {
+                        "severity": "warning",
+                        "type": "blocked_by_deps",
+                        "message": f"Task '{tid}' blocked by unmet deps: {', '.join(unmet)}",
+                        "action": f"Complete or unblock: {', '.join(unmet)}",
+                        "task_id": tid,
+                    }
+                )
 
         # --- Active tasks running too long ---
         elif status == "active":
@@ -159,16 +195,18 @@ def collect_inbox_items(
                     started = a.get("started_at", "")
                     duration = _age_seconds(started)
                     if duration > long_running_threshold:
-                        items.append({
-                            "severity": "warning",
-                            "type": "long_running",
-                            "message": (
-                                f"Task '{tid}' active for {int(duration / 60)}min "
-                                f"(worker: {a.get('worker_id', '?')})"
-                            ),
-                            "action": "Check worker health or pause task",
-                            "task_id": tid,
-                        })
+                        items.append(
+                            {
+                                "severity": "warning",
+                                "type": "long_running",
+                                "message": (
+                                    f"Task '{tid}' active for {int(duration / 60)}min "
+                                    f"(worker: {a.get('worker_id', '?')})"
+                                ),
+                                "action": "Check worker health or pause task",
+                                "task_id": tid,
+                            }
+                        )
                     break
 
         # --- Kicked-back tasks (detected from trail on ready tasks) ---
@@ -177,18 +215,18 @@ def collect_inbox_items(
         if status == "ready":
             trail = t.get("trail", [])
             # A ready task with a superseded attempt was kicked back
-            has_superseded = any(
-                a.get("status") == "superseded" for a in t.get("attempts", [])
-            )
+            has_superseded = any(a.get("status") == "superseded" for a in t.get("attempts", []))
             if has_superseded and trail:
                 reason = trail[-1].get("message", "unknown")
-                items.append({
-                    "severity": "info",
-                    "type": "kicked_back",
-                    "message": f"Task '{tid}' was kicked back: {reason[:100]}",
-                    "action": "Review rejection reason and requeue",
-                    "task_id": tid,
-                })
+                items.append(
+                    {
+                        "severity": "info",
+                        "type": "kicked_back",
+                        "message": f"Task '{tid}' was kicked back: {reason[:100]}",
+                        "action": "Review rejection reason and requeue",
+                        "task_id": tid,
+                    }
+                )
 
         # --- Retry-pattern failures ---
         # Count finished (DONE or SUPERSEDED) attempts and compare to the
@@ -198,57 +236,57 @@ def collect_inbox_items(
         # skipped — they're handled by their own lifecycle.
         if not _is_infra_task_id(tid):
             attempts = t.get("attempts", [])
-            finished = sum(
-                1 for a in attempts if a.get("status") in ("done", "superseded")
-            )
+            finished = sum(1 for a in attempts if a.get("status") in ("done", "superseded"))
             effective_max = t.get("max_attempts") or max_attempts_default
             trail = t.get("trail", [])
             if finished >= effective_max and status == "blocked":
                 reason = _last_failure_reason(trail)
-                items.append({
-                    "severity": "error",
-                    "type": "retry_ceiling",
-                    "message": (
-                        f"Task '{tid}' has failed {finished}/{effective_max} "
-                        f"attempts. Last failure: {reason[:120]}"
-                    ),
-                    "action": (
-                        "Task is at the retry ceiling. Inspect trail or "
-                        f"unblock via: antfarm kickback {tid}"
-                    ),
-                    "task_id": tid,
-                })
-            elif (
-                finished >= effective_max - 1
-                and finished > 0
-                and status != "blocked"
-            ):
+                items.append(
+                    {
+                        "severity": "error",
+                        "type": "retry_ceiling",
+                        "message": (
+                            f"Task '{tid}' has failed {finished}/{effective_max} "
+                            f"attempts. Last failure: {reason[:120]}"
+                        ),
+                        "action": (
+                            "Task is at the retry ceiling. Inspect trail or "
+                            f"unblock via: antfarm kickback {tid}"
+                        ),
+                        "task_id": tid,
+                    }
+                )
+            elif finished >= effective_max - 1 and finished > 0 and status != "blocked":
                 reason = _last_failure_reason(trail)
-                items.append({
-                    "severity": "warning",
-                    "type": "retrying",
-                    "message": (
-                        f"Task '{tid}' has failed {finished} of max "
-                        f"{effective_max} attempts. Last failure: {reason[:120]}"
-                    ),
-                    "action": (
-                        "Task may block the mission if the next attempt fails. "
-                        "Inspect trail before it hits the retry ceiling."
-                    ),
-                    "task_id": tid,
-                })
+                items.append(
+                    {
+                        "severity": "warning",
+                        "type": "retrying",
+                        "message": (
+                            f"Task '{tid}' has failed {finished} of max "
+                            f"{effective_max} attempts. Last failure: {reason[:120]}"
+                        ),
+                        "action": (
+                            "Task may block the mission if the next attempt fails. "
+                            "Inspect trail before it hits the retry ceiling."
+                        ),
+                        "task_id": tid,
+                    }
+                )
 
         # --- Tasks with signals (need human input) ---
         signals = t.get("signals", [])
         if signals:
             last_signal = signals[-1]
-            items.append({
-                "severity": "info",
-                "type": "has_signal",
-                "message": f"Task '{tid}' has signal: {last_signal.get('message', '')[:100]}",
-                "action": "Review signal and take action",
-                "task_id": tid,
-            })
+            items.append(
+                {
+                    "severity": "info",
+                    "type": "has_signal",
+                    "message": f"Task '{tid}' has signal: {last_signal.get('message', '')[:100]}",
+                    "action": "Review signal and take action",
+                    "task_id": tid,
+                }
+            )
 
     # Sort: errors first, then warnings, then info
     severity_order = {"error": 0, "warning": 1, "info": 2}

--- a/antfarm/core/missions.py
+++ b/antfarm/core/missions.py
@@ -20,6 +20,10 @@ if TYPE_CHECKING:
 VALID_COMPLETION_MODES = ("best_effort", "all_or_nothing")
 VALID_BLOCKED_TIMEOUT_ACTIONS = ("wait", "fail")
 VALID_AUTO_MERGE_MODES = ("never", "on-review-pass", "on-review-pass-and-ci-green")
+VALID_BUDGET_ACTIONS = ("pause", "cancel")
+
+# Bounded FIFO of recent UsageEvent IDs kept per-mission for dedup.
+_SEEN_EVENT_ID_CAP = 1000
 
 
 # ---------------------------------------------------------------------------
@@ -32,6 +36,7 @@ class MissionStatus(StrEnum):
     REVIEWING_PLAN = "reviewing_plan"
     BUILDING = "building"
     BLOCKED = "blocked"
+    PAUSED = "paused"
     COMPLETE = "complete"
     FAILED = "failed"
     CANCELLED = "cancelled"
@@ -55,6 +60,10 @@ class MissionConfig:
     blocked_timeout_minutes: int = 120
     auto_merge: str = "never"
     allow_auto_merge_on_external: bool = False
+    # Budget tripwire (v0.6.14 — issue #354). None means no limit.
+    max_cost_usd: float | None = None
+    max_tokens: int | None = None
+    budget_action: str = "pause"
 
     def __post_init__(self) -> None:
         if self.completion_mode not in VALID_COMPLETION_MODES:
@@ -65,6 +74,8 @@ class MissionConfig:
             )
         if self.auto_merge not in VALID_AUTO_MERGE_MODES:
             raise ValueError(f"auto_merge must be one of {VALID_AUTO_MERGE_MODES}")
+        if self.budget_action not in VALID_BUDGET_ACTIONS:
+            raise ValueError(f"budget_action must be one of {VALID_BUDGET_ACTIONS}")
 
     def to_dict(self) -> dict:
         return {
@@ -79,6 +90,9 @@ class MissionConfig:
             "blocked_timeout_minutes": self.blocked_timeout_minutes,
             "auto_merge": self.auto_merge,
             "allow_auto_merge_on_external": self.allow_auto_merge_on_external,
+            "max_cost_usd": self.max_cost_usd,
+            "max_tokens": self.max_tokens,
+            "budget_action": self.budget_action,
         }
 
     @classmethod
@@ -97,6 +111,9 @@ class MissionConfig:
             blocked_timeout_minutes=data.get("blocked_timeout_minutes", 120),
             auto_merge=data.get("auto_merge", "never"),
             allow_auto_merge_on_external=data.get("allow_auto_merge_on_external", False),
+            max_cost_usd=data.get("max_cost_usd"),
+            max_tokens=data.get("max_tokens"),
+            budget_action=data.get("budget_action", "pause"),
         )
 
 
@@ -371,6 +388,145 @@ def is_infra_task(task: dict) -> bool:
 # ---------------------------------------------------------------------------
 # link_task_to_mission
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# MissionUsage (v0.6 cost tripwire)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MissionUsage:
+    """Aggregated cost/token counters for a mission.
+
+    Persisted as a sidecar JSON file at
+    ``.antfarm/missions/<mission_id>_usage.json``. Mutations happen under
+    FileBackend._lock; idempotency against duplicate UsageEvents is enforced
+    by a bounded FIFO of seen event IDs.
+    """
+
+    mission_id: str
+    total_cost_usd: float = 0.0
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_cache_read_tokens: int = 0
+    total_cache_creation_tokens: int = 0
+    event_count: int = 0
+    first_event_at: str | None = None
+    last_event_at: str | None = None
+    # task_id → {cost_usd, input_tokens, output_tokens, cache_read_tokens,
+    #            cache_creation_tokens, event_count, top_attempt_id,
+    #            top_attempt_cost}
+    per_task: dict[str, dict] = field(default_factory=dict)
+    # FIFO of already-applied UsageEvent IDs, capped at _SEEN_EVENT_ID_CAP.
+    seen_event_ids: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "mission_id": self.mission_id,
+            "total_cost_usd": self.total_cost_usd,
+            "total_input_tokens": self.total_input_tokens,
+            "total_output_tokens": self.total_output_tokens,
+            "total_cache_read_tokens": self.total_cache_read_tokens,
+            "total_cache_creation_tokens": self.total_cache_creation_tokens,
+            "event_count": self.event_count,
+            "first_event_at": self.first_event_at,
+            "last_event_at": self.last_event_at,
+            "per_task": {k: dict(v) for k, v in self.per_task.items()},
+            "seen_event_ids": list(self.seen_event_ids),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> MissionUsage:
+        return cls(
+            mission_id=data["mission_id"],
+            total_cost_usd=float(data.get("total_cost_usd", 0.0)),
+            total_input_tokens=int(data.get("total_input_tokens", 0)),
+            total_output_tokens=int(data.get("total_output_tokens", 0)),
+            total_cache_read_tokens=int(data.get("total_cache_read_tokens", 0)),
+            total_cache_creation_tokens=int(data.get("total_cache_creation_tokens", 0)),
+            event_count=int(data.get("event_count", 0)),
+            first_event_at=data.get("first_event_at"),
+            last_event_at=data.get("last_event_at"),
+            per_task={k: dict(v) for k, v in data.get("per_task", {}).items()},
+            seen_event_ids=list(data.get("seen_event_ids", [])),
+        )
+
+    def apply(self, event) -> None:
+        """Apply a UsageEvent to the aggregates. Idempotent by event_id.
+
+        ``event`` is either a ``UsageEvent`` dataclass or its ``to_dict()``
+        form — both are accepted so callers don't need to round-trip.
+        """
+        # Accept dict or dataclass — keeps the call sites simple.
+        ed = event.to_dict() if hasattr(event, "to_dict") else dict(event)
+
+        event_id = ed.get("event_id")
+        if not event_id:
+            return
+        if event_id in self.seen_event_ids:
+            return
+
+        cost = float(ed.get("cost_usd", 0.0))
+        input_tok = int(ed.get("input_tokens", 0))
+        output_tok = int(ed.get("output_tokens", 0))
+        cache_r = int(ed.get("cache_read_tokens", 0))
+        cache_c = int(ed.get("cache_creation_tokens", 0))
+        ts = ed.get("ts")
+
+        self.total_cost_usd += cost
+        self.total_input_tokens += input_tok
+        self.total_output_tokens += output_tok
+        self.total_cache_read_tokens += cache_r
+        self.total_cache_creation_tokens += cache_c
+        self.event_count += 1
+
+        if ts is not None:
+            if self.first_event_at is None:
+                self.first_event_at = ts
+            self.last_event_at = ts
+
+        task_id = ed.get("task_id")
+        attempt_id = ed.get("attempt_id")
+        if task_id:
+            bucket = self.per_task.setdefault(
+                task_id,
+                {
+                    "cost_usd": 0.0,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_read_tokens": 0,
+                    "cache_creation_tokens": 0,
+                    "event_count": 0,
+                    "top_attempt_id": None,
+                    "top_attempt_cost": 0.0,
+                    "per_attempt": {},
+                },
+            )
+            bucket["cost_usd"] = float(bucket.get("cost_usd", 0.0)) + cost
+            bucket["input_tokens"] = int(bucket.get("input_tokens", 0)) + input_tok
+            bucket["output_tokens"] = int(bucket.get("output_tokens", 0)) + output_tok
+            bucket["cache_read_tokens"] = int(bucket.get("cache_read_tokens", 0)) + cache_r
+            bucket["cache_creation_tokens"] = int(bucket.get("cache_creation_tokens", 0)) + cache_c
+            bucket["event_count"] = int(bucket.get("event_count", 0)) + 1
+
+            # Track per-attempt cost so we can surface the most expensive
+            # attempt for this task — useful when a task churned and cost
+            # blew up across kickbacks.
+            per_attempt = bucket.setdefault("per_attempt", {})
+            if attempt_id:
+                prev = float(per_attempt.get(attempt_id, 0.0))
+                new_attempt_cost = prev + cost
+                per_attempt[attempt_id] = new_attempt_cost
+                if new_attempt_cost > float(bucket.get("top_attempt_cost", 0.0)):
+                    bucket["top_attempt_id"] = attempt_id
+                    bucket["top_attempt_cost"] = new_attempt_cost
+
+        # Record seen event_id; drop oldest when over the cap.
+        self.seen_event_ids.append(event_id)
+        overflow = len(self.seen_event_ids) - _SEEN_EVENT_ID_CAP
+        if overflow > 0:
+            del self.seen_event_ids[:overflow]
 
 
 def link_task_to_mission(

--- a/antfarm/core/models.py
+++ b/antfarm/core/models.py
@@ -559,3 +559,67 @@ class Node:
             max_workers=data.get("max_workers", 4),
             capabilities=list(data.get("capabilities", [])),
         )
+
+
+# ---------------------------------------------------------------------------
+# UsageEvent (v0.6 cost tripwire)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class UsageEvent:
+    """A single reported usage/cost datapoint for a mission budget.
+
+    Emitted by worker-side hooks (Stop hook for Claude Code, heartbeat-delta
+    for other agents) and aggregated by the colony into a MissionUsage
+    sidecar. Idempotency is enforced by ``event_id``.
+    """
+
+    event_id: str
+    worker_id: str
+    task_id: str | None
+    attempt_id: str | None
+    mission_id: str | None
+    ts: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_creation_tokens: int
+    cost_usd: float
+    source: str  # "claude_stop_hook" | "heartbeat_delta" | "manual"
+
+    def to_dict(self) -> dict:
+        return {
+            "event_id": self.event_id,
+            "worker_id": self.worker_id,
+            "task_id": self.task_id,
+            "attempt_id": self.attempt_id,
+            "mission_id": self.mission_id,
+            "ts": self.ts,
+            "model": self.model,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "cache_creation_tokens": self.cache_creation_tokens,
+            "cost_usd": self.cost_usd,
+            "source": self.source,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> UsageEvent:
+        return cls(
+            event_id=data["event_id"],
+            worker_id=data["worker_id"],
+            task_id=data.get("task_id"),
+            attempt_id=data.get("attempt_id"),
+            mission_id=data.get("mission_id"),
+            ts=data["ts"],
+            model=data.get("model", ""),
+            input_tokens=int(data.get("input_tokens", 0)),
+            output_tokens=int(data.get("output_tokens", 0)),
+            cache_read_tokens=int(data.get("cache_read_tokens", 0)),
+            cache_creation_tokens=int(data.get("cache_creation_tokens", 0)),
+            cost_usd=float(data.get("cost_usd", 0.0)),
+            source=data.get("source", "manual"),
+        )

--- a/antfarm/core/pricing.py
+++ b/antfarm/core/pricing.py
@@ -1,0 +1,179 @@
+"""Model pricing and cost computation for Antfarm mission budgets.
+
+Prices are expressed in USD per 1M tokens. Claude Anthropic APIs report four
+token buckets in a Stop-hook usage payload:
+
+- ``input_tokens``: ordinary (non-cached) input. Note that Claude reports this
+  DISJOINT from the cache fields — ``input_tokens`` does NOT include cache
+  read/creation tokens. Do NOT subtract cache tokens from input tokens.
+- ``output_tokens``: tokens generated in the assistant response.
+- ``cache_read_tokens``: tokens served from prompt cache (cheaper than input).
+- ``cache_creation_tokens``: tokens written to prompt cache (more expensive
+  than input, one-time cost).
+
+``resolve_model`` picks the longest-prefix match among the canonical keys in
+``PRICES`` so that specific minor versions (e.g. ``claude-sonnet-4-7``) take
+precedence over generic prefixes (e.g. ``claude-sonnet``). Unknown model IDs
+fall back to ``FALLBACK_RATES`` and emit a single WARNING per model ID.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Price table (USD per 1M tokens)
+# ---------------------------------------------------------------------------
+
+# Canonical model prefix → {input, output, cache_read, cache_creation} USD/MTok.
+PRICES: dict[str, dict[str, float]] = {
+    # Sonnet tier
+    "claude-sonnet-4-5": {
+        "input": 3.00,
+        "output": 15.00,
+        "cache_read": 0.30,
+        "cache_creation": 3.75,
+    },
+    "claude-sonnet-4-6": {
+        "input": 3.00,
+        "output": 15.00,
+        "cache_read": 0.30,
+        "cache_creation": 3.75,
+    },
+    "claude-sonnet-4-7": {
+        "input": 3.00,
+        "output": 15.00,
+        "cache_read": 0.30,
+        "cache_creation": 3.75,
+    },
+    # Opus tier
+    "claude-opus-4": {
+        "input": 15.00,
+        "output": 75.00,
+        "cache_read": 1.50,
+        "cache_creation": 18.75,
+    },
+    "claude-opus-4-5": {
+        "input": 15.00,
+        "output": 75.00,
+        "cache_read": 1.50,
+        "cache_creation": 18.75,
+    },
+    "claude-opus-4-6": {
+        "input": 15.00,
+        "output": 75.00,
+        "cache_read": 1.50,
+        "cache_creation": 18.75,
+    },
+    "claude-opus-4-7": {
+        "input": 15.00,
+        "output": 75.00,
+        "cache_read": 1.50,
+        "cache_creation": 18.75,
+    },
+    # Haiku tier
+    "claude-haiku-4": {
+        "input": 0.80,
+        "output": 4.00,
+        "cache_read": 0.08,
+        "cache_creation": 1.00,
+    },
+    "claude-haiku-4-5": {
+        "input": 0.80,
+        "output": 4.00,
+        "cache_read": 0.08,
+        "cache_creation": 1.00,
+    },
+}
+
+
+DEFAULT_MODEL = "claude-sonnet-4-6"
+
+
+# Fallback rates used when a model ID does not match any canonical prefix.
+# Chosen conservatively at the Sonnet tier so unknown models cannot silently
+# under-report cost.
+FALLBACK_RATES: dict[str, float] = {
+    "input": 3.00,
+    "output": 15.00,
+    "cache_read": 0.30,
+    "cache_creation": 3.75,
+}
+
+
+# Models that have already been warned about — prevents log spam.
+_WARNED_MODELS: set[str] = set()
+
+
+# ---------------------------------------------------------------------------
+# API
+# ---------------------------------------------------------------------------
+
+
+def resolve_model(raw: str) -> str:
+    """Return the canonical price-table key for a raw model string.
+
+    Matching is case-insensitive and uses longest-prefix semantics so that
+    ``"claude-sonnet-4-7-1m"`` resolves to ``"claude-sonnet-4-7"`` rather than
+    a shorter prefix.
+
+    Returns the empty string when no prefix matches — the caller can then
+    decide to use ``FALLBACK_RATES``.
+    """
+    if not raw:
+        return ""
+    needle = raw.lower()
+    best = ""
+    for key in PRICES:
+        if needle.startswith(key) and len(key) > len(best):
+            best = key
+    return best
+
+
+def compute_cost(
+    *,
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+) -> float:
+    """Compute USD cost for a single usage event.
+
+    Claude reports ``input_tokens`` disjoint from the cache fields — do NOT
+    subtract ``cache_read_tokens`` or ``cache_creation_tokens`` from
+    ``input_tokens``.
+
+    Unknown models log a single WARNING and fall back to ``FALLBACK_RATES``.
+
+    Args:
+        model: Raw model identifier (as reported by the Claude transcript).
+        input_tokens: Non-cached input tokens.
+        output_tokens: Generated output tokens.
+        cache_read_tokens: Tokens served from prompt cache.
+        cache_creation_tokens: Tokens written into prompt cache.
+
+    Returns:
+        Total cost in USD.
+    """
+    key = resolve_model(model)
+    if key:
+        rates = PRICES[key]
+    else:
+        if model and model not in _WARNED_MODELS:
+            logger.warning("pricing: unknown model '%s'; falling back to Sonnet rates", model)
+            _WARNED_MODELS.add(model)
+        rates = FALLBACK_RATES
+
+    # Prices are USD per 1M tokens.
+    scale = 1_000_000.0
+    cost = (
+        (input_tokens * rates["input"])
+        + (output_tokens * rates["output"])
+        + (cache_read_tokens * rates["cache_read"])
+        + (cache_creation_tokens * rates["cache_creation"])
+    ) / scale
+    return cost

--- a/antfarm/core/queen.py
+++ b/antfarm/core/queen.py
@@ -123,12 +123,19 @@ class Queen:
                     )
             time.sleep(self._adaptive_interval(missions))
 
+    # NOTE: _adaptive_interval treats paused missions as non-active so the
+    # loop idles appropriately; no change needed there.
+
     def stop(self) -> None:
         self._stopped = True
 
     # --- per-tick phase dispatch (all idempotent, all read fresh state) ---
 
     def _advance(self, mission: dict) -> None:
+        # Budget tripwire runs BEFORE status dispatch so a mid-phase breach
+        # pauses or cancels immediately rather than waiting for the next tick.
+        if self._check_budget(mission):
+            return
         status = mission["status"]
         if status == MissionStatus.PLANNING:
             self._advance_planning(mission)
@@ -138,6 +145,76 @@ class Queen:
             self._advance_building(mission)
         elif status == MissionStatus.BLOCKED:
             self._advance_blocked(mission)
+        elif status == MissionStatus.PAUSED:
+            # Paused missions are inert until `antfarm mission extend` is
+            # called (which flips status back via the HTTP handler).
+            return
+
+    # --- budget tripwire (v0.6.14 — issue #354) ------------------------
+
+    def _check_budget(self, mission: dict) -> bool:
+        """Return True if a budget breach was detected and acted upon.
+
+        When True, the caller should skip status dispatch — the mission has
+        been transitioned to PAUSED (budget_action='pause') or CANCELLED
+        (budget_action='cancel') in this tick.
+        """
+        cfg = mission.get("config") or {}
+        if cfg.get("max_cost_usd") is None and cfg.get("max_tokens") is None:
+            return False
+        # Already paused — the loop keeps us from re-triggering the event.
+        if mission.get("status") == MissionStatus.PAUSED.value:
+            return True
+
+        try:
+            usage = self.backend.get_mission_usage(mission["mission_id"]) or {}
+        except NotImplementedError:
+            return False
+        cost = float(usage.get("total_cost_usd", 0.0) or 0.0)
+        tokens = int(usage.get("total_input_tokens", 0) or 0) + int(
+            usage.get("total_output_tokens", 0) or 0
+        )
+
+        breach = False
+        if cfg.get("max_cost_usd") is not None and cost >= float(cfg["max_cost_usd"]):
+            breach = True
+        if cfg.get("max_tokens") is not None and tokens >= int(cfg["max_tokens"]):
+            breach = True
+        if not breach:
+            return False
+
+        action = cfg.get("budget_action", "pause")
+        mission_id = mission["mission_id"]
+        if action == "pause":
+            prior = mission.get("status")
+            self.backend.update_mission(
+                mission_id,
+                {
+                    "status": MissionStatus.PAUSED.value,
+                    "paused_from_status": prior,
+                },
+            )
+            _emit_event(
+                "mission_budget_exceeded",
+                "",
+                detail=(f"mission={mission_id} action=pause cost={cost:.4f} tokens={tokens}"),
+                actor="queen",
+            )
+        else:  # cancel
+            with contextlib.suppress(Exception):
+                self.backend.cancel_mission_tasks(mission_id, reason="mission budget exceeded")
+            with contextlib.suppress(Exception):
+                self.backend.update_mission(
+                    mission_id,
+                    {"status": MissionStatus.CANCELLED.value},
+                )
+            _emit_event(
+                "mission_budget_exceeded",
+                "",
+                detail=(f"mission={mission_id} action=cancel cost={cost:.4f} tokens={tokens}"),
+                actor="queen",
+            )
+        return True
 
     # --- phase handlers ---
 

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -406,6 +406,29 @@ class MissionUpdateRequest(BaseModel):
     updates: dict
 
 
+class WorkerUsageRequest(BaseModel):
+    """Usage/cost ping from a worker hook — mirrors UsageEvent (minus cost)."""
+
+    event_id: str
+    ts: str
+    model: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_creation_tokens: int = 0
+    source: str = "claude_stop_hook"
+    # Optional overrides — if omitted, the server derives from the worker's
+    # active task. Supplied by tests and by future non-Claude adapters.
+    task_id: str | None = None
+    attempt_id: str | None = None
+    mission_id: str | None = None
+
+
+class MissionExtendRequest(BaseModel):
+    additional_usd: float | None = None
+    additional_tokens: int | None = None
+
+
 # ---------------------------------------------------------------------------
 # App factory
 # ---------------------------------------------------------------------------
@@ -623,6 +646,140 @@ def get_app(
         _backend.deregister_worker(worker_id)
         return {"ok": True}
 
+    @app.post("/workers/{worker_id:path}/usage", status_code=200)
+    def worker_usage(worker_id: str, req: WorkerUsageRequest):
+        """Record a usage/cost event from a worker hook.
+
+        Attribution flow:
+        1. Explicit task_id/attempt_id/mission_id on the request wins.
+        2. Otherwise look up the worker's current active task and attribute
+           to its current_attempt.
+        3. Otherwise fall back to the worker's most recent harvested/done
+           attempt that still carries a mission_id — this catches the
+           Stop-hook-after-harvest ordering.
+        4. If no mission can be resolved, record the trail entry on the
+           task (if any) but skip mission aggregation.
+
+        The endpoint is idempotent by ``event_id`` — the backend usage
+        updater dedupes.
+        """
+        from antfarm.core.missions import MissionUsage
+        from antfarm.core.models import UsageEvent
+        from antfarm.core.pricing import compute_cost
+
+        task_id = req.task_id
+        attempt_id = req.attempt_id
+        mission_id = req.mission_id
+
+        # Fall back to worker lookup only when attribution fields are absent.
+        if task_id is None or mission_id is None:
+            try:
+                active_tasks = _backend.list_tasks(status="active")
+            except Exception:
+                active_tasks = []
+            found: dict | None = None
+            for t in active_tasks:
+                current_id = t.get("current_attempt")
+                if not current_id:
+                    continue
+                for a in t.get("attempts", []):
+                    if a.get("attempt_id") == current_id and a.get("worker_id") == worker_id:
+                        found = t
+                        break
+                if found is not None:
+                    break
+
+            if found is None:
+                # Fall back to last-completed attempt with a mission_id. The
+                # Stop hook frequently fires immediately after harvest, by
+                # which time the task is no longer active.
+                try:
+                    done_tasks = _backend.list_tasks(status="done")
+                except Exception:
+                    done_tasks = []
+                best_ts = ""
+                for t in done_tasks:
+                    if not t.get("mission_id"):
+                        continue
+                    for a in t.get("attempts", []):
+                        if a.get("worker_id") != worker_id:
+                            continue
+                        completed = a.get("completed_at") or a.get("started_at") or ""
+                        if completed > best_ts:
+                            best_ts = completed
+                            found = t
+                            attempt_id = attempt_id or a.get("attempt_id")
+
+            if found is not None:
+                task_id = task_id or found.get("id")
+                mission_id = mission_id or found.get("mission_id")
+                if attempt_id is None:
+                    attempt_id = found.get("current_attempt")
+
+        cost = compute_cost(
+            model=req.model,
+            input_tokens=req.input_tokens,
+            output_tokens=req.output_tokens,
+            cache_read_tokens=req.cache_read_tokens,
+            cache_creation_tokens=req.cache_creation_tokens,
+        )
+
+        event = UsageEvent(
+            event_id=req.event_id,
+            worker_id=worker_id,
+            task_id=task_id,
+            attempt_id=attempt_id,
+            mission_id=mission_id,
+            ts=req.ts,
+            model=req.model,
+            input_tokens=req.input_tokens,
+            output_tokens=req.output_tokens,
+            cache_read_tokens=req.cache_read_tokens,
+            cache_creation_tokens=req.cache_creation_tokens,
+            cost_usd=cost,
+            source=req.source,
+        )
+
+        total_cost: float = 0.0
+        total_tokens: int = 0
+        if mission_id:
+
+            def _updater(current: dict) -> dict:
+                usage = MissionUsage.from_dict(current)
+                usage.apply(event)
+                return usage.to_dict()
+
+            try:
+                new_state = _backend.update_mission_usage(mission_id, _updater)
+                total_cost = float(new_state.get("total_cost_usd", 0.0))
+                total_tokens = int(
+                    new_state.get("total_input_tokens", 0) + new_state.get("total_output_tokens", 0)
+                )
+            except NotImplementedError:
+                logger.warning("worker_usage: backend does not support mission usage; skipping")
+
+        # Append a trail entry on the task so operators see cost per task.
+        if task_id:
+            trail_msg = f"cost +${cost:.4f} model={req.model}"
+            entry = {
+                "ts": _now_iso(),
+                "worker_id": worker_id,
+                "message": trail_msg,
+                "action_type": "usage",
+            }
+            with contextlib.suppress(Exception), _lock:
+                _backend.append_trail(task_id, entry)
+
+        return {
+            "ok": True,
+            "event_id": req.event_id,
+            "cost_usd": cost,
+            "mission_id": mission_id,
+            "task_id": task_id,
+            "total_cost_usd": total_cost,
+            "total_tokens": total_tokens,
+        }
+
     # ------------------------------------------------------------------
     # Tasks
     # ------------------------------------------------------------------
@@ -688,14 +845,42 @@ def get_app(
 
     @app.post("/tasks/pull")
     def forage(req: PullRequest, response: Response):
-        """Pull the next eligible task for a worker. Returns 204 if queue is empty."""
-        with _lock:
-            task = _backend.pull(req.worker_id)
-            if task is not None:
-                # Atomically mark the worker active so the autoscaler does not
-                # retire it between task claim and the worker's next heartbeat.
-                with contextlib.suppress(Exception):
-                    _backend.heartbeat(req.worker_id, {"status": "active"})
+        """Pull the next eligible task for a worker. Returns 204 if queue is empty.
+
+        Tasks whose parent mission is paused or cancelled are returned to
+        ready/ (via reassign_task) so the claim doesn't wedge them on a
+        paused mission. We do this post-pull rather than pre-filtering inside
+        the scheduler to keep the scheduler path simple — bounded O(pauses)
+        retries per pull in the common case where no missions are paused.
+        """
+        # Try up to a handful of times in case we repeatedly pull tasks from
+        # paused missions. In practice a paused mission will have few tasks
+        # compared to the queue and the loop exits after one iteration.
+        for _ in range(8):
+            with _lock:
+                task = _backend.pull(req.worker_id)
+                if task is not None:
+                    with contextlib.suppress(Exception):
+                        _backend.heartbeat(req.worker_id, {"status": "active"})
+            if task is None:
+                break
+            mission_id = task.get("mission_id")
+            if not mission_id:
+                break
+            try:
+                mission = _backend.get_mission(mission_id)
+            except NotImplementedError:
+                mission = None
+            if mission is None:
+                break
+            if mission.get("status") not in ("paused", "cancelled"):
+                break
+            # Return the claimed task to ready/ so another pull (or a future
+            # extend) can pick it up. reassign_task supersedes the attempt
+            # and moves active/ → ready/.
+            with contextlib.suppress(Exception):
+                _backend.reassign_task(task["id"], req.worker_id)
+            task = None
         if task is None:
             response.status_code = 204
             return None
@@ -1024,6 +1209,72 @@ def get_app(
         ids = _backend.cancel_mission_tasks(mission_id, reason="mission cancelled")
         return {"ok": True, "cancelled_tasks": ids}
 
+    @app.get("/missions/{mission_id}/usage", status_code=200)
+    def get_mission_usage_endpoint(mission_id: str):
+        """Return aggregated usage for a mission. Empty object if none recorded."""
+        from antfarm.core.missions import MissionUsage
+
+        mission = _backend.get_mission(mission_id)
+        if mission is None:
+            raise HTTPException(status_code=404, detail=f"Mission '{mission_id}' not found")
+        usage = _backend.get_mission_usage(mission_id)
+        if usage is None:
+            return MissionUsage(mission_id=mission_id).to_dict()
+        return usage
+
+    @app.post("/missions/{mission_id}/extend", status_code=200)
+    def extend_mission(mission_id: str, req: MissionExtendRequest):
+        """Bump a mission's budget caps and resume if paused.
+
+        When ``additional_usd`` or ``additional_tokens`` is provided, the
+        corresponding config field is increased by that amount. If the mission
+        is currently PAUSED due to a budget tripwire, it is moved back to the
+        status recorded in ``paused_from_status`` (falling back to BUILDING).
+        """
+        from antfarm.core.missions import MissionStatus
+
+        mission = _backend.get_mission(mission_id)
+        if mission is None:
+            raise HTTPException(status_code=404, detail=f"Mission '{mission_id}' not found")
+
+        cfg = dict(mission.get("config") or {})
+        updates: dict = {}
+
+        if req.additional_usd is not None:
+            current = cfg.get("max_cost_usd")
+            new_val = (float(current) if current is not None else 0.0) + float(req.additional_usd)
+            cfg["max_cost_usd"] = new_val
+
+        if req.additional_tokens is not None:
+            current_tok = cfg.get("max_tokens")
+            new_tok = (int(current_tok) if current_tok is not None else 0) + int(
+                req.additional_tokens
+            )
+            cfg["max_tokens"] = new_tok
+
+        updates["config"] = cfg
+
+        if mission.get("status") == MissionStatus.PAUSED.value:
+            prior = mission.get("paused_from_status") or MissionStatus.BUILDING.value
+            updates["status"] = prior
+            updates["paused_from_status"] = None
+
+        try:
+            _backend.update_mission(mission_id, updates)
+        except FileNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+        _emit_event(
+            "mission_extended",
+            "",
+            detail=(
+                f"mission={mission_id} +usd={req.additional_usd} +tokens={req.additional_tokens}"
+            ),
+            actor="colony",
+        )
+
+        return _backend.get_mission(mission_id)
+
     @app.get("/missions/{mission_id}/context")
     def get_mission_context_endpoint(mission_id: str):
         """Return mission context blob for prompt cache sharing. 404 if not found."""
@@ -1180,10 +1431,15 @@ def get_app(
         Returns:
             Dict with 'status', 'tasks', and 'workers' keys.
         """
+        try:
+            missions = _backend.list_missions()
+        except NotImplementedError:
+            missions = []
         return {
             "status": _backend.status(),
             "tasks": _backend.list_tasks(),
             "workers": _backend.list_workers(),
+            "missions": missions,
             "soldier": _soldier_status,
             "doctor": _doctor_status,
             "queen": _queen_status,

--- a/tests/test_mission_backend.py
+++ b/tests/test_mission_backend.py
@@ -254,3 +254,72 @@ def test_github_backend_stubs_raise() -> None:
         gb.list_missions()
     with pytest.raises(NotImplementedError, match="Mission mode requires FileBackend"):
         gb.update_mission("x", {})
+    with pytest.raises(NotImplementedError, match="Mission mode requires FileBackend"):
+        gb.get_mission_usage("x")
+    with pytest.raises(NotImplementedError, match="Mission mode requires FileBackend"):
+        gb.update_mission_usage("x", lambda d: d)
+
+
+# ---------------------------------------------------------------------------
+# get_mission_usage / update_mission_usage
+# ---------------------------------------------------------------------------
+
+
+def test_get_mission_usage_none_for_unknown(backend: FileBackend) -> None:
+    assert backend.get_mission_usage("mission-missing") is None
+
+
+def test_update_mission_usage_creates_sidecar(backend: FileBackend, tmp_path) -> None:
+    backend.create_mission(_make_mission())
+
+    def _updater(current: dict) -> dict:
+        current["total_cost_usd"] = current.get("total_cost_usd", 0.0) + 0.25
+        return current
+
+    new_state = backend.update_mission_usage("mission-login-123", _updater)
+    assert new_state["total_cost_usd"] == 0.25
+    sidecar = tmp_path / ".antfarm" / "missions" / "mission-login-123_usage.json"
+    assert sidecar.exists()
+
+
+def test_update_mission_usage_is_read_modify_write(backend: FileBackend) -> None:
+    backend.create_mission(_make_mission())
+
+    def _add(amount: float):
+        def _fn(current: dict) -> dict:
+            current["total_cost_usd"] = current.get("total_cost_usd", 0.0) + amount
+            return current
+
+        return _fn
+
+    backend.update_mission_usage("mission-login-123", _add(0.10))
+    backend.update_mission_usage("mission-login-123", _add(0.20))
+    backend.update_mission_usage("mission-login-123", _add(0.05))
+    final = backend.get_mission_usage("mission-login-123")
+    assert round(final["total_cost_usd"], 6) == 0.35
+
+
+def test_update_mission_usage_concurrent_serialized(backend: FileBackend) -> None:
+    """Concurrent updaters under the backend lock must not clobber each other."""
+    backend.create_mission(_make_mission())
+    N = 50
+
+    def _increment(current: dict) -> dict:
+        current["total_cost_usd"] = current.get("total_cost_usd", 0.0) + 1.0
+        current["event_count"] = current.get("event_count", 0) + 1
+        return current
+
+    threads = []
+    for _ in range(N):
+        t = threading.Thread(
+            target=backend.update_mission_usage,
+            args=("mission-login-123", _increment),
+        )
+        threads.append(t)
+        t.start()
+    for t in threads:
+        t.join()
+
+    final = backend.get_mission_usage("mission-login-123")
+    assert final["event_count"] == N
+    assert final["total_cost_usd"] == float(N)

--- a/tests/test_mission_cli.py
+++ b/tests/test_mission_cli.py
@@ -586,3 +586,127 @@ def test_colony_no_queen_flag():
         assert result.exit_code == 0, result.output
         call_kwargs = mock_get_app.call_args
         assert call_kwargs.kwargs.get("enable_queen") is False
+
+
+# ---------------------------------------------------------------------------
+# mission create budget flags / mission extend / mission status budget
+# (v0.6.14 — issue #354)
+# ---------------------------------------------------------------------------
+
+
+def test_mission_create_with_max_cost_usd(tmp_path: Path):
+    spec_file = tmp_path / "spec.md"
+    spec_file.write_text("spec")
+    runner = CliRunner()
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"mission_id": "m1"}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission",
+                "create",
+                "--spec",
+                str(spec_file),
+                "--max-cost-usd",
+                "25.5",
+                "--max-tokens",
+                "100000",
+                "--budget-action",
+                "cancel",
+                "--colony-url",
+                "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+        assert payload["config"]["max_cost_usd"] == 25.5
+        assert payload["config"]["max_tokens"] == 100_000
+        assert payload["config"]["budget_action"] == "cancel"
+
+
+def test_mission_status_prints_budget_line():
+    runner = CliRunner()
+    with (
+        patch("antfarm.core.cli.httpx.get") as mock_get,
+    ):
+        # First call: /missions/<id>
+        mission_resp = MagicMock()
+        mission_resp.status_code = 200
+        mission_resp.json.return_value = {
+            "mission_id": "m-1",
+            "status": "building",
+            "config": {
+                "max_cost_usd": 10.0,
+                "max_tokens": 50_000,
+                "completion_mode": "best_effort",
+            },
+            "task_ids": ["task-1"],
+        }
+        # Second call: /missions/<id>/usage
+        usage_resp = MagicMock()
+        usage_resp.status_code = 200
+        usage_resp.json.return_value = {
+            "mission_id": "m-1",
+            "total_cost_usd": 2.50,
+            "total_input_tokens": 1000,
+            "total_output_tokens": 500,
+            "per_task": {
+                "task-1": {"cost_usd": 2.50},
+            },
+        }
+        mock_get.side_effect = [mission_resp, usage_resp]
+
+        result = runner.invoke(
+            main,
+            ["mission", "status", "m-1", "--colony-url", "http://localhost:7433"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Budget:" in result.output
+        assert "$2.5000" in result.output or "$2.5" in result.output
+        assert "$10" in result.output
+        assert "Tokens:" in result.output
+        assert "1500" in result.output
+        assert "50000" in result.output
+        assert "Top spend" in result.output
+
+
+def test_mission_extend_command():
+    runner = CliRunner()
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "mission_id": "m-1",
+            "status": "building",
+            "config": {"max_cost_usd": 15.0, "max_tokens": 1500},
+        }
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission",
+                "extend",
+                "m-1",
+                "--additional-usd",
+                "10.0",
+                "--additional-tokens",
+                "500",
+                "--colony-url",
+                "http://localhost:7433",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        url = mock_post.call_args.args[0]
+        assert "/missions/m-1/extend" in url
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+        assert payload["additional_usd"] == 10.0
+        assert payload["additional_tokens"] == 500
+        assert "15.0" in result.output
+        assert "1500" in result.output

--- a/tests/test_mission_serve.py
+++ b/tests/test_mission_serve.py
@@ -403,3 +403,191 @@ def test_create_mission_rejects_github_backend(tmp_path):
     assert r.status_code == 400
     assert "FileBackend" in r.json()["detail"]
     assert "v0.6.0" in r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Usage / budget (v0.6.14 — issue #354)
+# ---------------------------------------------------------------------------
+
+
+def _register_worker(client, worker_id: str = "node-1/w-1"):
+    client.post("/nodes", json={"node_id": "node-1"})
+    client.post(
+        "/workers/register",
+        json={
+            "worker_id": worker_id,
+            "node_id": "node-1",
+            "agent_type": "claude-code",
+            "workspace_root": "/tmp/ws",
+        },
+    )
+
+
+def _carry_task_in_mission(
+    client,
+    mission_id: str = "mission-b1",
+    task_id: str = "task-001",
+):
+    _create_mission(client, mission_id=mission_id)
+    _carry(client, task_id=task_id, mission_id=mission_id)
+    # Patch status past planning so the task is not skipped.
+    client.patch(
+        f"/missions/{mission_id}",
+        json={"updates": {"status": "building"}},
+    )
+
+
+def test_post_worker_usage_attributes_to_current_attempt(client):
+    """POST /workers/{id}/usage attributes cost to the worker's active task."""
+    _create_mission(client, mission_id="mission-usg")
+    client.patch(
+        "/missions/mission-usg",
+        json={"updates": {"status": "building"}},
+    )
+    _carry(client, task_id="task-usg-1", mission_id="mission-usg")
+    _register_worker(client, worker_id="node-1/w-1")
+
+    # Worker forages to claim the task.
+    r = client.post("/tasks/pull", json={"worker_id": "node-1/w-1"})
+    assert r.status_code == 200
+    task = r.json()
+    attempt_id = task["current_attempt"]
+
+    # Report usage.
+    r = client.post(
+        "/workers/node-1/w-1/usage",
+        json={
+            "event_id": "e-1",
+            "ts": "2026-04-22T10:00:00Z",
+            "model": "claude-sonnet-4-7",
+            "input_tokens": 1_000_000,
+            "output_tokens": 0,
+            "source": "claude_stop_hook",
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["task_id"] == "task-usg-1"
+    assert body["mission_id"] == "mission-usg"
+    assert round(body["cost_usd"], 2) == 3.00
+    assert body["total_cost_usd"] > 0
+
+    # Usage is persisted against the mission.
+    usage = client.get("/missions/mission-usg/usage").json()
+    assert round(usage["total_cost_usd"], 2) == 3.00
+    assert usage["per_task"]["task-usg-1"]["top_attempt_id"] == attempt_id
+
+
+def test_post_worker_usage_is_idempotent(client):
+    """Duplicate event_id must not double-count."""
+    _create_mission(client, mission_id="mission-dedup")
+    client.patch(
+        "/missions/mission-dedup",
+        json={"updates": {"status": "building"}},
+    )
+    _carry(client, task_id="task-dedup-1", mission_id="mission-dedup")
+    _register_worker(client, worker_id="node-1/w-1")
+    client.post("/tasks/pull", json={"worker_id": "node-1/w-1"})
+
+    payload = {
+        "event_id": "e-dupe",
+        "ts": "2026-04-22T10:00:00Z",
+        "model": "claude-sonnet-4-7",
+        "input_tokens": 1_000_000,
+        "output_tokens": 0,
+        "source": "claude_stop_hook",
+    }
+    client.post("/workers/node-1/w-1/usage", json=payload)
+    client.post("/workers/node-1/w-1/usage", json=payload)
+    client.post("/workers/node-1/w-1/usage", json=payload)
+
+    usage = client.get("/missions/mission-dedup/usage").json()
+    assert usage["event_count"] == 1
+    assert round(usage["total_cost_usd"], 2) == 3.00
+
+
+def test_post_mission_extend_bumps_budget(client):
+    """POST /missions/{id}/extend bumps the budget."""
+    _create_mission(client, mission_id="mission-ext")
+    client.patch(
+        "/missions/mission-ext",
+        json={
+            "updates": {
+                "config": {
+                    "max_cost_usd": 5.0,
+                    "max_tokens": 1000,
+                    "budget_action": "pause",
+                }
+            }
+        },
+    )
+
+    r = client.post(
+        "/missions/mission-ext/extend",
+        json={"additional_usd": 10.0, "additional_tokens": 500},
+    )
+    assert r.status_code == 200
+    cfg = r.json()["config"]
+    assert cfg["max_cost_usd"] == 15.0
+    assert cfg["max_tokens"] == 1500
+
+
+def test_post_mission_extend_resumes_paused(client):
+    """extend resumes a mission paused by the tripwire."""
+    _create_mission(client, mission_id="mission-resume")
+    # Simulate the Queen marking it paused.
+    client.patch(
+        "/missions/mission-resume",
+        json={
+            "updates": {
+                "status": "paused",
+                "paused_from_status": "building",
+                "config": {
+                    "max_cost_usd": 1.0,
+                    "budget_action": "pause",
+                },
+            }
+        },
+    )
+    r = client.post(
+        "/missions/mission-resume/extend",
+        json={"additional_usd": 5.0},
+    )
+    assert r.status_code == 200
+    assert r.json()["status"] == "building"
+    assert r.json().get("paused_from_status") is None
+
+
+def test_forage_skips_paused_mission(client):
+    """/tasks/pull returns 204 when all eligible tasks belong to paused missions."""
+    _create_mission(client, mission_id="mission-paused")
+    client.patch(
+        "/missions/mission-paused",
+        json={"updates": {"status": "paused"}},
+    )
+    _carry(client, task_id="task-paused-1", mission_id="mission-paused")
+    _register_worker(client, worker_id="node-1/w-1")
+
+    r = client.post("/tasks/pull", json={"worker_id": "node-1/w-1"})
+    assert r.status_code == 204
+
+    # Task was returned to ready/ (reassign supersedes the attempt).
+    tasks = client.get("/tasks").json()
+    paused_task = next(t for t in tasks if t["id"] == "task-paused-1")
+    assert paused_task["status"] == "ready"
+
+
+def test_get_mission_usage_returns_dict(client):
+    """GET /missions/{id}/usage returns an empty usage dict when none recorded."""
+    _create_mission(client, mission_id="mission-empty")
+    r = client.get("/missions/mission-empty/usage")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["mission_id"] == "mission-empty"
+    assert body["total_cost_usd"] == 0.0
+    assert body["event_count"] == 0
+
+
+def test_get_mission_usage_missing_mission_returns_404(client):
+    r = client.get("/missions/nope/usage")
+    assert r.status_code == 404

--- a/tests/test_mission_usage.py
+++ b/tests/test_mission_usage.py
@@ -1,0 +1,129 @@
+"""Tests for MissionUsage aggregation and idempotency."""
+
+from __future__ import annotations
+
+from antfarm.core.missions import MissionUsage
+from antfarm.core.models import UsageEvent
+
+
+def _make_event(
+    event_id: str = "e-001",
+    task_id: str = "task-1",
+    attempt_id: str = "att-1",
+    cost: float = 0.25,
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+    ts: str = "2026-04-22T10:00:00Z",
+) -> UsageEvent:
+    return UsageEvent(
+        event_id=event_id,
+        worker_id="node-1/w-1",
+        task_id=task_id,
+        attempt_id=attempt_id,
+        mission_id="mission-x",
+        ts=ts,
+        model="claude-sonnet-4-7",
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_creation_tokens=cache_creation_tokens,
+        cost_usd=cost,
+        source="claude_stop_hook",
+    )
+
+
+# ---------------------------------------------------------------------------
+# apply
+# ---------------------------------------------------------------------------
+
+
+def test_apply_single_event_sets_totals_and_timestamps():
+    usage = MissionUsage(mission_id="mission-x")
+    event = _make_event(ts="2026-04-22T10:00:00Z")
+    usage.apply(event)
+
+    assert usage.total_cost_usd == 0.25
+    assert usage.total_input_tokens == 100
+    assert usage.total_output_tokens == 50
+    assert usage.event_count == 1
+    assert usage.first_event_at == "2026-04-22T10:00:00Z"
+    assert usage.last_event_at == "2026-04-22T10:00:00Z"
+    assert "task-1" in usage.per_task
+    assert usage.per_task["task-1"]["cost_usd"] == 0.25
+
+
+def test_apply_multiple_events_sum_per_task():
+    usage = MissionUsage(mission_id="mission-x")
+    usage.apply(_make_event(event_id="e-001", task_id="task-1", cost=0.10, input_tokens=10))
+    usage.apply(_make_event(event_id="e-002", task_id="task-1", cost=0.20, input_tokens=20))
+    usage.apply(_make_event(event_id="e-003", task_id="task-2", cost=0.05, input_tokens=5))
+
+    assert round(usage.total_cost_usd, 6) == 0.35
+    assert usage.total_input_tokens == 35
+    assert usage.event_count == 3
+    assert round(usage.per_task["task-1"]["cost_usd"], 6) == 0.30
+    assert round(usage.per_task["task-2"]["cost_usd"], 6) == 0.05
+
+
+def test_apply_is_idempotent_on_event_id():
+    usage = MissionUsage(mission_id="mission-x")
+    event = _make_event(event_id="dupe-1", cost=0.10, input_tokens=10)
+    usage.apply(event)
+    usage.apply(event)
+    usage.apply(event)
+    assert usage.event_count == 1
+    assert usage.total_cost_usd == 0.10
+    assert usage.total_input_tokens == 10
+
+
+def test_apply_tracks_first_and_last_timestamp():
+    usage = MissionUsage(mission_id="mission-x")
+    usage.apply(_make_event(event_id="e-1", ts="2026-04-22T10:00:00Z"))
+    usage.apply(_make_event(event_id="e-2", ts="2026-04-22T11:00:00Z"))
+    usage.apply(_make_event(event_id="e-3", ts="2026-04-22T12:00:00Z"))
+
+    assert usage.first_event_at == "2026-04-22T10:00:00Z"
+    assert usage.last_event_at == "2026-04-22T12:00:00Z"
+
+
+def test_top_attempt_tracked_per_task():
+    usage = MissionUsage(mission_id="mission-x")
+    # attempt A: 2 events summing to $0.30
+    usage.apply(_make_event(event_id="e-1", task_id="task-1", attempt_id="att-A", cost=0.10))
+    usage.apply(_make_event(event_id="e-2", task_id="task-1", attempt_id="att-A", cost=0.20))
+    # attempt B: one expensive event
+    usage.apply(_make_event(event_id="e-3", task_id="task-1", attempt_id="att-B", cost=0.50))
+    # attempt C: cheap
+    usage.apply(_make_event(event_id="e-4", task_id="task-1", attempt_id="att-C", cost=0.01))
+
+    bucket = usage.per_task["task-1"]
+    assert bucket["top_attempt_id"] == "att-B"
+    assert round(bucket["top_attempt_cost"], 6) == 0.50
+
+
+def test_roundtrip_to_and_from_dict():
+    usage = MissionUsage(mission_id="mission-x")
+    usage.apply(_make_event(event_id="e-1", cost=0.10))
+    usage.apply(_make_event(event_id="e-2", cost=0.20))
+
+    d = usage.to_dict()
+    restored = MissionUsage.from_dict(d)
+
+    assert restored.mission_id == usage.mission_id
+    assert round(restored.total_cost_usd, 6) == round(usage.total_cost_usd, 6)
+    assert restored.total_input_tokens == usage.total_input_tokens
+    assert restored.event_count == usage.event_count
+    assert restored.first_event_at == usage.first_event_at
+    assert restored.last_event_at == usage.last_event_at
+    assert restored.seen_event_ids == usage.seen_event_ids
+
+
+def test_apply_accepts_dict_form():
+    """apply() should accept either a UsageEvent or its to_dict() form."""
+    usage = MissionUsage(mission_id="mission-x")
+    event = _make_event(event_id="e-1", cost=0.25)
+    usage.apply(event.to_dict())
+    assert usage.event_count == 1
+    assert round(usage.total_cost_usd, 6) == 0.25

--- a/tests/test_missions_model.py
+++ b/tests/test_missions_model.py
@@ -274,3 +274,42 @@ def test_mission_report_defaults_auto_merge_counts_zero():
     report = _make_mission_report()
     assert report.auto_merged_tasks == 0
     assert report.manual_merged_tasks == 0
+
+
+# ---------------------------------------------------------------------------
+# Budget fields on MissionConfig (v0.6.14 — issue #354)
+# ---------------------------------------------------------------------------
+
+
+def test_mission_config_accepts_budget_fields():
+    cfg = MissionConfig(max_cost_usd=25.0, max_tokens=100_000, budget_action="cancel")
+    assert cfg.max_cost_usd == 25.0
+    assert cfg.max_tokens == 100_000
+    assert cfg.budget_action == "cancel"
+
+
+def test_mission_config_default_budget_action_is_pause():
+    cfg = MissionConfig()
+    assert cfg.budget_action == "pause"
+    assert cfg.max_cost_usd is None
+    assert cfg.max_tokens is None
+
+
+def test_mission_config_rejects_invalid_budget_action():
+    with pytest.raises(ValueError, match="budget_action must be one of"):
+        MissionConfig(budget_action="delete")
+
+
+def test_mission_config_round_trip_includes_budget_fields():
+    cfg = MissionConfig(max_cost_usd=5.5, max_tokens=42_000, budget_action="cancel")
+    d = cfg.to_dict()
+    assert d["max_cost_usd"] == 5.5
+    assert d["max_tokens"] == 42_000
+    assert d["budget_action"] == "cancel"
+
+    restored = MissionConfig.from_dict(d)
+    assert restored == cfg
+
+
+def test_mission_status_has_paused_value():
+    assert MissionStatus.PAUSED.value == "paused"

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,154 @@
+"""Tests for antfarm.core.pricing."""
+
+from __future__ import annotations
+
+import logging
+
+from antfarm.core import pricing
+from antfarm.core.pricing import (
+    DEFAULT_MODEL,
+    FALLBACK_RATES,
+    PRICES,
+    compute_cost,
+    resolve_model,
+)
+
+# ---------------------------------------------------------------------------
+# Price table sanity
+# ---------------------------------------------------------------------------
+
+
+def test_default_model_is_in_price_table():
+    assert DEFAULT_MODEL in PRICES
+
+
+def test_every_price_entry_has_all_rate_keys():
+    expected_keys = {"input", "output", "cache_read", "cache_creation"}
+    for key, rates in PRICES.items():
+        assert set(rates.keys()) == expected_keys, f"{key} missing rate keys"
+
+
+# ---------------------------------------------------------------------------
+# compute_cost
+# ---------------------------------------------------------------------------
+
+
+def test_sonnet_input_only_cost():
+    """1M input tokens on Sonnet should cost $3.00 exactly."""
+    cost = compute_cost(
+        model="claude-sonnet-4-7",
+        input_tokens=1_000_000,
+        output_tokens=0,
+    )
+    assert cost == 3.00
+
+
+def test_cache_read_cheaper_than_input():
+    sonnet = PRICES["claude-sonnet-4-7"]
+    assert sonnet["cache_read"] < sonnet["input"]
+
+    input_cost = compute_cost(
+        model="claude-sonnet-4-7",
+        input_tokens=1_000_000,
+        output_tokens=0,
+    )
+    cache_read_cost = compute_cost(
+        model="claude-sonnet-4-7",
+        input_tokens=0,
+        output_tokens=0,
+        cache_read_tokens=1_000_000,
+    )
+    assert cache_read_cost < input_cost
+
+
+def test_cache_creation_more_expensive_than_input():
+    sonnet = PRICES["claude-sonnet-4-7"]
+    assert sonnet["cache_creation"] > sonnet["input"]
+
+    input_cost = compute_cost(
+        model="claude-sonnet-4-7",
+        input_tokens=1_000_000,
+        output_tokens=0,
+    )
+    cache_creation_cost = compute_cost(
+        model="claude-sonnet-4-7",
+        input_tokens=0,
+        output_tokens=0,
+        cache_creation_tokens=1_000_000,
+    )
+    assert cache_creation_cost > input_cost
+
+
+def test_output_rate():
+    """1M output tokens on Sonnet should cost $15.00 exactly."""
+    cost = compute_cost(
+        model="claude-sonnet-4-6",
+        input_tokens=0,
+        output_tokens=1_000_000,
+    )
+    assert cost == 15.00
+
+
+def test_opus_costs_more_than_sonnet_for_same_tokens():
+    opus = compute_cost(model="claude-opus-4-7", input_tokens=1000, output_tokens=1000)
+    sonnet = compute_cost(model="claude-sonnet-4-7", input_tokens=1000, output_tokens=1000)
+    assert opus > sonnet
+
+
+def test_haiku_cheaper_than_sonnet():
+    sonnet = compute_cost(model="claude-sonnet-4-7", input_tokens=1000, output_tokens=1000)
+    haiku = compute_cost(model="claude-haiku-4-5", input_tokens=1000, output_tokens=1000)
+    assert haiku < sonnet
+
+
+def test_zero_tokens_zero_cost():
+    assert compute_cost(model="claude-sonnet-4-7", input_tokens=0, output_tokens=0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# resolve_model
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_model_prefix_match():
+    # Exact match
+    assert resolve_model("claude-sonnet-4-7") == "claude-sonnet-4-7"
+    # Longer suffix matches longest prefix (4-7 wins over 4-6)
+    assert resolve_model("claude-sonnet-4-7-1m") == "claude-sonnet-4-7"
+    # Case-insensitive
+    assert resolve_model("CLAUDE-SONNET-4-7") == "claude-sonnet-4-7"
+
+
+def test_resolve_model_distinguishes_families():
+    assert resolve_model("claude-opus-4-7") == "claude-opus-4-7"
+    assert resolve_model("claude-haiku-4-5") == "claude-haiku-4-5"
+
+
+def test_resolve_model_fallback_for_unknown_returns_empty():
+    assert resolve_model("gpt-4") == ""
+    assert resolve_model("") == ""
+
+
+def test_compute_cost_fallback_for_unknown_warns(caplog):
+    """Unknown model uses FALLBACK_RATES and logs a WARNING (once)."""
+    # Reset warned set to ensure this test sees the warning.
+    pricing._WARNED_MODELS.discard("mystery-model-v9")
+
+    with caplog.at_level(logging.WARNING, logger="antfarm.core.pricing"):
+        cost = compute_cost(
+            model="mystery-model-v9",
+            input_tokens=1_000_000,
+            output_tokens=0,
+        )
+    assert cost == FALLBACK_RATES["input"]
+    assert "mystery-model-v9" in caplog.text
+
+
+def test_compute_cost_unknown_warns_only_once(caplog):
+    pricing._WARNED_MODELS.discard("double-warn-test")
+    with caplog.at_level(logging.WARNING, logger="antfarm.core.pricing"):
+        compute_cost(model="double-warn-test", input_tokens=10, output_tokens=0)
+        compute_cost(model="double-warn-test", input_tokens=10, output_tokens=0)
+    # Count number of warnings referencing our model string
+    count = sum(1 for rec in caplog.records if "double-warn-test" in rec.getMessage())
+    assert count == 1

--- a/tests/test_queen.py
+++ b/tests/test_queen.py
@@ -1545,3 +1545,118 @@ def test_re_plan_task_spec_embeds_parallelism_directives(env):
     assert "MANY SMALL INDEPENDENT" in spec
     assert "3" in spec  # configured cap survives into the re-plan prompt
     assert "split more" in spec  # reviewer feedback preserved
+
+
+# ---------------------------------------------------------------------------
+# Budget tripwire (v0.6.14 — issue #354)
+# ---------------------------------------------------------------------------
+
+
+def _seed_usage(backend: FileBackend, mission_id: str, *, cost: float = 0.0, tokens: int = 0):
+    """Populate a MissionUsage sidecar for a mission."""
+
+    def _updater(current: dict) -> dict:
+        current["total_cost_usd"] = cost
+        current["total_input_tokens"] = tokens
+        current["total_output_tokens"] = 0
+        current["event_count"] = 1 if (cost or tokens) else 0
+        return current
+
+    backend.update_mission_usage(mission_id, _updater)
+
+
+def test_queen_pauses_mission_on_cost_budget(env):
+    backend = env["backend"]
+    queen = env["queen"]
+
+    mission = _create_mission(
+        backend,
+        mission_id="mission-budget-pause",
+        config_overrides={"max_cost_usd": 5.0, "budget_action": "pause"},
+    )
+    # Advance once so the mission has a plan_task and real status.
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)
+
+    _seed_usage(backend, mission["mission_id"], cost=6.50)
+
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)
+
+    m = backend.get_mission(mission["mission_id"])
+    assert m["status"] == "paused"
+    assert m.get("paused_from_status") == "planning"
+
+
+def test_queen_cancels_mission_on_token_budget(env):
+    backend = env["backend"]
+    queen = env["queen"]
+
+    mission = _create_mission(
+        backend,
+        mission_id="mission-budget-cancel",
+        config_overrides={"max_tokens": 1000, "budget_action": "cancel"},
+    )
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)
+
+    _seed_usage(backend, mission["mission_id"], tokens=2000)
+
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)
+
+    m = backend.get_mission(mission["mission_id"])
+    assert m["status"] == "cancelled"
+
+
+def test_queen_no_trip_when_budget_unset(env):
+    """Regression: mission with no budget never hits the tripwire."""
+    backend = env["backend"]
+    queen = env["queen"]
+
+    mission = _create_mission(backend, mission_id="mission-no-budget")
+    # Dump an absurdly large usage record — no budget means no pause.
+    _seed_usage(backend, mission["mission_id"], cost=999_999.99, tokens=999_999)
+
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)
+
+    m = backend.get_mission(mission["mission_id"])
+    assert m["status"] not in ("paused", "cancelled")
+
+
+def test_queen_resume_after_extend_flips_back_to_building(env):
+    """When a paused mission's budget is extended, Queen should not re-pause it."""
+    backend = env["backend"]
+    queen = env["queen"]
+
+    mission = _create_mission(
+        backend,
+        mission_id="mission-resume-flow",
+        config_overrides={"max_cost_usd": 5.0, "budget_action": "pause"},
+    )
+    # Move mission past planning so paused_from_status is meaningful
+    backend.update_mission(mission["mission_id"], {"status": "building"})
+
+    _seed_usage(backend, mission["mission_id"], cost=6.00)
+
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)
+    m = backend.get_mission(mission["mission_id"])
+    assert m["status"] == "paused"
+    assert m.get("paused_from_status") == "building"
+
+    # Operator bumps the cap and flips status back to building (as HTTP does).
+    backend.update_mission(
+        mission["mission_id"],
+        {
+            "status": "building",
+            "paused_from_status": None,
+            "config": {**m["config"], "max_cost_usd": 100.0},
+        },
+    )
+
+    m = backend.get_mission(mission["mission_id"])
+    queen._advance(m)
+    m = backend.get_mission(mission["mission_id"])
+    assert m["status"] == "building"


### PR DESCRIPTION
## Summary
- Adds a mission budget tripwire. `MissionConfig` now accepts `max_cost_usd`, `max_tokens`, and `budget_action` (`pause` | `cancel`). Queen trips over the limit on every tick before status dispatch.
- Claude Code `Stop` hook reports per-session usage to the colony, which computes cost from a pricing table keyed by model prefix (Sonnet / Opus / Haiku tiers) and aggregates per mission in a `.antfarm/missions/<id>_usage.json` sidecar.
- CLI: `mission create --max-cost-usd / --max-tokens / --budget-action`, new `mission extend` subcommand, and a budget block in `mission status`. `antfarm inbox` surfaces `mission_budget_exceeded` findings.

## Key design points
- Cost computed centrally in `antfarm/core/pricing.py`; the Stop hook reports raw token counts only. `input_tokens` is treated as disjoint from cache fields (Claude's wire format).
- `MissionUsage.apply()` is idempotent by `event_id` via a bounded FIFO (cap 1000), so retried Stop hooks don't double-count.
- `update_mission_usage` is a read-modify-write under `FileBackend._lock`. `GitHubBackend` raises `NotImplementedError` per plan.
- `/tasks/pull` skips tasks whose mission is paused/cancelled by reassigning them back to ready — avoids wedging claims on a paused mission without making the scheduler mission-aware.
- Queen event `mission_budget_exceeded` fires once per breach (short-circuits on already-paused missions).

## Test plan
- [x] `pytest tests/ -x -q` — 1289 passed
- [x] `ruff check antfarm/ tests/` — clean
- [x] `ruff format --check` on modified files — clean
- [x] New coverage:
  - `tests/test_pricing.py` — rate table + resolve_model prefix match + unknown-model fallback + single-warning
  - `tests/test_mission_usage.py` — apply single/multiple, idempotency, top-attempt tracking, round-trip, dict form
  - `tests/test_missions_model.py` — budget fields accepted, invalid `budget_action` rejected, round-trip
  - `tests/test_mission_backend.py` — `get_mission_usage` None, `update_mission_usage` RMW + concurrent serialization + GitHub stub
  - `tests/test_mission_serve.py` — `/workers/{id}/usage` attribution + idempotency; `/missions/{id}/extend` bumps budget + resumes paused; `/tasks/pull` skips paused missions; `GET /missions/{id}/usage`
  - `tests/test_queen.py` — pause on cost, cancel on tokens, no trip without budget, resume after extend
  - `tests/test_mission_cli.py` — `--max-cost-usd` flag, `mission extend` command, `mission status` budget block

🤖 Generated with [Claude Code](https://claude.com/claude-code)