### PR TITLE
fix(autoscaler): always spawn first builder regardless of scale-up threshold (Closes #366)

### DIFF
--- a/antfarm/core/autoscaler.py
+++ b/antfarm/core/autoscaler.py
@@ -6,8 +6,10 @@ started workers on other machines are untouched.
 
 Depth-aware (issue #320): builder target is
 ``ceil(ready_unblocked * builder_depth_factor)`` clamped to
-``max_builders``. Scale-up is immediate once
-``builder_scale_up_threshold`` is met; scale-down is lazy — at most one
+``max_builders``. The first builder is always spawned when desired >= 1
+(otherwise a mission with a single root task would deadlock — issue
+#366). ``builder_scale_up_threshold`` only gates spawning ADDITIONAL
+builders beyond a baseline of one; scale-down is lazy — at most one
 builder is retired per tick, and only after it has been idle for
 ``builder_scale_down_idle_seconds``. The mission-wide
 ``max_parallel_builders`` is enforced as a hard cap.
@@ -232,8 +234,11 @@ class AutoscalerConfig:
     # target_builders = min(max_builders, max(1 if ready>0 else 0,
     #                                          ceil(ready * builder_depth_factor)))
     builder_depth_factor: float = 0.5
-    # Minimum ready_unblocked before the autoscaler will spawn a NEW builder
-    # beyond what's already running. Prevents flutter on a shallow queue.
+    # Minimum ready_unblocked before the autoscaler will spawn an ADDITIONAL
+    # builder beyond a baseline of one. The first builder is always spawned
+    # when desired >= 1 regardless of this threshold (see issue #366 — a
+    # single-root-task mission would otherwise never start). This threshold
+    # only prevents flutter when scaling above one already-running builder.
     builder_scale_up_threshold: int = 2
     # Seconds a builder must be idle before it is eligible for retirement.
     # Lazy scale-down: retire at most one idle builder per reconcile tick.
@@ -361,10 +366,12 @@ class Autoscaler:
     def _reconcile_builders(self, desired: int, actual: int, ready_unblocked: int) -> None:
         """Depth-aware reconciliation for the builder pool.
 
-        Scale-up: only spawn NEW builders above ``actual`` when the queue has
-        enough work to justify it (``ready_unblocked >=
-        builder_scale_up_threshold``). No cooldown — spawn the full delta
-        immediately when the threshold is met.
+        Scale-up: always spawn the first builder when ``actual == 0`` and
+        ``desired >= 1`` (otherwise missions with a single root task
+        deadlock — issue #366). Beyond ``actual >= 1``, only spawn
+        additional builders when ``ready_unblocked >=
+        builder_scale_up_threshold``. No cooldown — spawn the full delta
+        immediately when the gate is satisfied.
 
         Scale-down: lazy and conservative. Retire at most ONE builder per
         reconcile tick, and only when that builder has been idle for at least
@@ -372,11 +379,11 @@ class Autoscaler:
         """
         delta = desired - actual
         if delta > 0:
-            if ready_unblocked >= self.config.builder_scale_up_threshold:
+            if actual == 0 or ready_unblocked >= self.config.builder_scale_up_threshold:
                 while delta > 0:
                     self._start_worker("builder")
                     delta -= 1
-            # Otherwise: threshold not met, hold the current count steady.
+            # Otherwise: actual >= 1 and threshold not met — hold steady (anti-flutter).
             return
         if delta < 0:
             # Retire at most one builder per tick, and only after the idle

--- a/tests/test_autoscaler.py
+++ b/tests/test_autoscaler.py
@@ -828,8 +828,13 @@ class TestDepthAwareTarget:
 
 
 class TestScaleUpThreshold:
-    def test_scale_up_respects_threshold(self):
-        """ready_unblocked=1, builder_scale_up_threshold=2 -> do NOT spawn."""
+    def test_first_builder_spawns_when_actual_zero_and_one_ready(self):
+        """Bootstrap: actual=0, ready_unblocked=1 < threshold=2 -> spawn 1 (issue #366).
+
+        Without this carve-out, a mission with a single root task would
+        deadlock: desired=1, actual=0, but the threshold gate would refuse to
+        spawn the first builder, leaving the queue stuck forever.
+        """
         pm = _mock_pm()
         a = _make_autoscaler(
             _pm=pm,
@@ -837,15 +842,123 @@ class TestScaleUpThreshold:
             builder_depth_factor=0.5,
             builder_scale_up_threshold=2,
         )
-        # One ready unblocked task
         a.backend.list_tasks.return_value = [_task("task-1", status="ready")]
         a.backend.list_workers.return_value = []
 
         a._reconcile()
 
-        # compute_depth_aware_target(1, ...) == 1, actual == 0, delta == 1.
-        # But ready_unblocked (1) < threshold (2), so no spawn.
-        assert pm.start.call_count == 0
+        # Exactly one builder spawned despite ready_unblocked < threshold.
+        builder_starts = [
+            c for c in pm.start.call_args_list if "builder" in str(c)
+        ]
+        assert len(builder_starts) == 1
+
+    def test_no_spawn_when_actual_zero_and_no_ready_work(self):
+        """actual=0, ready_unblocked=0 -> desired=0, no spawn."""
+        pm = _mock_pm()
+        a = _make_autoscaler(
+            _pm=pm,
+            max_builders=5,
+            builder_depth_factor=0.5,
+            builder_scale_up_threshold=2,
+        )
+        # No ready build tasks (only an infra plan task, which doesn't count)
+        a.backend.list_tasks.return_value = [
+            _task("plan-001", status="ready", capabilities_required=["plan"]),
+        ]
+        a.backend.list_workers.return_value = []
+
+        a._reconcile()
+
+        builder_starts = [
+            c for c in pm.start.call_args_list if "builder" in str(c)
+        ]
+        assert len(builder_starts) == 0
+
+    def test_no_spawn_above_baseline_when_below_threshold(self):
+        """actual=1, ready_unblocked=1 < threshold=2 -> hold steady (anti-flutter).
+
+        Use builder_depth_factor=2.0 so ready=1 -> desired=ceil(2)=2 and
+        delta=1, exercising the anti-flutter gate above the bootstrap.
+        """
+        pm = _mock_pm()
+        a = _make_autoscaler(
+            _pm=pm,
+            max_builders=5,
+            builder_depth_factor=2.0,
+            builder_scale_up_threshold=2,
+        )
+        # Pre-existing managed builder so actual=1
+        a.managed["auto-builder-1"] = ManagedWorker(
+            name="auto-builder-1",
+            role="builder",
+            worker_id="local/auto-builder-1",
+        )
+        a.backend.list_tasks.return_value = [_task("task-1", status="ready")]
+        a.backend.list_workers.return_value = [
+            _worker("local/auto-builder-1", status="idle"),
+        ]
+
+        a._reconcile()
+
+        # desired=ceil(1*2.0)=2, actual=1, delta=1. ready_unblocked=1 < threshold=2
+        # AND actual != 0, so the anti-flutter branch holds steady.
+        builder_starts = [
+            c for c in pm.start.call_args_list if "builder" in str(c)
+        ]
+        assert len(builder_starts) == 0
+
+    def test_scale_up_above_baseline_when_threshold_met(self):
+        """actual=1, ready_unblocked=4 >= threshold=2 -> spawn delta builders."""
+        pm = _mock_pm()
+        a = _make_autoscaler(
+            _pm=pm,
+            max_builders=5,
+            builder_depth_factor=0.5,
+            builder_scale_up_threshold=2,
+        )
+        # Pre-existing managed builder so actual=1
+        a.managed["auto-builder-1"] = ManagedWorker(
+            name="auto-builder-1",
+            role="builder",
+            worker_id="local/auto-builder-1",
+        )
+        # 4 ready tasks: desired=ceil(4*0.5)=2, actual=1, delta=1. ready=4>=2.
+        a.backend.list_tasks.return_value = [
+            _task(f"task-{i}", status="ready") for i in range(1, 5)
+        ]
+        a.backend.list_workers.return_value = [
+            _worker("local/auto-builder-1", status="idle"),
+        ]
+
+        a._reconcile()
+
+        builder_starts = [
+            c for c in pm.start.call_args_list if "builder" in str(c)
+        ]
+        assert len(builder_starts) == 1
+
+    def test_first_spawn_respects_max_builders_cap(self):
+        """max_builders=1 caps desired even when bootstrap path applies."""
+        pm = _mock_pm()
+        a = _make_autoscaler(
+            _pm=pm,
+            max_builders=1,
+            builder_depth_factor=0.5,
+            builder_scale_up_threshold=2,
+        )
+        # Many ready tasks, but max_builders=1 caps desired at 1.
+        a.backend.list_tasks.return_value = [
+            _task(f"task-{i}", status="ready") for i in range(1, 11)
+        ]
+        a.backend.list_workers.return_value = []
+
+        a._reconcile()
+
+        builder_starts = [
+            c for c in pm.start.call_args_list if "builder" in str(c)
+        ]
+        assert len(builder_starts) == 1
 
 
 class TestDepthAwareScaleDown:


### PR DESCRIPTION
## Summary
- Carve out a bootstrap path in `Autoscaler._reconcile_builders`: always spawn when `actual == 0` and `desired >= 1`, regardless of `builder_scale_up_threshold`. Previously a mission with only one ready root task deadlocked because the threshold gate (default 2) held builders at 0 forever.
- Threshold continues to gate scaling **above** a baseline of one already-running builder, preserving the anti-flutter property on shallow queues.
- Replaces the old `test_scale_up_respects_threshold` (which encoded the bug) with five tests covering bootstrap, no-work, anti-flutter above baseline, scale-up above baseline when threshold met, and `max_builders` cap on bootstrap.

## Files touched
- `antfarm/core/autoscaler.py` — patch line in `_reconcile_builders`, refreshed module/function docstrings + config field comment.
- `tests/test_autoscaler.py` — replaced `TestScaleUpThreshold` body with the five new tests.

`MultiNodeAutoscaler` does not use `_reconcile_builders` (it pushes desired counts via actuators), so the threshold-gate bug was single-host only and no multi-node tests needed updating.

## Test plan
- [x] `pytest tests/test_autoscaler.py tests/test_multi_node_autoscaler.py -v` — 73 passed
- [x] `pytest tests/ -x -q` — 1409 passed
- [x] `ruff check antfarm/ tests/` — clean

Closes #366

🤖 Generated with [Claude Code](https://claude.com/claude-code)