### PR TITLE
fix(queen): bump max_re_plans default to 2 + per-mission override (Closes #364)

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -1384,6 +1384,12 @@ def mission():
 @click.option("--no-plan-review", is_flag=True, default=False, help="Skip plan review step.")
 @click.option("--max-builders", type=int, default=None, help="Max parallel builder workers.")
 @click.option("--max-attempts", type=int, default=None, help="Max attempts per task.")
+@click.option(
+    "--max-re-plans",
+    type=int,
+    default=None,
+    help="Max re-plan cycles before mission fails. Overrides Queen-wide default.",
+)
 @click.option("--integration-branch", default=None, help="Integration branch for this mission.")
 @click.option(
     "--auto-merge",
@@ -1424,6 +1430,7 @@ def mission_create(
     no_plan_review: bool,
     max_builders: int | None,
     max_attempts: int | None,
+    max_re_plans: int | None,
     integration_branch: str | None,
     auto_merge: str | None,
     allow_auto_merge_on_external: bool,
@@ -1445,6 +1452,8 @@ def mission_create(
         config["max_parallel_builders"] = max_builders
     if max_attempts is not None:
         config["max_attempts"] = max_attempts
+    if max_re_plans is not None:
+        config["max_re_plans"] = max_re_plans
     if integration_branch is not None:
         config["integration_branch"] = integration_branch
     if auto_merge is not None:
@@ -1624,12 +1633,19 @@ def mission_report(mission_id: str, fmt: str, colony_url: str, token: str | None
     default=None,
     help="Permit auto-merge even when the viewer is not an ADMIN of the target repo.",
 )
+@click.option(
+    "--max-re-plans",
+    type=int,
+    default=None,
+    help="Max re-plan cycles before mission fails. Overrides Queen-wide default.",
+)
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def mission_update(
     mission_id: str,
     auto_merge: str | None,
     allow_auto_merge_on_external: bool | None,
+    max_re_plans: int | None,
     colony_url: str,
     token: str | None,
 ):
@@ -1639,9 +1655,14 @@ def mission_update(
         partial["auto_merge"] = auto_merge
     if allow_auto_merge_on_external is not None:
         partial["allow_auto_merge_on_external"] = bool(allow_auto_merge_on_external)
+    if max_re_plans is not None:
+        partial["max_re_plans"] = max_re_plans
 
     if not partial:
-        click.echo("No updates specified. Use --auto-merge or --allow-auto-merge-on-external.")
+        click.echo(
+            "No updates specified. "
+            "Use --auto-merge, --allow-auto-merge-on-external, or --max-re-plans."
+        )
         return
 
     # Fetch current config and shallow-merge so fields we did not touch are preserved.

--- a/antfarm/core/missions.py
+++ b/antfarm/core/missions.py
@@ -50,6 +50,9 @@ class MissionStatus(StrEnum):
 @dataclass
 class MissionConfig:
     max_attempts: int = 3
+    # Per-mission override for Queen.config.max_re_plans. None defers to the
+    # Queen-wide default. Negative values are rejected.
+    max_re_plans: int | None = None
     max_parallel_builders: int = 4
     require_plan_review: bool = True
     stall_threshold_minutes: int = 30
@@ -76,10 +79,13 @@ class MissionConfig:
             raise ValueError(f"auto_merge must be one of {VALID_AUTO_MERGE_MODES}")
         if self.budget_action not in VALID_BUDGET_ACTIONS:
             raise ValueError(f"budget_action must be one of {VALID_BUDGET_ACTIONS}")
+        if self.max_re_plans is not None and self.max_re_plans < 0:
+            raise ValueError("max_re_plans must be non-negative")
 
     def to_dict(self) -> dict:
         return {
             "max_attempts": self.max_attempts,
+            "max_re_plans": self.max_re_plans,
             "max_parallel_builders": self.max_parallel_builders,
             "require_plan_review": self.require_plan_review,
             "stall_threshold_minutes": self.stall_threshold_minutes,
@@ -99,6 +105,7 @@ class MissionConfig:
     def from_dict(cls, data: dict) -> MissionConfig:
         return cls(
             max_attempts=data.get("max_attempts", 3),
+            max_re_plans=data.get("max_re_plans"),
             max_parallel_builders=data.get("max_parallel_builders", 4),
             require_plan_review=data.get("require_plan_review", True),
             stall_threshold_minutes=data.get("stall_threshold_minutes", 30),

--- a/antfarm/core/queen.py
+++ b/antfarm/core/queen.py
@@ -83,7 +83,7 @@ class QueenConfig:
     base_interval: float = 30.0
     active_interval: float = 10.0
     idle_interval: float = 60.0
-    max_re_plans: int = 1
+    max_re_plans: int = 2
     enable_mission_context: bool = True
 
 
@@ -360,7 +360,9 @@ class Queen:
             self._transition(mission, MissionStatus.BUILDING)
             self._maybe_generate_context(mission)
         elif verdict["verdict"] == "needs_changes":
-            if mission["re_plan_count"] >= self.config.max_re_plans:
+            per_mission = mission.get("config", {}).get("max_re_plans")
+            limit = per_mission if per_mission is not None else self.config.max_re_plans
+            if mission["re_plan_count"] >= limit:
                 summary = verdict.get("summary", "no summary")
                 self._fail(mission, f"review: plan rejected - {summary}")
                 return

--- a/tests/test_mission_cli.py
+++ b/tests/test_mission_cli.py
@@ -710,3 +710,94 @@ def test_mission_extend_command():
         assert payload["additional_tokens"] == 500
         assert "15.0" in result.output
         assert "1500" in result.output
+
+
+# ---------------------------------------------------------------------------
+# mission create / update --max-re-plans (#364)
+# ---------------------------------------------------------------------------
+
+
+def test_mission_create_max_re_plans_persists_to_config(tmp_path: Path):
+    """--max-re-plans threads max_re_plans into config payload."""
+    spec_file = tmp_path / "spec.md"
+    spec_file.write_text("spec")
+
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"mission_id": "m1"}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission",
+                "create",
+                "--spec",
+                str(spec_file),
+                "--max-re-plans",
+                "3",
+                "--colony-url",
+                "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+        assert payload["config"]["max_re_plans"] == 3
+
+
+def test_mission_update_max_re_plans_patches_config_preserving_other_fields():
+    """mission update --max-re-plans GETs, merges, then PATCHes config."""
+    runner = CliRunner()
+
+    current_mission = {
+        "mission_id": "m1",
+        "status": "building",
+        "config": {
+            "completion_mode": "best_effort",
+            "max_parallel_builders": 4,
+            "auto_merge": "never",
+        },
+        "task_ids": [],
+        "created_at": "2026-04-22T00:00:00Z",
+    }
+
+    with (
+        patch("antfarm.core.cli.httpx.get") as mock_get,
+        patch("antfarm.core.cli.httpx.patch") as mock_patch,
+    ):
+        mock_get_resp = MagicMock()
+        mock_get_resp.status_code = 200
+        mock_get_resp.json.return_value = current_mission
+        mock_get.return_value = mock_get_resp
+
+        mock_patch_resp = MagicMock()
+        mock_patch_resp.status_code = 200
+        mock_patch_resp.json.return_value = {"ok": True}
+        mock_patch.return_value = mock_patch_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission",
+                "update",
+                "m1",
+                "--max-re-plans",
+                "0",
+                "--colony-url",
+                "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = mock_patch.call_args.kwargs.get("json") or mock_patch.call_args[1]["json"]
+        merged_config = payload["updates"]["config"]
+        # Existing fields preserved
+        assert merged_config["completion_mode"] == "best_effort"
+        assert merged_config["max_parallel_builders"] == 4
+        assert merged_config["auto_merge"] == "never"
+        # New value applied
+        assert merged_config["max_re_plans"] == 0

--- a/tests/test_missions_model.py
+++ b/tests/test_missions_model.py
@@ -313,3 +313,41 @@ def test_mission_config_round_trip_includes_budget_fields():
 
 def test_mission_status_has_paused_value():
     assert MissionStatus.PAUSED.value == "paused"
+
+
+# ---------------------------------------------------------------------------
+# max_re_plans per-mission override (#364)
+# ---------------------------------------------------------------------------
+
+
+def test_mission_config_default_max_re_plans_is_none():
+    cfg = MissionConfig()
+    assert cfg.max_re_plans is None
+
+
+def test_mission_config_round_trip_max_re_plans_none():
+    cfg = MissionConfig()
+    d = cfg.to_dict()
+    assert d["max_re_plans"] is None
+    restored = MissionConfig.from_dict(d)
+    assert restored.max_re_plans is None
+    assert restored == cfg
+
+
+def test_mission_config_round_trip_max_re_plans_explicit():
+    cfg = MissionConfig(max_re_plans=5)
+    d = cfg.to_dict()
+    assert d["max_re_plans"] == 5
+    restored = MissionConfig.from_dict(d)
+    assert restored.max_re_plans == 5
+    assert restored == cfg
+
+
+def test_mission_config_accepts_max_re_plans_zero():
+    cfg = MissionConfig(max_re_plans=0)
+    assert cfg.max_re_plans == 0
+
+
+def test_mission_config_rejects_negative_max_re_plans():
+    with pytest.raises(ValueError, match="max_re_plans must be non-negative"):
+        MissionConfig(max_re_plans=-1)

--- a/tests/test_queen.py
+++ b/tests/test_queen.py
@@ -547,7 +547,11 @@ def test_queen_review_needs_changes_triggers_re_plan(env):
 
 def test_queen_review_verdict_needs_changes_twice_fails_with_review_prefix(env):
     backend = env["backend"]
-    queen = env["queen"]
+    # Preserve original test intent under the new default of max_re_plans=2:
+    # this scenario validates that the *second* needs_changes verdict trips
+    # the failure path. Pin the Queen to the legacy limit of 1 re-plan.
+    fake_time = env["fake_time"]
+    queen = Queen(backend, config=QueenConfig(max_re_plans=1), clock=lambda: fake_time[0])
 
     mission = _create_mission(backend)
     m = backend.get_mission(mission["mission_id"])
@@ -594,6 +598,94 @@ def test_queen_review_verdict_needs_changes_twice_fails_with_review_prefix(env):
     m = backend.get_mission(mission["mission_id"])
     assert m["status"] == "failed"
     assert m.get("failure_reason", "").startswith("review: ")
+
+
+# ---------------------------------------------------------------------------
+# Test 11b: Default max_re_plans=2 allows 2 re-plan cycles, fails on 3rd (#364)
+# ---------------------------------------------------------------------------
+
+
+def _run_needs_changes_cycle(
+    backend, queen, mission_id: str, attempt_id: str, summary: str
+) -> None:
+    """Drive one full cycle: advance → harvest re-plan → advance → reject."""
+    # advance: PLANNING → creates re-plan task
+    m = backend.get_mission(mission_id)
+    queen._advance(m)
+    m = backend.get_mission(mission_id)
+    plan_task_id = m["plan_task_id"]
+    assert plan_task_id is not None
+    artifact = _make_plan_artifact(plan_task_id=plan_task_id, attempt_id=attempt_id)
+    _harvest_plan_task_with_artifact(backend, plan_task_id, artifact)
+
+    # advance: → REVIEWING_PLAN
+    m = backend.get_mission(mission_id)
+    queen._advance(m)
+
+    # set review verdict to needs_changes
+    review_task_id = f"review-plan-{mission_id}"
+    _set_review_verdict_on_task(
+        backend, review_task_id, _make_review_verdict("needs_changes", summary)
+    )
+
+    # advance: consumes the verdict
+    m = backend.get_mission(mission_id)
+    queen._advance(m)
+
+
+def test_queen_default_max_re_plans_allows_two_cycles_fails_on_third(env):
+    """With Queen default max_re_plans=2, two needs_changes verdicts re-plan
+    and the third one fails the mission."""
+    backend = env["backend"]
+    queen = env["queen"]  # uses QueenConfig() default — max_re_plans=2
+
+    mission = _create_mission(backend)
+    mid = mission["mission_id"]
+
+    # Cycle 1: re_plan_count goes 0 → 1
+    _run_needs_changes_cycle(backend, queen, mid, "att-001", "needs work")
+    m = backend.get_mission(mid)
+    assert m["status"] == "planning"
+    assert m["re_plan_count"] == 1
+
+    # Cycle 2: re_plan_count goes 1 → 2
+    _run_needs_changes_cycle(backend, queen, mid, "att-re1", "still needs work")
+    m = backend.get_mission(mid)
+    assert m["status"] == "planning"
+    assert m["re_plan_count"] == 2
+
+    # Cycle 3: re_plan_count is already at the limit (2) — must fail
+    _run_needs_changes_cycle(backend, queen, mid, "att-re2", "give up")
+    m = backend.get_mission(mid)
+    assert m["status"] == "failed"
+    assert m.get("failure_reason", "").startswith("review: ")
+
+
+# ---------------------------------------------------------------------------
+# Test 11c: Per-mission max_re_plans=0 overrides Queen default (#364)
+# ---------------------------------------------------------------------------
+
+
+def test_queen_per_mission_max_re_plans_zero_overrides_queen_default(tmp_path):
+    """Mission-level max_re_plans=0 wins over a permissive Queen default."""
+    backend = FileBackend(root=str(tmp_path / ".antfarm"))
+    fake_time = [time.time()]
+    # Queen permissively allows 5, but the per-mission cap of 0 should apply.
+    queen = Queen(backend, config=QueenConfig(max_re_plans=5), clock=lambda: fake_time[0])
+
+    mission = _create_mission(
+        backend,
+        mission_id="mission-zero-cap",
+        config_overrides={"max_re_plans": 0},
+    )
+    mid = mission["mission_id"]
+
+    # First cycle: with cap=0, re_plan_count(0) >= 0 → mission fails immediately.
+    _run_needs_changes_cycle(backend, queen, mid, "att-001", "no replans allowed")
+    m = backend.get_mission(mid)
+    assert m["status"] == "failed"
+    assert m.get("failure_reason", "").startswith("review: ")
+    assert m["re_plan_count"] == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Bump `QueenConfig.max_re_plans` default from `1` to `2` so the planner gets two re-plan cycles by default (was firing prematurely on the first needs_changes verdict).
- Add `MissionConfig.max_re_plans: int | None = None` so a single mission can override the Queen-wide cap (set `0` to disallow re-plans entirely, or a higher number for stubborn missions). `None` defers to `QueenConfig.max_re_plans`.
- Wire `--max-re-plans INT` into `antfarm mission create` and `antfarm mission update` (mirrors the existing flag-shape used for budget/auto-merge fields).
- Pin the existing `test_queen_review_verdict_needs_changes_twice_fails_with_review_prefix` test to `QueenConfig(max_re_plans=1)` so it keeps validating "second needs_changes fails" under the new default.

## Test plan

- [x] `pytest tests/ -x -q` — 1428 passed
- [x] `ruff check .` — clean
- [x] New unit tests:
  - `test_missions_model.py`: round-trip `max_re_plans` (None + explicit), accept `0`, reject negative
  - `test_queen.py`: default=2 allows two re-plan cycles and fails on the third; per-mission `max_re_plans=0` overrides a permissive Queen default of `5`
  - `test_mission_cli.py`: `mission create --max-re-plans` and `mission update --max-re-plans` both persist into the config payload

## Related Issues

Closes #364