### PR TITLE
fix(soldier): decouple auto-merge squash from local branch delete (Closes #360)

### DIFF
--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -1328,6 +1328,39 @@ class Soldier:
             check=False,
         )
 
+    def _delete_local_branch_with_reclaim(self, branch: str) -> bool:
+        """Delete a local branch, reclaiming any blocking antfarm worktree.
+
+        Runs ``git branch -D <branch>`` in the soldier clone. If the delete
+        fails because the branch is checked out in an antfarm-managed
+        worktree (``used by worktree at '<path>'``), invokes
+        ``_remove_blocking_worktree`` and retries exactly once.
+
+        Best-effort: returns True iff the branch is gone after this call.
+        Callers use the return value for logging only — a False result must
+        never abort the surrounding merge-success flow (#360).
+        """
+        r = subprocess.run(
+            ["git", "branch", "-D", branch],
+            cwd=self.repo_path,
+            capture_output=True,
+            check=False,
+        )
+        if r.returncode == 0:
+            return True
+        stderr = r.stderr.decode(errors="replace") if r.stderr else ""
+        if "used by worktree at" not in stderr:
+            return False
+        if not self._remove_blocking_worktree(stderr):
+            return False
+        retry = subprocess.run(
+            ["git", "branch", "-D", branch],
+            cwd=self.repo_path,
+            capture_output=True,
+            check=False,
+        )
+        return retry.returncode == 0
+
     def _remove_blocking_worktree(self, stderr: str) -> bool:
         """Parse a 'branch already used by worktree at <path>' stderr message
         and, if the path is an antfarm-managed worktree, remove it with
@@ -1340,7 +1373,7 @@ class Soldier:
         and the workspaces root itself) is refused without invoking
         ``git worktree remove``. See #349.
         """
-        match = re.search(r"is already used by worktree at '([^']+)'", stderr)
+        match = re.search(r"used by worktree at '([^']+)'", stderr)
         if not match:
             return False
 
@@ -2111,14 +2144,29 @@ class Soldier:
             return None
         return parse_pr_state(r.stdout or "")
 
-    def _gh_pr_merge_squash(self, pr: str) -> tuple[bool, str]:
-        """Run ``gh pr merge <pr> --squash --delete-branch``.
+    def _gh_pr_merge_squash(self, pr: str, branch: str | None = None) -> tuple[bool, str]:
+        """Run ``gh pr merge <pr> --squash`` and clean up the branch separately.
+
+        Auto-merge flow (#360): the squash-merge and the branch-delete are
+        decoupled so a branch cleanup hiccup (local branch checked out in a
+        stale antfarm worktree, or remote already gone) never poisons an
+        already-successful remote merge. Cleanup is best-effort.
 
         Returns (ok, stderr_tail). Never raises.
+
+        Behavior:
+        - ``gh pr merge --squash`` returncode 0 → success; attempt branch
+          cleanup, then return ``(True, "")`` regardless of cleanup outcome.
+        - Non-zero gh exit → consult ``_check_pr_merged_on_origin`` because
+          gh sometimes exits non-zero after the remote merge already
+          landed (flaky follow-up calls, auth races). When the origin
+          confirms MERGED, emit ``auto_merge_gh_nonzero_but_merged``,
+          attempt branch cleanup, and return ``(True, "")``. Otherwise
+          surface the failure normally.
         """
         try:
             r = subprocess.run(
-                ["gh", "pr", "merge", pr, "--squash", "--delete-branch"],
+                ["gh", "pr", "merge", pr, "--squash"],
                 cwd=self.repo_path,
                 capture_output=True,
                 text=True,
@@ -2127,10 +2175,62 @@ class Soldier:
             )
         except (OSError, subprocess.TimeoutExpired) as exc:
             return False, f"gh pr merge exec error: {exc}"
-        if r.returncode == 0:
-            return True, ""
-        tail = (r.stderr or r.stdout or "").strip().splitlines()
-        return False, "\n".join(tail[-20:])
+
+        if r.returncode != 0:
+            # gh non-zero exits can race with successful remote merges.
+            # Re-check origin state before kicking the task back.
+            tail = (r.stderr or r.stdout or "").strip().splitlines()
+            stderr_tail = "\n".join(tail[-20:])
+            merged = self._check_pr_merged_on_origin(pr)
+            if merged is True:
+                _emit(
+                    "auto_merge_gh_nonzero_but_merged",
+                    "",
+                    f"pr={pr} stderr_tail={stderr_tail!r}",
+                )
+                self._cleanup_merged_branch(branch)
+                return True, ""
+            return False, stderr_tail
+
+        self._cleanup_merged_branch(branch)
+        return True, ""
+
+    def _cleanup_merged_branch(self, branch: str | None) -> None:
+        """Best-effort local + remote branch deletion after a squash-merge.
+
+        Never raises. All subprocess errors (including ``TimeoutExpired``)
+        are swallowed — by the time we get here the remote merge already
+        landed and we must not let janitorial noise surface as a failure
+        (#360).
+        """
+        if not branch:
+            return
+        try:
+            self._delete_local_branch_with_reclaim(branch)
+        except Exception:
+            logger.debug(
+                "auto-merge: local branch delete raised for %r",
+                branch,
+                exc_info=True,
+            )
+        try:
+            subprocess.run(
+                ["git", "push", "origin", "--delete", branch],
+                cwd=self.repo_path,
+                capture_output=True,
+                timeout=20,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            logger.debug(
+                "auto-merge: remote branch delete timed out for %r", branch
+            )
+        except Exception:
+            logger.debug(
+                "auto-merge: remote branch delete raised for %r",
+                branch,
+                exc_info=True,
+            )
 
     def _resolve_repo_slug(self) -> str | None:
         """Return ``owner/name`` for the repo we're operating on, or None."""
@@ -2378,7 +2478,8 @@ class Soldier:
         attempt_id = task.get("current_attempt") or ""
 
         if outcome.action == "merge":
-            ok, stderr_tail = self._gh_pr_merge_squash(outcome.pr)
+            branch = self._get_attempt_branch(task)
+            ok, stderr_tail = self._gh_pr_merge_squash(outcome.pr, branch=branch)
             if not ok:
                 self.last_failure_reason = f"auto_merge: gh pr merge failed: {stderr_tail}"
                 _emit(

--- a/tests/test_soldier.py
+++ b/tests/test_soldier.py
@@ -4086,6 +4086,39 @@ def test_remove_blocking_worktree_malformed_stderr(tmp_path, monkeypatch):
     assert not any(c[:3] == ["git", "worktree", "remove"] for c in calls)
 
 
+def test_remove_blocking_worktree_matches_git_branch_d_phrasing(tmp_path, monkeypatch):
+    """``git branch -D`` emits ``used by worktree at '<path>'`` without the
+    ``is already`` prefix that ``git checkout`` uses. The widened regex (#360)
+    must match both phrasings so the reclaim path fires for branch-delete
+    failures too."""
+    import os as _os
+    import subprocess as _sp
+
+    soldier = _build_bare_soldier(tmp_path)
+
+    blocked_path = _os.path.join(str(tmp_path), ".antfarm", "workspaces", "task-bd-att-001")
+    _os.makedirs(blocked_path, exist_ok=True)
+    expected_abs = _os.path.realpath(blocked_path)
+
+    # ``git branch -D`` phrasing — note: no "is already" prefix.
+    stderr = (
+        f"error: cannot delete branch 'feat/task-bd' checked out at '{blocked_path}'\n"
+        f"error: cannot delete branch 'feat/task-bd' used by worktree at '{blocked_path}'\n"
+    )
+
+    calls: list[list[str]] = []
+
+    def fake_run(args, **kwargs):
+        calls.append(list(args))
+        return _sp.CompletedProcess(args, 0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(soldier_module.subprocess, "run", fake_run)
+
+    assert soldier._remove_blocking_worktree(stderr) is True
+    git_calls = [c for c in calls if c and c[:2] == ["git", "worktree"]]
+    assert git_calls == [["git", "worktree", "remove", "--force", expected_abs]]
+
+
 def test_rebase_checkout_retries_after_removing_worktree(tmp_path, monkeypatch):
     """Integration: first checkout -B fails with the worktree-collision
     sentinel, the helper reclaims the worktree, and the retry succeeds

--- a/tests/test_soldier_auto_merge.py
+++ b/tests/test_soldier_auto_merge.py
@@ -121,10 +121,10 @@ def test_on_review_pass_clean_triggers_gh_merge(monkeypatch):
     # Auto-merge security gate: simulate ADMIN on main.
     monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
     monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
-    merge_calls: list[str] = []
+    merge_calls: list[tuple[str, str | None]] = []
 
-    def fake_merge(pr: str):
-        merge_calls.append(pr)
+    def fake_merge(pr: str, branch: str | None = None):
+        merge_calls.append((pr, branch))
         return True, ""
 
     monkeypatch.setattr(s, "_gh_pr_merge_squash", fake_merge)
@@ -137,7 +137,7 @@ def test_on_review_pass_clean_triggers_gh_merge(monkeypatch):
 
     result = s._handle_auto_merge_outcome(outcome, task)
     assert result == MergeResult.MERGED
-    assert merge_calls == ["https://github.com/org/repo/pull/1"]
+    assert merge_calls == [("https://github.com/org/repo/pull/1", "feat/task-1")]
     # mark_merged should receive auto_merged=True
     s.colony.mark_merged.assert_called_once_with("task-1", "att-1", auto_merged=True)
 
@@ -157,7 +157,7 @@ def test_on_review_pass_unstable_merges_ci_agnostic(monkeypatch):
     )
     monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
     monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
-    monkeypatch.setattr(s, "_gh_pr_merge_squash", lambda pr: (True, ""))
+    monkeypatch.setattr(s, "_gh_pr_merge_squash", lambda pr, branch=None: (True, ""))
     monkeypatch.setattr(s, "_sync_integration_branch_after_auto_merge", lambda: None)
 
     outcome = s._attempt_auto_merge(_task())
@@ -377,7 +377,7 @@ def test_emits_auto_merged_event_on_success(monkeypatch):
     )
     monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
     monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
-    monkeypatch.setattr(s, "_gh_pr_merge_squash", lambda pr: (True, ""))
+    monkeypatch.setattr(s, "_gh_pr_merge_squash", lambda pr, branch=None: (True, ""))
     monkeypatch.setattr(s, "_sync_integration_branch_after_auto_merge", lambda: None)
 
     emitted = []
@@ -434,7 +434,9 @@ def test_gh_pr_merge_failure_returns_failed(monkeypatch):
     )
     monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
     monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
-    monkeypatch.setattr(s, "_gh_pr_merge_squash", lambda pr: (False, "remote rejected"))
+    monkeypatch.setattr(
+        s, "_gh_pr_merge_squash", lambda pr, branch=None: (False, "remote rejected")
+    )
 
     task = _task()
     outcome = s._attempt_auto_merge(task)
@@ -531,6 +533,254 @@ def test_mission_without_auto_merge_key_is_never():
     s.colony.get_mission.return_value = {"mission_id": "m", "status": "building", "config": {}}
     outcome = s._attempt_auto_merge(_task())
     assert outcome is None
+
+
+# ---------------------------------------------------------------------------
+# #360: _gh_pr_merge_squash decouples remote merge from branch cleanup.
+#
+# The helper now runs ``gh pr merge --squash`` without ``--delete-branch`` and
+# drives local + remote branch deletes itself, so a janky cleanup (worktree
+# collision, remote already gone) never turns a successful merge into a
+# kickback. Regression tests for each branch of the new contract.
+# ---------------------------------------------------------------------------
+
+
+def _make_soldier_for_gh() -> Soldier:
+    """Bare soldier suitable for exercising ``_gh_pr_merge_squash`` directly."""
+    s = Soldier.__new__(Soldier)
+    s.colony = MagicMock()
+    s.colony_url = ""
+    s.repo_path = "/fake/repo"
+    s.integration_branch = "main"
+    s.test_command = ["true"]
+    s.poll_interval = 0.0
+    s.require_review = True
+    s.poll_external_merges = False
+    s.data_dir_name = ".antfarm"
+    s.last_failure_reason = ""
+    s._event_cursor = 0
+    s._preflight_done = True
+    s._auto_merge_last_checked = {}
+    s._repo_permission_cache = {}
+    s.auto_merge_poll_backoff_seconds = 30.0
+    return s
+
+
+def test_gh_pr_merge_squash_success_with_branch(monkeypatch):
+    """gh returns 0 → branch-delete attempts are issued (both local + remote)
+    but their failures are swallowed; helper returns (True, "")."""
+    s = _make_soldier_for_gh()
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        if cmd[:3] == ["gh", "pr", "merge"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        # Both local and remote deletes simulate failures — must be tolerated.
+        if cmd[:3] == ["git", "branch", "-D"]:
+            return SimpleNamespace(
+                returncode=1,
+                stdout=b"",
+                stderr=b"error: branch 'feat/x' not found.\n",
+            )
+        if cmd[:4] == ["git", "push", "origin", "--delete"]:
+            return SimpleNamespace(
+                returncode=1,
+                stdout=b"",
+                stderr=b"error: unable to delete 'feat/x': remote ref does not exist\n",
+            )
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ok, tail = s._gh_pr_merge_squash("PR-1", branch="feat/x")
+    assert ok is True
+    assert tail == ""
+    # gh invocation must NOT include --delete-branch.
+    gh_cmds = [c for c in calls if c[:3] == ["gh", "pr", "merge"]]
+    assert gh_cmds and "--delete-branch" not in gh_cmds[0]
+    # Cleanup attempts were made despite failures.
+    assert any(c[:3] == ["git", "branch", "-D"] for c in calls)
+    assert any(c[:4] == ["git", "push", "origin", "--delete"] for c in calls)
+
+
+def test_gh_pr_merge_squash_local_branch_delete_reclaim(monkeypatch):
+    """gh 0 → local ``git branch -D`` first fails with 'used by worktree at',
+    reclaim path runs, retry succeeds; helper still returns (True, "")."""
+    s = _make_soldier_for_gh()
+
+    branch_delete_calls = {"n": 0}
+    reclaim_calls: list[str] = []
+
+    def fake_reclaim(stderr: str) -> bool:
+        reclaim_calls.append(stderr)
+        return True
+
+    monkeypatch.setattr(s, "_remove_blocking_worktree", fake_reclaim)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["gh", "pr", "merge"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[:3] == ["git", "branch", "-D"]:
+            branch_delete_calls["n"] += 1
+            if branch_delete_calls["n"] == 1:
+                return SimpleNamespace(
+                    returncode=1,
+                    stdout=b"",
+                    stderr=(
+                        b"error: cannot delete branch 'feat/x' used by worktree "
+                        b"at '/fake/repo/.antfarm/workspaces/task-x-att-001'\n"
+                    ),
+                )
+            return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+        if cmd[:4] == ["git", "push", "origin", "--delete"]:
+            return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ok, tail = s._gh_pr_merge_squash("PR-1", branch="feat/x")
+    assert ok is True
+    assert tail == ""
+    assert reclaim_calls, "reclaim helper should have been invoked"
+    assert branch_delete_calls["n"] == 2  # initial fail + retry success
+
+
+def test_gh_pr_merge_squash_local_branch_delete_unrelated_error(monkeypatch):
+    """gh 0 → local ``git branch -D`` fails with a non-worktree stderr.
+    No reclaim attempted. Helper still returns (True, "")."""
+    s = _make_soldier_for_gh()
+
+    reclaim_calls: list[str] = []
+    monkeypatch.setattr(
+        s,
+        "_remove_blocking_worktree",
+        lambda stderr: reclaim_calls.append(stderr) or True,
+    )
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["gh", "pr", "merge"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[:3] == ["git", "branch", "-D"]:
+            return SimpleNamespace(
+                returncode=1,
+                stdout=b"",
+                stderr=b"error: branch 'feat/x' not found.\n",
+            )
+        if cmd[:4] == ["git", "push", "origin", "--delete"]:
+            return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ok, tail = s._gh_pr_merge_squash("PR-1", branch="feat/x")
+    assert ok is True
+    assert tail == ""
+    # Non-worktree stderr must NOT route through the reclaim helper.
+    assert reclaim_calls == []
+
+
+def test_gh_pr_merge_squash_nonzero_but_merged(monkeypatch):
+    """gh returns 1 but origin reports MERGED → treat as success.
+
+    Emits ``auto_merge_gh_nonzero_but_merged`` and still attempts branch
+    cleanup. Returns (True, "")."""
+    s = _make_soldier_for_gh()
+
+    monkeypatch.setattr(s, "_check_pr_merged_on_origin", lambda pr: True)
+
+    cleanup_calls: list[tuple] = []
+
+    def fake_cleanup(branch):
+        cleanup_calls.append(("cleanup", branch))
+
+    monkeypatch.setattr(s, "_cleanup_merged_branch", fake_cleanup)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["gh", "pr", "merge"]:
+            return SimpleNamespace(
+                returncode=1, stdout="", stderr="already merged or transient"
+            )
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    emitted: list[tuple[str, str, str]] = []
+
+    def fake_emit(event_type, task_id, detail="", actor="soldier"):
+        emitted.append((event_type, task_id, detail))
+
+    with patch("antfarm.core.serve._emit_event", side_effect=fake_emit):
+        ok, tail = s._gh_pr_merge_squash("PR-1", branch="feat/x")
+
+    assert ok is True
+    assert tail == ""
+    assert any(e[0] == "auto_merge_gh_nonzero_but_merged" for e in emitted)
+    assert cleanup_calls == [("cleanup", "feat/x")]
+
+
+def test_gh_pr_merge_squash_nonzero_not_merged(monkeypatch):
+    """gh returns 1 and origin reports OPEN → surface failure with tail."""
+    s = _make_soldier_for_gh()
+    monkeypatch.setattr(s, "_check_pr_merged_on_origin", lambda pr: False)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["gh", "pr", "merge"]:
+            return SimpleNamespace(
+                returncode=1, stdout="", stderr="remote rejected\nbecause reasons\n"
+            )
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ok, tail = s._gh_pr_merge_squash("PR-1", branch="feat/x")
+    assert ok is False
+    assert "remote rejected" in tail
+
+
+def test_gh_pr_merge_squash_nonzero_state_unknown(monkeypatch):
+    """gh returns 1 and origin state is unknown (None) → conservative FAIL."""
+    s = _make_soldier_for_gh()
+    monkeypatch.setattr(s, "_check_pr_merged_on_origin", lambda pr: None)
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["gh", "pr", "merge"]:
+            return SimpleNamespace(
+                returncode=1, stdout="", stderr="network blip"
+            )
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ok, tail = s._gh_pr_merge_squash("PR-1", branch="feat/x")
+    assert ok is False
+    assert "network blip" in tail
+
+
+def test_gh_pr_merge_squash_remote_branch_delete_fails(monkeypatch):
+    """gh 0 → local delete OK, ``git push origin --delete`` fails; still
+    returns (True, "") — cleanup must never poison a successful merge."""
+    s = _make_soldier_for_gh()
+
+    def fake_run(cmd, **kwargs):
+        if cmd[:3] == ["gh", "pr", "merge"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[:3] == ["git", "branch", "-D"]:
+            return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+        if cmd[:4] == ["git", "push", "origin", "--delete"]:
+            return SimpleNamespace(
+                returncode=1,
+                stdout=b"",
+                stderr=b"error: unable to delete 'feat/x': remote ref does not exist\n",
+            )
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    ok, tail = s._gh_pr_merge_squash("PR-1", branch="feat/x")
+    assert ok is True
+    assert tail == ""
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Split ``gh pr merge --squash`` from branch cleanup so a flaky local branch delete (worktree collision, missing ref) never turns a successful remote merge into a kickback.
- ``_gh_pr_merge_squash`` now accepts an optional ``branch`` kwarg, drops ``--delete-branch``, and consults ``_check_pr_merged_on_origin`` when gh exits non-zero (emits ``auto_merge_gh_nonzero_but_merged`` when the remote confirms MERGED).
- New ``_delete_local_branch_with_reclaim`` helper runs ``git branch -D`` and, if it fails with "used by worktree at", invokes ``_remove_blocking_worktree`` to reclaim the antfarm-managed worktree and retries once.
- Widens ``_remove_blocking_worktree`` regex to ``used by worktree at`` so it matches both ``git checkout`` and ``git branch -D`` phrasings.

## Test Plan
- [x] ``pytest tests/ -x -q`` — 1402 passed
- [x] ``ruff check antfarm/ tests/`` — all checks passed
- [x] New unit tests cover: gh success + cleanup failure tolerance, reclaim-on-worktree-collision, unrelated local-delete error, gh-nonzero-but-merged (emits event), gh-nonzero-and-open, gh-nonzero-and-state-unknown (conservative FAIL), remote delete failure tolerated, widened regex matches ``git branch -D`` phrasing.
- [x] Existing auto-merge mock tests updated to accept the new optional ``branch`` kwarg.

Closes #360