### PR TITLE
fix(serve,tui): suppress doctor TUI row when doctor is disabled

### DIFF
--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -48,8 +48,8 @@ _autoscaler_instance = None
 # /status/full. Appends are guarded by _colony_activity_lock so readers never
 # observe a partially-mutated dict.
 _colony_activity_lock = threading.Lock()
-_soldier_activity: dict = {"action": None, "target": None, "text": None, "since": None}
-_doctor_activity: dict = {"action": None, "target": None, "text": None, "since": None}
+_soldier_activity: dict | None = None
+_doctor_activity: dict | None = None
 
 # SSE event bus
 _event_queue: collections.deque = collections.deque(maxlen=1000)
@@ -87,15 +87,15 @@ def _set_colony_activity(kind: str, action: str, target: str = "") -> None:
         since = _now_iso()
         with _colony_activity_lock:
             if kind == "soldier":
-                _soldier_activity["action"] = action
-                _soldier_activity["target"] = target
-                _soldier_activity["text"] = text
-                _soldier_activity["since"] = since
+                global _soldier_activity
+                _soldier_activity = {
+                    "action": action, "target": target, "text": text, "since": since
+                }
             elif kind == "doctor":
-                _doctor_activity["action"] = action
-                _doctor_activity["target"] = target
-                _doctor_activity["text"] = text
-                _doctor_activity["since"] = since
+                global _doctor_activity
+                _doctor_activity = {
+                    "action": action, "target": target, "text": text, "since": since
+                }
     except Exception:
         logger.debug("_set_colony_activity(%s) failed", kind, exc_info=True)
 
@@ -1502,8 +1502,8 @@ def get_app(
         # render them as synthetic rows (#348). Copies are shallow but all
         # values are primitives, so this is safe.
         with _colony_activity_lock:
-            soldier_activity = dict(_soldier_activity)
-            doctor_activity = dict(_doctor_activity)
+            soldier_activity = dict(_soldier_activity) if _soldier_activity is not None else None
+            doctor_activity = dict(_doctor_activity) if _doctor_activity is not None else None
         return {
             "status": _backend.status(),
             "tasks": _backend.list_tasks(),

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -721,22 +721,51 @@ def test_colony_activity_in_status_full(client):
 
 
 def test_colony_activity_defaults_to_empty_in_status_full(tmp_path):
-    """When no subsystem has emitted activity, the dicts exist but are empty."""
+    """When no subsystem has emitted activity, both activity fields are None (#359)."""
     from antfarm.core.backends.file import FileBackend
 
     # Reset module state (tests run in-process and may have stale state).
-    serve_mod._soldier_activity.update(
-        {"action": None, "target": None, "text": None, "since": None}
-    )
-    serve_mod._doctor_activity.update({"action": None, "target": None, "text": None, "since": None})
+    serve_mod._soldier_activity = None
+    serve_mod._doctor_activity = None
 
     backend = FileBackend(root=str(tmp_path / ".antfarm"))
     app = get_app(backend=backend, enable_soldier=False)
     local = TestClient(app)
 
     data = local.get("/status/full").json()
-    assert data["soldier_activity"]["text"] is None
-    assert data["doctor_activity"]["text"] is None
+    assert data["soldier_activity"] is None
+    assert data["doctor_activity"] is None
+
+
+def test_doctor_activity_none_when_no_doctor_emit(tmp_path):
+    """Confirms /status/full returns None for doctor_activity when doctor hasn't emitted (#359)."""
+    from antfarm.core.backends.file import FileBackend
+
+    serve_mod._doctor_activity = None
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend, enable_soldier=False)
+    local = TestClient(app)
+
+    data = local.get("/status/full").json()
+    assert data["doctor_activity"] is None
+
+
+def test_soldier_activity_populated_after_emit(tmp_path):
+    """After _set_colony_activity('soldier', ...), /status/full has dict with text (#359)."""
+    from antfarm.core.backends.file import FileBackend
+
+    serve_mod._soldier_activity = None
+
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    app = get_app(backend=backend, enable_soldier=False)
+    local = TestClient(app)
+
+    serve_mod._set_colony_activity("soldier", "merging", "task-099")
+    data = local.get("/status/full").json()
+    assert data["soldier_activity"] is not None
+    assert data["soldier_activity"]["text"] == "merging task-099"
+    assert data["soldier_activity"]["since"] is not None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -852,6 +852,32 @@ def test_render_workers_shows_both_synthetic_rows():
     assert result.row_count == 2
 
 
+def test_render_workers_hides_doctor_row_when_activity_none():
+    """Regression for #359: doctor row must not appear when doctor_activity is None.
+
+    Before the fix, _doctor_activity was initialised as a dict with all-None
+    values (truthy because non-empty), so the `if doctor_activity:` guard in
+    _render_workers always fired.  Now the server returns None until the first
+    emit, and this test ensures the TUI honours that.
+    """
+    tui = _make_tui()
+
+    # No doctor_activity (None) and no soldiers/workers — only placeholder row.
+    result = tui._render_workers([], soldier_status="disabled", doctor_activity=None)
+    assert result.row_count == 1  # placeholder "no workers" only
+
+    # Explicit empty dict also treated as falsy by tui — same expectation.
+    result2 = tui._render_workers([], soldier_status="disabled", doctor_activity={})
+    assert result2.row_count == 1
+
+    # Once doctor emits a real dict, the row does appear.
+    from datetime import UTC, datetime
+
+    real_activity = {"text": "scanning guards", "since": datetime.now(UTC).isoformat()}
+    result3 = tui._render_workers([], soldier_status="disabled", doctor_activity=real_activity)
+    assert result3.row_count == 1  # 1 doctor row (no placeholder when there are rows)
+
+
 def test_get_worker_type_builder():
     tui = _make_tui()
     assert tui._get_worker_type({"agent_type": "claude-code"}) == "builder"


### PR DESCRIPTION
## Summary
- `_soldier_activity` and `_doctor_activity` were initialised as dicts with all-`None` values — truthy, so the TUI's `if doctor_activity:` guard always fired and showed a doctor row even when no doctor thread was running
- Now both globals start as `None`; `_set_colony_activity` replaces the global with a fresh dict on first emit; `/status/full` returns `None` for each field until that point
- No change to `tui.py` — its existing `full.get("doctor_activity") or None` + `if doctor_activity:` checks now correctly suppress the row when the server returns `None`

## Test Plan
- [x] Updated `test_colony_activity_defaults_to_empty_in_status_full` — resets via `serve_mod._soldier_activity = None` and asserts `None` in response
- [x] Added `test_doctor_activity_none_when_no_doctor_emit` — confirms `/status/full` returns `None` before any emit
- [x] Added `test_soldier_activity_populated_after_emit` — after `_set_colony_activity("soldier", ...)`, dict is present with `text`
- [x] Added `test_render_workers_hides_doctor_row_when_activity_none` — regression for #359; covers `None`, `{}`, and real-activity cases
- [x] `pytest tests/test_serve.py tests/test_tui.py -x -q` — 178 passed
- [x] `pytest tests/ -x -q` — 1397 passed
- [x] `ruff check .` — clean

## Related Issues
Closes #359