### PR TITLE
feat(tui,worker): natural-language Activity column for workers + soldier + doctor

### DIFF
--- a/antfarm/adapters/claude_code/hooks/post_tool.sh
+++ b/antfarm/adapters/claude_code/hooks/post_tool.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
-# PostToolUse hook: clear worker activity.
-# Claude Code fires pre/post hooks per top-level tool use, serially.
-# Nested operations happen inside the tool process and do not re-fire hooks,
-# so we don't need to worry about clearing too early.
+# PostToolUse hook: set worker activity to "awaiting claude response".
+# Claude Code fires pre/post hooks per top-level tool use, serially. Nested
+# operations happen inside the tool process and do not re-fire hooks, so we
+# don't need to worry about clearing too early.
+#
+# Previously this posted action=null (clear). We now post a canonical
+# "awaiting" verb so the TUI shows a useful state between tool calls
+# instead of a blank em-dash (#348).
 set -u
 : "${ANTFARM_URL:?}"
 : "${WORKER_ID:?}"
 
 curl -s -m 1 "$ANTFARM_URL/workers/$WORKER_ID/activity" \
-  -X POST -H "Content-Type: application/json" -d '{"action": null}' || true
+  -X POST -H "Content-Type: application/json" \
+  -d '{"action":"awaiting","target":"","source":"hook"}' || true

--- a/antfarm/adapters/claude_code/hooks/pre_tool.sh
+++ b/antfarm/adapters/claude_code/hooks/pre_tool.sh
@@ -1,26 +1,79 @@
 #!/usr/bin/env bash
-# PreToolUse hook: post worker activity before each tool call.
+# PreToolUse hook: post structured worker activity before each tool call.
 # Claude Code delivers hook context as JSON on stdin.
 # See: https://docs.claude.ai/en/docs/claude-code/hooks (PreToolUse)
+#
+# Emits {action, target, source:"hook"} so the colony server can synthesize
+# a human-readable line like "editing src/foo.py" or "running pytest -x"
+# and store it in the worker's current_action field (#348).
+#
+# Graceful fallback: without jq, action/target stay empty and the server
+# clamps to sensible defaults. curl with || true ensures the hook never fails.
 set -u
 : "${ANTFARM_URL:?}"
 : "${WORKER_ID:?}"
 
-# Read stdin (may be empty if invoked outside a hook context — fallback to "tool")
-INPUT=$(cat 2>/dev/null || echo "")
-if command -v jq >/dev/null 2>&1 && [ -n "$INPUT" ]; then
-  TOOL_NAME=$(printf '%s' "$INPUT" | jq -r '.tool_name // "tool"' 2>/dev/null || echo "tool")
-else
-  TOOL_NAME="tool"
-fi
-ACTION="Running: $TOOL_NAME"
+HOOK_INPUT=$(cat 2>/dev/null || echo "")
 
-# Use jq to build a safely-quoted JSON payload.
+ACTION=""
+TARGET=""
+if command -v jq >/dev/null 2>&1 && [ -n "$HOOK_INPUT" ]; then
+  TOOL_NAME=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
+  case "$TOOL_NAME" in
+    Edit|Write)
+      TARGET=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null || echo "")
+      ACTION=editing
+      ;;
+    Read)
+      TARGET=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null || echo "")
+      ACTION=reading
+      ;;
+    Bash)
+      # First three space-separated tokens of the command — enough to show
+      # what's running without leaking args/secrets.
+      TARGET=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.command // "" | split(" ") | .[0:3] | join(" ")' 2>/dev/null || echo "")
+      ACTION=running
+      ;;
+    WebFetch)
+      TARGET=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.url // ""' 2>/dev/null || echo "")
+      ACTION=searching
+      ;;
+    WebSearch)
+      TARGET=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.query // ""' 2>/dev/null || echo "")
+      ACTION=searching
+      ;;
+    Glob|Grep)
+      TARGET=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.pattern // .tool_input.path // ""' 2>/dev/null || echo "")
+      ACTION=scanning
+      ;;
+    TodoWrite)
+      TARGET=""
+      ACTION=planning
+      ;;
+    "")
+      ACTION=tool
+      ;;
+    *)
+      # Unknown verb: lowercased tool name; server falls through to
+      # freeform "<action> <target>" synthesis.
+      ACTION=$(printf '%s' "$TOOL_NAME" | tr '[:upper:]' '[:lower:]')
+      TARGET=""
+      ;;
+  esac
+fi
+
+# Trim target to 60 chars so the payload stays tiny; server also truncates.
+if [ -n "$TARGET" ] && [ "${#TARGET}" -gt 60 ]; then
+  TARGET="${TARGET:0:60}"
+fi
+
+# Build JSON payload safely when jq is available; fall back to best-effort
+# shell quoting otherwise. Tool names and tokens are alphanumeric in practice.
 if command -v jq >/dev/null 2>&1; then
-  PAYLOAD=$(jq -nc --arg a "$ACTION" '{action:$a}')
+  PAYLOAD=$(jq -nc --arg a "$ACTION" --arg t "$TARGET" \
+    '{action:$a, target:$t, source:"hook"}')
 else
-  # Fallback: best-effort shell-quoted JSON (tool names are alphanumeric in practice).
-  PAYLOAD="{\"action\": \"$ACTION\"}"
+  PAYLOAD="{\"action\":\"$ACTION\",\"target\":\"$TARGET\",\"source\":\"hook\"}"
 fi
 
 curl -s -m 1 "$ANTFARM_URL/workers/$WORKER_ID/activity" \

--- a/antfarm/adapters/generic/README.md
+++ b/antfarm/adapters/generic/README.md
@@ -100,6 +100,42 @@ curl -s "$ANTFARM_URL/workers/$WORKER_ID" -X DELETE
 Always deregister on clean shutdown so the worker slot is freed immediately
 rather than waiting for heartbeat timeout.
 
+## Reporting activity
+
+The activity endpoint accepts a structured `{action, target}` pair that the
+colony synthesizes into a human-readable line for the TUI's Activity column
+(#348). It's optional — agents that only send heartbeats still work.
+
+```bash
+curl -s -m 1 "$ANTFARM_URL/workers/$WORKER_ID/activity" -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"action":"running","target":"pytest -x","source":"worker"}' || true
+```
+
+Canonical verbs the server knows how to format:
+
+| Verb | Rendered as |
+|------|-------------|
+| `editing` | `editing <target>` |
+| `reading` | `reading <target>` |
+| `running` | `running <target>` |
+| `searching` | `searching <target>` |
+| `scanning` | `scanning <target>` |
+| `planning` | `planning` (target ignored) |
+| `awaiting` | `awaiting claude response` (target ignored) |
+| `rebasing` | `rebasing <target>` |
+| `merging` | `merging <target>` |
+| `running_tests` | `running tests (<target>)` |
+| `fast_forwarding` | `fast-forwarding <target>` |
+| `pushing` | `pushing <target>` |
+| `fetching` | `fetching <target>` |
+| `cleanup` | `cleanup` |
+| `polling` | `polling` |
+| `idle` | `idle` |
+
+Unknown verbs fall through to `"<action> <target>"`. Pass `{"action": null}`
+to clear the activity cell. Targets longer than 60 chars are truncated.
+
 ## Optional telemetry payload
 
 The heartbeat endpoint accepts an optional `status` dict for telemetry:

--- a/antfarm/core/activity.py
+++ b/antfarm/core/activity.py
@@ -1,0 +1,101 @@
+"""Activity text synthesis for the TUI Activity column.
+
+Pure module — no server or IO dependencies. Converts a structured
+``(action, target)`` pair (typically posted by a Claude Code PreToolUse hook,
+the Soldier, or the Doctor) into a short human-readable line suitable for the
+``current_action`` field on a worker record and the Activity cell in the TUI.
+
+The server synthesizes the text and stores it in the existing
+``current_action`` field, so everything downstream (``doctor.check_stuck_workers``,
+the Activity column, legacy API clients) continues to work unchanged.
+"""
+
+from __future__ import annotations
+
+# Canonical verb → template mapping. ``{target}`` is filled in when present.
+# A verb without ``{target}`` deliberately ignores whatever target the caller
+# supplies (e.g. ``planning``, ``awaiting``) — the template is the full line.
+VERB_TEMPLATES: dict[str, str] = {
+    "editing": "editing {target}",
+    "reading": "reading {target}",
+    "running": "running {target}",
+    "searching": "searching {target}",
+    "scanning": "scanning {target}",
+    "planning": "planning",
+    "awaiting": "awaiting claude response",
+    "rebasing": "rebasing {target}",
+    "merging": "merging {target}",
+    "running_tests": "running tests ({target})",
+    "fast_forwarding": "fast-forwarding {target}",
+    "pushing": "pushing {target}",
+    "fetching": "fetching {target}",
+    "cleanup": "cleanup",
+    "polling": "polling",
+    "idle": "idle",
+}
+
+# Claude Code tool name → canonical verb mapping for the PreToolUse hook.
+_TOOL_VERBS: dict[str, str] = {
+    "Edit": "editing",
+    "Write": "editing",
+    "Read": "reading",
+    "Bash": "running",
+    "WebFetch": "searching",
+    "WebSearch": "searching",
+    "Glob": "scanning",
+    "Grep": "scanning",
+    "TodoWrite": "planning",
+}
+
+_TARGET_MAX = 60
+
+
+def _truncate_target(target: str) -> str:
+    """Trim ``target`` to ``_TARGET_MAX`` chars with an ellipsis suffix."""
+    if len(target) <= _TARGET_MAX:
+        return target
+    # 57 + "..." = 60. Keeps the cell readable in the TUI.
+    return target[: _TARGET_MAX - 3] + "..."
+
+
+def synthesize_text(action: str | None, target: str | None) -> str | None:
+    """Return a human-readable activity line or None when both inputs are empty.
+
+    Args:
+        action: Canonical verb (e.g. ``"editing"``) or free-form string for
+            unknown verbs. Falsy values (None, empty string) are treated as
+            "no action".
+        target: Optional target associated with the action (file path, branch,
+            command). Falsy values are treated as "no target".
+
+    Returns:
+        A short line suitable for the ``current_action`` field, or None when
+        both ``action`` and ``target`` are falsy.
+    """
+    action_s = (action or "").strip()
+    target_s = (target or "").strip()
+    if not action_s and not target_s:
+        return None
+
+    if action_s in VERB_TEMPLATES:
+        template = VERB_TEMPLATES[action_s]
+        if "{target}" in template:
+            return template.format(target=_truncate_target(target_s))
+        return template
+
+    # Unknown verb: fall back to "<action> <target>". Either half may be empty.
+    if action_s and target_s:
+        return f"{action_s} {_truncate_target(target_s)}"
+    return action_s or _truncate_target(target_s)
+
+
+def tool_to_verb(tool_name: str) -> str:
+    """Map a Claude Code tool name to a canonical verb.
+
+    Unknown tool names fall back to their lowercased form; empty/missing names
+    map to ``"tool"`` so the PreToolUse hook always has something to emit.
+    """
+    name = (tool_name or "").strip()
+    if not name:
+        return "tool"
+    return _TOOL_VERBS.get(name, name.lower())

--- a/antfarm/core/doctor.py
+++ b/antfarm/core/doctor.py
@@ -53,6 +53,23 @@ class Finding:
     fixed: bool = False
 
 
+def _set_doctor_activity(action: str, target: str = "") -> None:
+    """Publish doctor phase activity to the colony for the TUI (#348).
+
+    Lazy-imports ``_set_colony_activity``. Best-effort: ANY failure is
+    swallowed — a broken TUI sidecar must never break doctor checks.
+    """
+    try:
+        from antfarm.core.serve import _set_colony_activity
+    except Exception:
+        logger.debug("doctor _set_doctor_activity: could not import helper", exc_info=True)
+        return
+    try:
+        _set_colony_activity("doctor", action, target)
+    except Exception:
+        logger.debug("doctor _set_doctor_activity(%s) raised", action, exc_info=True)
+
+
 def run_doctor(
     backend,
     config: dict,
@@ -87,28 +104,41 @@ def run_doctor(
     """
     findings: list[Finding] = []
 
+    _set_doctor_activity("scanning", "filesystem")
     findings.extend(check_filesystem(config, fix))
+    _set_doctor_activity("scanning", "colony")
     findings.extend(check_colony_reachable(config))
+    _set_doctor_activity("scanning", "git")
     findings.extend(check_git_config())
+    _set_doctor_activity("scanning", "workers")
     findings.extend(check_stale_workers(backend, config, fix))
     findings.extend(check_stuck_workers(backend, config, fix))
+    _set_doctor_activity("scanning", "tasks")
     findings.extend(check_stale_tasks(backend, config, fix))
     findings.extend(check_retry_patterns(backend, config))
+    _set_doctor_activity("scanning", "review_queue")
     findings.extend(check_review_queue_saturated(backend, config))
     findings.extend(check_no_reviewer_capacity(backend, config))
+    _set_doctor_activity("scanning", "guards")
     findings.extend(check_stale_guards(backend, config, fix))
+    _set_doctor_activity("scanning", "workspaces")
     findings.extend(check_workspace_conflicts(backend))
     findings.extend(check_orphan_workspaces(config, fix))
+    _set_doctor_activity("scanning", "worktrees")
     findings.extend(check_stale_worktrees(backend, config, fix=fix, keep_worktrees=keep_worktrees))
+    _set_doctor_activity("scanning", "state")
     findings.extend(check_state_consistency(backend))
     findings.extend(check_dependency_cycles(backend))
+    _set_doctor_activity("scanning", "runners")
     findings.extend(check_runner_health(backend, config))
+    _set_doctor_activity("scanning", "tmux")
     findings.extend(check_tmux_available(config))
     findings.extend(check_orphan_tmux_sessions(config, fix))
 
     if sweep_legacy_tmux:
         findings.extend(sweep_legacy_tmux_sessions(config, confirmed=True))
 
+    _set_doctor_activity("idle", "")
     return findings
 
 

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -24,6 +24,7 @@ from fastapi import FastAPI, HTTPException, Query, Response
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
+from antfarm.core import activity
 from antfarm.core.backends.base import TaskBackend
 
 logger = logging.getLogger(__name__)
@@ -41,6 +42,15 @@ _autoscaler_thread: threading.Thread | None = None
 _autoscaler_status: str = "not started"
 _autoscaler_instance = None
 
+# Activity state for the soldier and doctor (synthetic TUI rows — #348).
+# These live on the server (not in the backend) because the soldier/doctor run
+# in-process as threads alongside the FastAPI app. The TUI surfaces them via
+# /status/full. Appends are guarded by _colony_activity_lock so readers never
+# observe a partially-mutated dict.
+_colony_activity_lock = threading.Lock()
+_soldier_activity: dict = {"action": None, "target": None, "text": None, "since": None}
+_doctor_activity: dict = {"action": None, "target": None, "text": None, "since": None}
+
 # SSE event bus
 _event_queue: collections.deque = collections.deque(maxlen=1000)
 _event_counter: int = 0
@@ -55,6 +65,39 @@ _server_epoch: str = str(uuid.uuid4())
 
 def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
+
+
+def _set_colony_activity(kind: str, action: str, target: str = "") -> None:
+    """Update the soldier/doctor synthetic activity rows (#348).
+
+    Intended to be called from ``antfarm.core.soldier`` and
+    ``antfarm.core.doctor`` via a lazy import to avoid circular imports at
+    module-load time (serve.py imports soldier/doctor indirectly).
+
+    Best-effort: any failure is swallowed so merge/check logic never breaks
+    because the TUI sidecar is unhappy.
+
+    Args:
+        kind: "soldier" or "doctor". Unknown kinds are ignored.
+        action: Canonical verb (see ``activity.VERB_TEMPLATES``).
+        target: Optional target; truncated by the synthesizer.
+    """
+    try:
+        text = activity.synthesize_text(action, target)
+        since = _now_iso()
+        with _colony_activity_lock:
+            if kind == "soldier":
+                _soldier_activity["action"] = action
+                _soldier_activity["target"] = target
+                _soldier_activity["text"] = text
+                _soldier_activity["since"] = since
+            elif kind == "doctor":
+                _doctor_activity["action"] = action
+                _doctor_activity["target"] = target
+                _doctor_activity["text"] = text
+                _doctor_activity["since"] = since
+    except Exception:
+        logger.debug("_set_colony_activity(%s) failed", kind, exc_info=True)
 
 
 def _emit_event(event_type: str, task_id: str, detail: str = "", actor: str = "colony") -> None:
@@ -328,6 +371,9 @@ class HeartbeatRequest(BaseModel):
 
 class ActivityRequest(BaseModel):
     action: str | None = None
+    target: str | None = None
+    source: str | None = None  # "hook" | "soldier" | "doctor"
+    text: str | None = None  # caller-provided; server synthesizes if absent
 
 
 class PullRequest(BaseModel):
@@ -629,10 +675,27 @@ def get_app(
     def worker_activity(worker_id: str, req: ActivityRequest):
         """Set or clear the worker's current action.
 
+        Accepts either a freeform ``action`` string (legacy) or a structured
+        ``{action, target}`` pair that the server synthesizes into a
+        human-readable line (#348). Callers may also pre-compute ``text`` and
+        pass it verbatim. Clearing is still done via ``action=null``.
+
         Does not update last_heartbeat — activity is a separate signal. Unknown
         workers are a silent no-op at the backend layer.
         """
-        _backend.update_worker_activity(worker_id, req.action)
+        # Resolution order: explicit text → synthesize(action, target) →
+        # legacy action-as-text → None (clear).
+        if req.text is not None:
+            resolved: str | None = req.text
+        elif req.action is None and req.target is None:
+            resolved = None
+        else:
+            synthesized = activity.synthesize_text(req.action, req.target)
+            # Back-compat: if neither verb is canonical nor a target is set,
+            # ``synthesize_text`` returns the raw action string — preserves
+            # prior behavior for freeform callers like legacy hooks.
+            resolved = synthesized if synthesized is not None else req.action
+        _backend.update_worker_activity(worker_id, resolved)
         return {"ok": True}
 
     @app.get("/workers", status_code=200)
@@ -1435,6 +1498,12 @@ def get_app(
             missions = _backend.list_missions()
         except NotImplementedError:
             missions = []
+        # Copy soldier/doctor activity dicts under the lock so the TUI can
+        # render them as synthetic rows (#348). Copies are shallow but all
+        # values are primitives, so this is safe.
+        with _colony_activity_lock:
+            soldier_activity = dict(_soldier_activity)
+            doctor_activity = dict(_doctor_activity)
         return {
             "status": _backend.status(),
             "tasks": _backend.list_tasks(),
@@ -1444,6 +1513,8 @@ def get_app(
             "doctor": _doctor_status,
             "queen": _queen_status,
             "autoscaler": _autoscaler_status,
+            "soldier_activity": soldier_activity,
+            "doctor_activity": doctor_activity,
             "warnings": _compute_status_warnings(_backend),
         }
 

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -165,6 +165,24 @@ def _emit(event_type: str, task_id: str, detail: str = "") -> None:
         logger.debug("soldier _emit: _emit_event(%s) raised", event_type, exc_info=True)
 
 
+def _set_activity(action: str, target: str = "") -> None:
+    """Publish soldier phase activity to the colony (#348).
+
+    Lazy-imports ``_set_colony_activity`` to avoid a circular import at module
+    load time. Best-effort: ANY failure inside the publish pipeline is
+    swallowed. The soldier must never break because the TUI sidecar is unhappy.
+    """
+    try:
+        from antfarm.core.serve import _set_colony_activity
+    except Exception:
+        logger.debug("soldier _set_activity: could not import helper", exc_info=True)
+        return
+    try:
+        _set_colony_activity("soldier", action, target)
+    except Exception:
+        logger.debug("soldier _set_activity(%s) raised", action, exc_info=True)
+
+
 def _stderr_tail(stderr_bytes: bytes, n: int = 20) -> str:
     """Return the last ``n`` lines of decoded stderr bytes.
 
@@ -257,6 +275,7 @@ class Soldier:
         """
         self._run_preflight_if_needed()
         while True:
+            _set_activity("polling", "")
             if self.require_review:
                 self.run_once_with_review()
             else:
@@ -712,6 +731,7 @@ class Soldier:
             )
             return MergeResult.FAILED
 
+        _set_activity("merging", task_id)
         # Canonical diagnostic event (new in 0.6.7).
         attempt_detail = f"attempt={attempt_id} branch={branch}"
         _emit("merge_attempted", task_id, attempt_detail)
@@ -738,6 +758,7 @@ class Soldier:
         temp_branch = "antfarm/temp-merge"
         try:
             # Fetch latest state from origin
+            _set_activity("fetching", "origin")
             r = subprocess.run(
                 ["git", "fetch", "origin"],
                 cwd=self.repo_path,
@@ -754,6 +775,7 @@ class Soldier:
                 return MergeResult.FAILED
 
             # Create temp branch from integration branch
+            _set_activity("rebasing", task_id)
             r = self._checkout_with_reclaim(
                 [
                     "checkout",
@@ -797,6 +819,7 @@ class Soldier:
                 )
 
             # Run tests
+            _set_activity("running_tests", task_id)
             r = subprocess.run(
                 self.test_command,
                 cwd=self.repo_path,
@@ -819,6 +842,7 @@ class Soldier:
                 return MergeResult.FAILED
 
             # Fast-forward integration branch
+            _set_activity("fast_forwarding", self.integration_branch)
             r = self._checkout_with_reclaim(["checkout", self.integration_branch])
             if r.returncode != 0:
                 self.last_failure_reason = (
@@ -847,6 +871,7 @@ class Soldier:
                 return MergeResult.FAILED
 
             # Push to origin
+            _set_activity("pushing", self.integration_branch)
             r = subprocess.run(
                 ["git", "push", "origin", self.integration_branch],
                 cwd=self.repo_path,
@@ -995,6 +1020,7 @@ class Soldier:
         Returns a definitive ``MergeResult`` — the caller must not re-attempt.
         """
         del initial_conflict_stderr  # captured for debugging; reason set below.
+        _set_activity("rebasing", f"{task_id} onto {self.integration_branch}")
 
         # 1) Abort the conflicting merge so we can move off temp_branch cleanly.
         subprocess.run(
@@ -1456,6 +1482,7 @@ class Soldier:
         - No temp branch
         - Clean working tree matching origin/{integration_branch}
         """
+        _set_activity("cleanup", "")
         # 1) Hard reset first — wipes conflict state / partial merge.
         subprocess.run(
             ["git", "reset", "--hard", "HEAD"],
@@ -1537,6 +1564,7 @@ class Soldier:
             detail = f"branch={head} dirty={dirty}"
             _emit("cleanup_incomplete", "", detail)
             logger.error("soldier cleanup incomplete: %s", detail)
+        _set_activity("idle", "")
 
     def _get_attempt_branch(self, task: dict) -> str | None:
         """Extract the branch from the task's current attempt.

--- a/antfarm/core/tui.py
+++ b/antfarm/core/tui.py
@@ -197,6 +197,8 @@ class AntfarmTUI:
             tasks = full.get("tasks", [])
             workers = full.get("workers", [])
             soldier_status = full.get("soldier", "unknown")
+            soldier_activity = full.get("soldier_activity") or None
+            doctor_activity = full.get("doctor_activity") or None
         except httpx.ConnectError:
             layout = Layout()
             msg = (
@@ -224,10 +226,13 @@ class AntfarmTUI:
         layout = Layout()
         missions_size = max(5, min(len(missions) + 4, 10)) if missions else 5
         warnings_size = len(snap.warnings) + 2 if snap.warnings else 0
+        # Workers panel grows by 1 when the doctor synthetic row is present
+        # (the soldier row is already budgeted into the +5 headroom).
+        doctor_row_extra = 1 if doctor_activity else 0
         column_slices = [
             Layout(name="header", size=10),
             Layout(name="missions", size=missions_size),
-            Layout(name="workers", size=max(5, len(workers) + 5)),
+            Layout(name="workers", size=max(5, len(workers) + 5 + doctor_row_extra)),
             Layout(name="waiting", size=7),
             Layout(name="planning", size=5),
             Layout(name="building", size=6),
@@ -287,10 +292,19 @@ class AntfarmTUI:
             )
         )
 
-        worker_count = len(workers) + (1 if soldier_status != "disabled" else 0)
+        worker_count = (
+            len(workers)
+            + (1 if soldier_status != "disabled" else 0)
+            + (1 if doctor_activity else 0)
+        )
         layout["workers"].update(
             Panel(
-                self._render_workers(workers, soldier_status),
+                self._render_workers(
+                    workers,
+                    soldier_status,
+                    soldier_activity=soldier_activity,
+                    doctor_activity=doctor_activity,
+                ),
                 title=f"[bold cyan]Workers ({worker_count})[/bold cyan]",
             )
         )
@@ -1042,33 +1056,76 @@ class AntfarmTUI:
             return "reviewer"
         return "builder"
 
-    def _format_activity_cell(self, worker: dict, stuck_ttl: int = 300) -> Text:
-        """Format the Activity column cell for a worker row.
+    def _format_activity_cell(
+        self,
+        current_action: str | dict | None,
+        current_action_at: str | None = None,
+        now: datetime | None = None,
+        fresh_ttl: int = 30,
+        warn_ttl: int = 90,
+        stuck_ttl: int = 300,
+    ) -> Text:
+        """Format the Activity column cell.
 
-        Returns a Rich Text object rendering '<action[:40]> (<N>s)' when the
-        worker has a current_action, dim em-dash when it does not, and red
-        when the elapsed time exceeds stuck_ttl.
+        Renders ``<action[:40]> (<N>s)`` when an action is present, or a dim
+        em-dash when it is absent. Color bands follow elapsed seconds:
+
+        - ``< fresh_ttl`` (default 30s): green — actively working
+        - ``< warn_ttl`` (default 90s): default (no style) — normal
+        - ``< stuck_ttl`` (default 300s): yellow — slow/stalling
+        - ``>= stuck_ttl``: red — likely stuck; matches
+          ``doctor.check_stuck_workers`` TTL
+
+        Back-compat: the first arg still accepts a worker dict for existing
+        callers. When a dict is passed, ``current_action`` and
+        ``current_action_at`` are read from its keys.
         """
-        action = worker.get("current_action")
-        action_at = worker.get("current_action_at")
-        if not action or not action_at:
+        # Back-compat shim: dict form resolves both fields from keys.
+        if isinstance(current_action, dict):
+            worker = current_action
+            current_action = worker.get("current_action")
+            current_action_at = worker.get("current_action_at")
+
+        if not current_action or not current_action_at:
             return Text("—", style="dim")
 
+        now = now or datetime.now(UTC)
         try:
-            start = datetime.fromisoformat(action_at)
+            start = datetime.fromisoformat(current_action_at)
             if start.tzinfo is None:
                 start = start.replace(tzinfo=UTC)
-            elapsed = int((datetime.now(UTC) - start).total_seconds())
+            elapsed = int((now - start).total_seconds())
         except (ValueError, TypeError):
-            return Text(str(action)[:40], style="dim")
+            return Text(str(current_action)[:40], style="dim")
 
-        truncated = action[:40]
+        truncated = str(current_action)[:40]
         label = f"{truncated} ({elapsed}s)"
-        style = "red" if elapsed > stuck_ttl else ""
+        if elapsed < fresh_ttl:
+            style = "green"
+        elif elapsed < warn_ttl:
+            style = ""
+        elif elapsed < stuck_ttl:
+            style = "yellow"
+        else:
+            style = "red"
         return Text(label, style=style)
 
-    def _render_workers(self, workers: list, soldier_status: str = "unknown") -> Table:
-        """Render worker list with type column, including Soldier."""
+    def _render_workers(
+        self,
+        workers: list,
+        soldier_status: str = "unknown",
+        soldier_activity: dict | None = None,
+        doctor_activity: dict | None = None,
+    ) -> Table:
+        """Render worker list with type column, including Soldier and Doctor.
+
+        ``soldier_activity`` and ``doctor_activity`` are the per-subsystem
+        activity dicts returned by ``/status/full`` (see
+        ``serve._set_colony_activity``). When present, their ``text`` and
+        ``since`` fields drive the Activity cell for the synthetic row. The
+        doctor row is only rendered when ``doctor_activity`` is provided —
+        absent activity implies the doctor thread is disabled.
+        """
         table = Table(show_header=True, header_style="bold", box=None, padding=(0, 1))
         table.add_column("Worker", max_width=22, no_wrap=True)
         table.add_column("Node", max_width=15, no_wrap=True)
@@ -1080,16 +1137,34 @@ class AntfarmTUI:
         # Soldier row (virtual — it's a thread, not a registered worker)
         if soldier_status != "disabled":
             s_style = "green" if soldier_status == "running" else "yellow"
+            sa = soldier_activity or {}
+            s_activity_cell = self._format_activity_cell(sa.get("text"), sa.get("since"))
             table.add_row(
                 Text("soldier", style="bold"),
                 Text("colony", style="dim"),
                 Text(soldier_status, style=s_style),
                 Text("soldier", style="bold"),
-                Text("—", style="dim"),
+                s_activity_cell,
                 Text("—", style="dim"),
             )
 
-        if not workers and soldier_status == "disabled":
+        # Doctor row (virtual — same pattern as soldier). Only shown when
+        # activity is available; callers that don't run a doctor thread
+        # simply pass None.
+        if doctor_activity:
+            d_activity_cell = self._format_activity_cell(
+                doctor_activity.get("text"), doctor_activity.get("since")
+            )
+            table.add_row(
+                Text("doctor", style="bold"),
+                Text("colony", style="dim"),
+                Text("running", style="green"),
+                Text("doctor", style="bold"),
+                d_activity_cell,
+                Text("—", style="dim"),
+            )
+
+        if not workers and soldier_status == "disabled" and not doctor_activity:
             table.add_row("[dim]\u2014[/dim]", "[dim]no workers[/dim]", "", "", "", "")
             return table
 

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -1,0 +1,107 @@
+"""Tests for antfarm.core.activity — text synthesis for the Activity column.
+
+Pure unit tests: no FastAPI, no backend, no IO.
+"""
+
+from __future__ import annotations
+
+from antfarm.core import activity
+
+
+def test_synthesize_text_editing():
+    assert activity.synthesize_text("editing", "src/foo.py") == "editing src/foo.py"
+
+
+def test_synthesize_text_awaiting():
+    # "awaiting" has no {target} slot — target is ignored.
+    assert activity.synthesize_text("awaiting", "") == "awaiting claude response"
+    assert activity.synthesize_text("awaiting", "ignored-target") == "awaiting claude response"
+
+
+def test_synthesize_text_none():
+    assert activity.synthesize_text(None, None) is None
+    assert activity.synthesize_text("", "") is None
+    assert activity.synthesize_text(None, "") is None
+
+
+def test_synthesize_text_freeform_unknown_verb():
+    # Unknown verb: fall through to "<action> <target>".
+    assert activity.synthesize_text("foobar", "baz") == "foobar baz"
+    assert activity.synthesize_text("foobar", "") == "foobar"
+    assert activity.synthesize_text("", "baz") == "baz"
+
+
+def test_synthesize_text_running():
+    assert activity.synthesize_text("running", "pytest -x") == "running pytest -x"
+
+
+def test_synthesize_text_running_tests_uses_parens():
+    assert activity.synthesize_text("running_tests", "task-001") == "running tests (task-001)"
+
+
+def test_synthesize_text_fast_forwarding_hyphenates():
+    assert activity.synthesize_text("fast_forwarding", "dev") == "fast-forwarding dev"
+
+
+def test_synthesize_text_planning_ignores_target():
+    assert activity.synthesize_text("planning", "") == "planning"
+    assert activity.synthesize_text("planning", "ignored") == "planning"
+
+
+def test_synthesize_text_idle_and_polling():
+    assert activity.synthesize_text("idle", "") == "idle"
+    assert activity.synthesize_text("polling", "") == "polling"
+
+
+def test_synthesize_truncates_long_target():
+    long = "a" * 200
+    out = activity.synthesize_text("editing", long)
+    assert out is not None
+    # verb "editing " + truncated target = 8 + 60 = 68 chars
+    assert len(out) == len("editing ") + 60
+    assert out.endswith("...")
+    # Truncation keeps the first 57 chars + "..."
+    assert out == "editing " + "a" * 57 + "..."
+
+
+def test_synthesize_does_not_truncate_short_target():
+    out = activity.synthesize_text("editing", "a/b.py")
+    assert out == "editing a/b.py"
+
+
+def test_synthesize_strips_whitespace():
+    # Whitespace-only inputs count as empty.
+    assert activity.synthesize_text("   ", "   ") is None
+    assert activity.synthesize_text(" editing ", " file.py ") == "editing file.py"
+
+
+def test_tool_to_verb_edit_write_read():
+    assert activity.tool_to_verb("Edit") == "editing"
+    assert activity.tool_to_verb("Write") == "editing"
+    assert activity.tool_to_verb("Read") == "reading"
+
+
+def test_tool_to_verb_bash():
+    assert activity.tool_to_verb("Bash") == "running"
+
+
+def test_tool_to_verb_web():
+    assert activity.tool_to_verb("WebFetch") == "searching"
+    assert activity.tool_to_verb("WebSearch") == "searching"
+
+
+def test_tool_to_verb_glob_grep():
+    assert activity.tool_to_verb("Glob") == "scanning"
+    assert activity.tool_to_verb("Grep") == "scanning"
+
+
+def test_tool_to_verb_todowrite():
+    assert activity.tool_to_verb("TodoWrite") == "planning"
+
+
+def test_tool_to_verb_unknown_defaults():
+    # Unknown tools fall back to their lowercased name.
+    assert activity.tool_to_verb("SomeOther") == "someother"
+    # Empty/missing → "tool"
+    assert activity.tool_to_verb("") == "tool"
+    assert activity.tool_to_verb("   ") == "tool"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2435,3 +2435,33 @@ def test_stale_worktree_parsing_hazard_unparseable_name(tmp_path):
     stale = [f for f in findings if f.check == "stale_worktree"]
     assert stale, "rule 4 should fire once dir mtime is past TTL"
     assert "reason=ttl" in stale[0].message
+
+
+# ---------------------------------------------------------------------------
+# Activity emission (#348)
+# ---------------------------------------------------------------------------
+
+
+def test_run_doctor_emits_activity_per_check(setup, monkeypatch):
+    """run_doctor publishes 'scanning' activity for each phase (#348)."""
+    from antfarm.core import serve
+
+    backend, config = setup
+    calls: list[tuple[str, str, str]] = []
+
+    def _capture(kind, action, target=""):
+        calls.append((kind, action, target))
+
+    monkeypatch.setattr(serve, "_set_colony_activity", _capture)
+
+    run_doctor(backend, config, fix=False)
+
+    doctor_calls = [c for c in calls if c[0] == "doctor"]
+    scanning = {c[2] for c in doctor_calls if c[1] == "scanning"}
+    # A handful of critical stages — don't pin the full list so new checks
+    # can be added without churning this test.
+    for expected in {"filesystem", "workers", "tasks", "guards"}:
+        assert expected in scanning, f"expected scanning target {expected!r}; got {scanning}"
+
+    # Final call is idle — doctor is done.
+    assert doctor_calls[-1] == ("doctor", "idle", "")

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -663,6 +663,82 @@ def test_activity_endpoint_unknown_worker_noop(client):
     assert client.get("/workers").json() == []
 
 
+def test_activity_endpoint_accepts_action_plus_target(client):
+    """POST {action, target} is synthesized into current_action (#348)."""
+    _register_worker(client, "worker-syn")
+    r = client.post(
+        "/workers/worker-syn/activity",
+        json={"action": "editing", "target": "src/a.py", "source": "hook"},
+    )
+    assert r.status_code == 200
+
+    worker = next(w for w in client.get("/workers").json() if w["worker_id"] == "worker-syn")
+    assert worker["current_action"] == "editing src/a.py"
+    assert worker["current_action_at"] is not None
+
+
+def test_activity_endpoint_backcompat_freeform(client):
+    """Legacy callers posting {action: '<freeform>'} still work unchanged."""
+    _register_worker(client, "worker-legacy")
+    r = client.post(
+        "/workers/worker-legacy/activity",
+        json={"action": "Running: Bash"},
+    )
+    assert r.status_code == 200
+
+    worker = next(w for w in client.get("/workers").json() if w["worker_id"] == "worker-legacy")
+    assert worker["current_action"] == "Running: Bash"
+
+
+def test_activity_endpoint_accepts_explicit_text(client):
+    """Explicit text bypasses synthesis and is stored verbatim."""
+    _register_worker(client, "worker-text")
+    r = client.post(
+        "/workers/worker-text/activity",
+        json={"action": "editing", "target": "ignored", "text": "custom literal"},
+    )
+    assert r.status_code == 200
+    worker = next(w for w in client.get("/workers").json() if w["worker_id"] == "worker-text")
+    assert worker["current_action"] == "custom literal"
+
+
+def test_colony_activity_in_status_full(client):
+    """soldier_activity + doctor_activity are surfaced in /status/full (#348)."""
+    # Populate both via the internal helper.
+    serve_mod._set_colony_activity("soldier", "merging", "task-001")
+    serve_mod._set_colony_activity("doctor", "scanning", "workers")
+
+    r = client.get("/status/full")
+    assert r.status_code == 200
+    data = r.json()
+    assert "soldier_activity" in data
+    assert "doctor_activity" in data
+    assert data["soldier_activity"]["action"] == "merging"
+    assert data["soldier_activity"]["target"] == "task-001"
+    assert data["soldier_activity"]["text"] == "merging task-001"
+    assert data["soldier_activity"]["since"] is not None
+    assert data["doctor_activity"]["text"] == "scanning workers"
+
+
+def test_colony_activity_defaults_to_empty_in_status_full(tmp_path):
+    """When no subsystem has emitted activity, the dicts exist but are empty."""
+    from antfarm.core.backends.file import FileBackend
+
+    # Reset module state (tests run in-process and may have stale state).
+    serve_mod._soldier_activity.update(
+        {"action": None, "target": None, "text": None, "since": None}
+    )
+    serve_mod._doctor_activity.update({"action": None, "target": None, "text": None, "since": None})
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend, enable_soldier=False)
+    local = TestClient(app)
+
+    data = local.get("/status/full").json()
+    assert data["soldier_activity"]["text"] is None
+    assert data["doctor_activity"]["text"] is None
+
+
 # ---------------------------------------------------------------------------
 # Rate limit: GET /workers endpoint
 # ---------------------------------------------------------------------------

--- a/tests/test_soldier.py
+++ b/tests/test_soldier.py
@@ -1585,6 +1585,53 @@ def test_soldier_emits_reconciled_external_and_skips_merge_events(
     assert _events_of_type(clear_events, "merge_succeeded") == []
 
 
+def test_soldier_emits_activity_during_attempt_merge(soldier_env, monkeypatch):
+    """Soldier publishes phase activity through _set_colony_activity (#348).
+
+    We don't pin the exact sequence — it depends on the test repo state (e.g.
+    whether conflict paths run). We assert that the critical phases ALL appear
+    at least once on a green merge: merging, fetching, rebasing, running_tests,
+    fast_forwarding, pushing, cleanup, idle. Additionally, the outer run loop
+    emits 'polling' — we verify that too.
+    """
+    from antfarm.core import serve
+
+    calls: list[tuple[str, str, str]] = []
+
+    def _capture(kind, action, target=""):
+        calls.append((kind, action, target))
+
+    monkeypatch.setattr(serve, "_set_colony_activity", _capture)
+
+    soldier = soldier_env["soldier"]
+    cc = soldier_env["colony_client"]
+    repo = soldier_env["repo_path"]
+
+    _carry_and_harvest(cc, repo, "task-act-ok", "feat/task-act-ok")
+
+    results = soldier.run_once()
+    assert results == [("task-act-ok", MergeResult.MERGED)]
+
+    soldier_calls = [c for c in calls if c[0] == "soldier"]
+    actions = {c[1] for c in soldier_calls}
+    # Lifecycle of a green merge.
+    for expected in {
+        "merging",
+        "fetching",
+        "rebasing",
+        "running_tests",
+        "fast_forwarding",
+        "pushing",
+        "cleanup",
+        "idle",
+    }:
+        assert expected in actions, f"expected {expected!r} in soldier activity; got {actions}"
+
+    # The "merging" activity carries the task id as target.
+    merging = next(c for c in soldier_calls if c[1] == "merging")
+    assert merging[2] == "task-act-ok"
+
+
 def test_soldier_does_not_re_emit_colony_event_types(soldier_env, clear_events):
     """Colony-owned events (harvested/kickback/merged) must not fire with actor='soldier'."""
     soldier = soldier_env["soldier"]

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -728,6 +728,130 @@ def test_render_workers_includes_soldier():
     assert result.row_count == 1  # soldier row only
 
 
+def test_format_activity_cell_fresh_is_green():
+    """Elapsed < fresh_ttl (30s by default) renders green (#348)."""
+    from datetime import UTC, datetime
+
+    tui = _make_tui()
+    now_iso = datetime.now(UTC).isoformat()
+    cell = tui._format_activity_cell("editing src/a.py", now_iso)
+    assert "editing src/a.py" in cell.plain
+    assert cell.style == "green"
+
+
+def test_format_activity_cell_warn_band_is_default_style():
+    """Elapsed in [fresh_ttl, warn_ttl) band uses no style (#348)."""
+    from datetime import UTC, datetime, timedelta
+
+    tui = _make_tui()
+    # 60s ago: above fresh_ttl (30) and below warn_ttl (90).
+    old_iso = (datetime.now(UTC) - timedelta(seconds=60)).isoformat()
+    cell = tui._format_activity_cell("editing src/a.py", old_iso)
+    assert cell.style == ""
+
+
+def test_format_activity_cell_warn_band_is_yellow():
+    """Elapsed in [warn_ttl, stuck_ttl) band is yellow (#348).
+
+    warn_ttl defaults to 90s, stuck_ttl to 300s. 150s sits between them.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    tui = _make_tui()
+    old_iso = (datetime.now(UTC) - timedelta(seconds=150)).isoformat()
+    cell = tui._format_activity_cell("editing src/a.py", old_iso)
+    assert cell.style == "yellow"
+
+
+def test_format_activity_cell_stuck_is_red():
+    """Elapsed >= stuck_ttl (300s by default) renders red (#348)."""
+    from datetime import UTC, datetime, timedelta
+
+    tui = _make_tui()
+    old_iso = (datetime.now(UTC) - timedelta(seconds=600)).isoformat()
+    cell = tui._format_activity_cell("editing src/a.py", old_iso)
+    assert cell.style == "red"
+
+
+def test_format_activity_cell_accepts_now_arg():
+    """Callers can pass an explicit `now` for deterministic testing."""
+    from datetime import UTC, datetime, timedelta
+
+    tui = _make_tui()
+    start = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    now = start + timedelta(seconds=42)
+    cell = tui._format_activity_cell("merging task-001", start.isoformat(), now=now)
+    assert "(42s)" in cell.plain
+
+
+def test_render_workers_shows_soldier_activity_row():
+    """Soldier synthetic row renders the soldier_activity text cell (#348).
+
+    We assert the Activity column cell for the soldier row contains the
+    synthesized text. Rich ``Table.columns`` exposes the per-row cells.
+    """
+    from datetime import UTC, datetime
+
+    tui = _make_tui()
+    soldier_activity = {
+        "action": "merging",
+        "target": "task-001",
+        "text": "merging task-001",
+        "since": datetime.now(UTC).isoformat(),
+    }
+    result = tui._render_workers(
+        [],
+        soldier_status="running",
+        soldier_activity=soldier_activity,
+    )
+    assert result.row_count == 1
+    activity_col = next(c for c in result.columns if c.header == "Activity")
+    cell = list(activity_col.cells)[0]
+    plain = cell.plain if hasattr(cell, "plain") else str(cell)
+    assert "merging task-001" in plain
+
+
+def test_render_workers_shows_doctor_activity_row():
+    """Doctor synthetic row only appears when doctor_activity is provided (#348)."""
+    from datetime import UTC, datetime
+
+    tui = _make_tui()
+    doctor_activity = {
+        "action": "scanning",
+        "target": "workers",
+        "text": "scanning workers",
+        "since": datetime.now(UTC).isoformat(),
+    }
+    # No soldier, with doctor.
+    result = tui._render_workers(
+        [],
+        soldier_status="disabled",
+        doctor_activity=doctor_activity,
+    )
+    assert isinstance(result, Table)
+    assert result.row_count == 1  # doctor row only
+
+    # Without doctor_activity, and no workers, table falls back to placeholder row.
+    result2 = tui._render_workers([], soldier_status="disabled")
+    assert result2.row_count == 1  # "no workers" placeholder
+
+
+def test_render_workers_shows_both_synthetic_rows():
+    """Both soldier and doctor rows render together when both are present."""
+    from datetime import UTC, datetime
+
+    tui = _make_tui()
+    since = datetime.now(UTC).isoformat()
+    result = tui._render_workers(
+        [],
+        soldier_status="running",
+        soldier_activity={"text": "polling", "since": since},
+        doctor_activity={"text": "scanning workers", "since": since},
+    )
+    # 1 soldier row + 1 doctor row.
+    assert result.row_count == 2
+
+
 def test_get_worker_type_builder():
     tui = _make_tui()
     assert tui._get_worker_type({"agent_type": "claude-code"}) == "builder"


### PR DESCRIPTION
## Summary

- New `antfarm/core/activity` module: pure `(action, target) -> text` synthesis with a canonical verb vocabulary (`editing`, `running`, `merging`, `rebasing`, `running_tests`, `fast_forwarding`, `pushing`, `fetching`, `cleanup`, `polling`, `awaiting`, `idle`, ...). Targets are truncated to 60 chars with an ellipsis.
- `/workers/{id}/activity` now accepts structured `{action, target, source, text}`; the server synthesizes text and stores it in the existing `current_action` field, preserving `doctor.check_stuck_workers` and every legacy client. Freeform payloads (e.g. `{action: "Running: Bash"}`) still work unchanged.
- `/status/full` exposes `soldier_activity` and `doctor_activity` dicts, populated in-process via `serve._set_colony_activity`. The Soldier instruments `attempt_merge` phases (`merging`, `fetching`, `rebasing`, `running_tests`, `fast_forwarding`, `pushing`, `cleanup`, `idle`) and the outer `run` loop emits `polling`. The Doctor emits `scanning <stage>` around each check.
- TUI `_format_activity_cell` gains fresh/warn/stuck color bands (green / default / yellow / red at 30s / 90s / 300s) and accepts either the legacy worker dict or `(current_action, current_action_at)`. `_render_workers` gains synthetic soldier + doctor rows driven by the activity dicts.
- Claude Code hooks: `pre_tool.sh` emits structured `{action, target}` (`Edit`/`Write` → `editing <file>`, `Bash` → `running <cmd>`, `Glob`/`Grep` → `scanning <pat>`, etc.), with graceful fallback when `jq` is missing. `post_tool.sh` now emits `awaiting claude response` instead of clearing the cell — fills the gap between tool calls.
- Generic adapter README gains a "Reporting activity" section with the canonical verb table and an example `curl`.

Closes #348

## Test plan

- [x] `pytest tests/ -x -q` — 1394 passed
- [x] `ruff check antfarm/ tests/` — clean
- [x] `ruff format --check` — clean on touched files
- [x] `bash -n` on both hook scripts — clean
- [x] New `tests/test_activity.py` — 18 unit tests for synthesis + tool mapping
- [x] `tests/test_serve.py` — `{action, target}`, back-compat freeform, explicit text, `/status/full` activity, default-empty activity
- [x] `tests/test_tui.py` — fresh/warn/yellow/red color bands, explicit `now` arg, soldier + doctor synthetic rows, both-synthetic-rows rendering
- [x] `tests/test_soldier.py` — `_set_colony_activity` monkeypatched; verifies the full phase sequence on a green merge
- [x] `tests/test_doctor.py` — `_set_colony_activity` monkeypatched; verifies `scanning <stage>` + trailing `idle`

🤖 Generated with [Claude Code](https://claude.com/claude-code)