### PR TITLE
fix(soldier,auto_merge): detect CONFLICTING + bound rebase attempts (Closes #365)

### DIFF
--- a/antfarm/core/auto_merge.py
+++ b/antfarm/core/auto_merge.py
@@ -95,6 +95,14 @@ def decide(
     unexpected mergeStateStatus collapses to ``skip`` rather than guessing
     an action.
 
+    Precedence inside DIRTY/BEHIND (#365): GitHub keeps reporting
+    ``mergeStateStatus=DIRTY`` (or BEHIND) even after a rebase resolves
+    nothing — when ``mergeable=="CONFLICTING"`` the branch has real merge
+    conflicts that no amount of rebasing will clear. Detect that case
+    BEFORE dispatching ``rebase`` and route to ``kickback_ci`` so the worker
+    fixes the conflict in a fresh attempt instead of looping the soldier
+    on a doomed rebase.
+
     Args:
         mode: One of ``never``, ``on-review-pass``,
             ``on-review-pass-and-ci-green``. Unknown modes collapse to
@@ -119,6 +127,8 @@ def decide(
         if status == "UNSTABLE":
             # CI-agnostic mode: proceed despite failing/pending checks.
             return AutoMergeOutcome(action="merge", pr=pr, mode=mode, reason="UNSTABLE ci-agnostic")
+        if status in ("DIRTY", "BEHIND") and (pr_state.mergeable or "").upper() == "CONFLICTING":
+            return AutoMergeOutcome(action="kickback_ci", pr=pr, mode=mode, reason="merge_conflict")
         if status in ("DIRTY", "BEHIND"):
             return AutoMergeOutcome(
                 action="rebase", pr=pr, mode=mode, reason=f"{status} needs rebase"
@@ -156,6 +166,8 @@ def decide(
             )
         if status == "PENDING":
             return AutoMergeOutcome(action="wait_ci", pr=pr, mode=mode, reason="PENDING")
+        if status in ("DIRTY", "BEHIND") and (pr_state.mergeable or "").upper() == "CONFLICTING":
+            return AutoMergeOutcome(action="kickback_ci", pr=pr, mode=mode, reason="merge_conflict")
         if status in ("DIRTY", "BEHIND"):
             return AutoMergeOutcome(
                 action="rebase", pr=pr, mode=mode, reason=f"{status} needs rebase"

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -273,6 +273,13 @@ class Soldier:
         self._auto_merge_last_checked: dict[str, float] = {}
         self._repo_permission_cache: dict[str, tuple[str, float]] = {}
         self.auto_merge_poll_backoff_seconds: float = 30.0
+        # Auto-merge rebase loop bound (#365): per-attempt counter so a
+        # CONFLICTING-but-DIRTY PR (or any other rebase that GitHub never
+        # marks CLEAN) can't pin the soldier in an infinite rebase loop.
+        # Keyed by attempt_id; cleared on MERGED, exhausted on >=
+        # ``auto_merge_max_rebase_attempts``.
+        self._auto_merge_rebase_attempts: dict[str, int] = {}
+        self.auto_merge_max_rebase_attempts: int = 2
         # Mission-wide reconciliation (#367): per-task TTL cache for
         # ``gh pr view`` calls during the bulk reconciliation pass at the
         # top of every poll. Keyed by task_id, value is the last-checked
@@ -2471,9 +2478,15 @@ class Soldier:
         Wraps the existing deterministic rebase helper. Any failure is
         logged and surfaces as an ``auto_merge_rebasing`` event with
         ``status=failed`` so the next tick re-evaluates.
+
+        #365: tracks the per-attempt rebase counter so the outer
+        ``_handle_auto_merge_outcome`` can bound retries. Increments on any
+        non-MERGED outcome (we did spend a rebase attempt) and pops on
+        MERGED so a successful path leaves no stale counter behind.
         """
         branch = self._get_attempt_branch(task) or ""
         task_id = task.get("id", "")
+        attempt_id = task.get("current_attempt") or ""
         if not branch:
             _emit("auto_merge_rebasing", task_id, f"pr={pr} status=failed reason=no_branch")
             return
@@ -2486,6 +2499,13 @@ class Soldier:
             temp_branch="antfarm/temp-merge",
             initial_conflict_stderr="auto-merge triggered rebase",
         )
+        if attempt_id:
+            if outcome == MergeResult.MERGED:
+                self._auto_merge_rebase_attempts.pop(attempt_id, None)
+            else:
+                self._auto_merge_rebase_attempts[attempt_id] = (
+                    self._auto_merge_rebase_attempts.get(attempt_id, 0) + 1
+                )
         detail = f"pr={pr} branch={branch} result={outcome.value}"
         _emit("auto_merge_rebasing", task_id, detail)
 
@@ -2654,9 +2674,33 @@ class Soldier:
                     task_id,
                     f"pr={outcome.pr} attempt={attempt_id} type={type(exc).__name__}",
                 )
+            # #365: clear rebase counter on successful merge so a future
+            # re-attempt of the same attempt_id (rare, but possible if the
+            # task is replayed) starts fresh.
+            self._auto_merge_rebase_attempts.pop(attempt_id, None)
             return MergeResult.MERGED
 
         if outcome.action == "rebase":
+            # #365: bound rebase attempts per attempt_id so a PR GitHub keeps
+            # reporting as DIRTY/BEHIND can't trap us in an infinite loop. The
+            # decide() module already routes CONFLICTING away from rebase, but
+            # the counter is the belt-and-suspenders guard for any other
+            # case where the rebase never converges.
+            current_attempts = self._auto_merge_rebase_attempts.get(attempt_id, 0)
+            if current_attempts >= self.auto_merge_max_rebase_attempts:
+                cascade_reason = f"auto_merge_rebase_exhausted attempts={current_attempts}"
+                _emit(
+                    "auto_merge_kickback",
+                    task_id,
+                    f"pr={outcome.pr} mode={outcome.mode} reason={cascade_reason}",
+                )
+                self.last_failure_reason = cascade_reason
+                try:
+                    self.kickback_with_cascade(task_id, self.last_failure_reason)
+                except Exception:
+                    logger.exception("auto-merge: kickback_with_cascade failed for %s", task_id)
+                self._auto_merge_rebase_attempts.pop(attempt_id, None)
+                return MergeResult.FAILED
             _emit(
                 "auto_merge_rebasing",
                 task_id,
@@ -2679,7 +2723,14 @@ class Soldier:
                 task_id,
                 f"pr={outcome.pr} mode={outcome.mode} reason={outcome.reason}",
             )
-            self.last_failure_reason = f"auto_merge_ci_failed: {outcome.reason}"
+            # #365: distinguish merge-conflict kickbacks from CI-failure
+            # kickbacks so worker-side review prompts and cascade logs make
+            # the cause unambiguous.
+            if (outcome.reason or "").startswith("merge_conflict"):
+                cascade_reason = f"auto_merge_merge_conflict: {outcome.reason}"
+            else:
+                cascade_reason = f"auto_merge_ci_failed: {outcome.reason}"
+            self.last_failure_reason = cascade_reason
             try:
                 self.kickback_with_cascade(task_id, self.last_failure_reason)
             except Exception:
@@ -2732,6 +2783,8 @@ class Soldier:
         instance._auto_merge_last_checked = {}
         instance._repo_permission_cache = {}
         instance.auto_merge_poll_backoff_seconds = 30.0
+        instance._auto_merge_rebase_attempts = {}
+        instance.auto_merge_max_rebase_attempts = 2
         instance._reconcile_last_checked = {}
         instance.reconcile_backoff_seconds = 60.0
         return instance

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -88,6 +88,42 @@ def test_decide_on_review_pass_behind_rebase():
     assert out.action == "rebase"
 
 
+def test_decide_on_review_pass_dirty_conflicting_kicks_back():
+    """#365: DIRTY + mergeable=CONFLICTING means real merge conflict.
+    Must route to kickback_ci, not rebase, so the worker fixes it in a
+    fresh attempt instead of looping the soldier on a doomed rebase."""
+    out = decide(
+        "on-review-pass",
+        verdict_passed=True,
+        pr_state=_state(mergeStateStatus="DIRTY", mergeable="CONFLICTING"),
+        pr="p",
+    )
+    assert out.action == "kickback_ci"
+    assert out.reason == "merge_conflict"
+
+
+def test_decide_on_review_pass_dirty_mergeable_still_rebases():
+    """#365: DIRTY + mergeable=MERGEABLE remains a rebase (no conflict)."""
+    out = decide(
+        "on-review-pass",
+        verdict_passed=True,
+        pr_state=_state(mergeStateStatus="DIRTY", mergeable="MERGEABLE"),
+        pr="p",
+    )
+    assert out.action == "rebase"
+
+
+def test_decide_on_review_pass_behind_mergeable_rebases():
+    """#365: BEHIND + mergeable=MERGEABLE remains a rebase."""
+    out = decide(
+        "on-review-pass",
+        verdict_passed=True,
+        pr_state=_state(mergeStateStatus="BEHIND", mergeable="MERGEABLE"),
+        pr="p",
+    )
+    assert out.action == "rebase"
+
+
 def test_decide_on_review_pass_blocked_ci_failing_kicks_back():
     out = decide(
         "on-review-pass",
@@ -169,6 +205,18 @@ def test_decide_on_review_pass_and_ci_green_dirty_rebase():
         pr="p",
     )
     assert out.action == "rebase"
+
+
+def test_decide_on_review_pass_and_ci_green_dirty_conflicting_kicks_back():
+    """#365: same precedence in CI-green mode."""
+    out = decide(
+        "on-review-pass-and-ci-green",
+        verdict_passed=True,
+        pr_state=_state(mergeStateStatus="DIRTY", mergeable="CONFLICTING"),
+        pr="p",
+    )
+    assert out.action == "kickback_ci"
+    assert out.reason == "merge_conflict"
 
 
 def test_decide_on_review_pass_and_ci_green_blocked_ci_kicks_back():

--- a/tests/test_soldier_auto_merge.py
+++ b/tests/test_soldier_auto_merge.py
@@ -42,6 +42,8 @@ def _make_soldier(integration_branch: str = "main", monkeypatch=None) -> Soldier
     s._auto_merge_last_checked = {}
     s._repo_permission_cache = {}
     s.auto_merge_poll_backoff_seconds = 30.0
+    s._auto_merge_rebase_attempts = {}
+    s.auto_merge_max_rebase_attempts = 2
     s._reconcile_last_checked = {}
     s.reconcile_backoff_seconds = 60.0
     return s
@@ -260,10 +262,12 @@ def test_blocked_missing_reviews_pauses_mission(monkeypatch):
 def test_dirty_triggers_rebase(monkeypatch):
     s = _make_soldier()
     s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass")
+    # #365: DIRTY only triggers rebase when mergeable=MERGEABLE. The
+    # CONFLICTING case is now routed to kickback_ci by the decide() module.
     monkeypatch.setattr(
         s,
         "_query_pr_state",
-        lambda pr: PRState("DIRTY", "CONFLICTING", "APPROVED", "SUCCESS"),
+        lambda pr: PRState("DIRTY", "MERGEABLE", "APPROVED", "SUCCESS"),
     )
     monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
     monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
@@ -280,6 +284,157 @@ def test_dirty_triggers_rebase(monkeypatch):
     result = s._handle_auto_merge_outcome(outcome, task)
     assert result == MergeResult.NEEDS_REVIEW
     assert rebase_called == [("task-1", "https://github.com/org/repo/pull/1")]
+
+
+# ---------------------------------------------------------------------------
+# #365: CONFLICTING => kickback_ci, no rebase
+# ---------------------------------------------------------------------------
+
+
+def test_conflicting_triggers_kickback_no_rebase(monkeypatch):
+    """#365: DIRTY + mergeable=CONFLICTING must route to kickback with the
+    auto_merge_merge_conflict reason, and the rebase helper must NOT fire."""
+    s = _make_soldier()
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass")
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: PRState("DIRTY", "CONFLICTING", "APPROVED", "SUCCESS"),
+    )
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+
+    rebase_called: list[tuple] = []
+    monkeypatch.setattr(
+        s,
+        "_rebase_pr_branch_for_auto_merge",
+        lambda task, pr: rebase_called.append((task["id"], pr)),
+    )
+
+    kickback_calls: list[tuple[str, str]] = []
+
+    def fake_kickback(task_id, reason, **kw):
+        kickback_calls.append((task_id, reason))
+
+    monkeypatch.setattr(s, "kickback_with_cascade", fake_kickback)
+
+    task = _task()
+    outcome = s._attempt_auto_merge(task)
+    assert outcome.action == "kickback_ci"
+    assert outcome.reason == "merge_conflict"
+
+    result = s._handle_auto_merge_outcome(outcome, task)
+    assert result == MergeResult.FAILED
+    assert rebase_called == [], "rebase helper must not fire on CONFLICTING"
+    assert kickback_calls and kickback_calls[0][0] == "task-1"
+    assert "auto_merge_merge_conflict" in kickback_calls[0][1]
+    assert "merge_conflict" in kickback_calls[0][1]
+
+
+# ---------------------------------------------------------------------------
+# #365: bounded rebase attempts — exhaustion triggers kickback
+# ---------------------------------------------------------------------------
+
+
+def test_rebase_attempts_counter_increments_then_kicks_back(monkeypatch):
+    """#365: two consecutive rebase outcomes increment the counter; the
+    third dispatch finds the cap reached and kicks back with
+    auto_merge_rebase_exhausted."""
+    s = _make_soldier()
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass")
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: PRState("BEHIND", "MERGEABLE", "APPROVED", "SUCCESS"),
+    )
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+
+    # Rebase always fails — every attempt bumps the counter.
+    monkeypatch.setattr(
+        s,
+        "_rebase_and_retry_merge",
+        lambda task_id, branch, temp_branch, initial_conflict_stderr: MergeResult.FAILED,
+    )
+    monkeypatch.setattr(s, "_get_attempt_branch", lambda task: "feat/task-1")
+
+    kickback_calls: list[tuple[str, str]] = []
+
+    def fake_kickback(task_id, reason, **kw):
+        kickback_calls.append((task_id, reason))
+
+    monkeypatch.setattr(s, "kickback_with_cascade", fake_kickback)
+
+    task = _task()
+
+    # First two ticks: rebase dispatched, counter increments.
+    for _ in range(s.auto_merge_max_rebase_attempts):
+        # Reset poll backoff so each tick re-queries.
+        s._auto_merge_last_checked.clear()
+        outcome = s._attempt_auto_merge(task)
+        assert outcome.action == "rebase"
+        result = s._handle_auto_merge_outcome(outcome, task)
+        assert result == MergeResult.NEEDS_REVIEW
+
+    assert s._auto_merge_rebase_attempts.get("att-1") == s.auto_merge_max_rebase_attempts
+    assert kickback_calls == []  # not yet exhausted at dispatch time
+
+    # Third tick: counter at cap → kickback.
+    s._auto_merge_last_checked.clear()
+    outcome = s._attempt_auto_merge(task)
+    assert outcome.action == "rebase"
+    result = s._handle_auto_merge_outcome(outcome, task)
+    assert result == MergeResult.FAILED
+    assert kickback_calls and kickback_calls[0][0] == "task-1"
+    assert "auto_merge_rebase_exhausted" in kickback_calls[0][1]
+    assert f"attempts={s.auto_merge_max_rebase_attempts}" in kickback_calls[0][1]
+    # Counter cleared after exhaustion.
+    assert "att-1" not in s._auto_merge_rebase_attempts
+
+
+def test_rebase_attempts_counter_clears_on_success(monkeypatch):
+    """#365: a MERGED outcome from the rebase helper pops the counter."""
+    s = _make_soldier()
+    monkeypatch.setattr(s, "_get_attempt_branch", lambda task: "feat/task-1")
+    monkeypatch.setattr(
+        s,
+        "_rebase_and_retry_merge",
+        lambda task_id, branch, temp_branch, initial_conflict_stderr: MergeResult.MERGED,
+    )
+
+    task = _task()
+    # Pre-seed a counter to verify it is cleared.
+    s._auto_merge_rebase_attempts["att-1"] = 1
+    s._rebase_pr_branch_for_auto_merge(task, "https://github.com/org/repo/pull/1")
+    assert "att-1" not in s._auto_merge_rebase_attempts
+
+
+def test_rebase_attempts_counter_keyed_by_attempt_id(monkeypatch):
+    """#365: distinct attempt_ids must keep independent counters so the
+    same task being retried under a fresh attempt doesn't inherit prior
+    rebase exhaustion."""
+    s = _make_soldier()
+    monkeypatch.setattr(s, "_get_attempt_branch", lambda task: "feat/x")
+    monkeypatch.setattr(
+        s,
+        "_rebase_and_retry_merge",
+        lambda task_id, branch, temp_branch, initial_conflict_stderr: MergeResult.FAILED,
+    )
+
+    task_a = _task(task_id="task-a")
+    task_a["current_attempt"] = "att-A"
+    task_a["attempts"][0]["attempt_id"] = "att-A"
+
+    task_b = _task(task_id="task-b")
+    task_b["current_attempt"] = "att-B"
+    task_b["attempts"][0]["attempt_id"] = "att-B"
+
+    s._rebase_pr_branch_for_auto_merge(task_a, "pr-a")
+    s._rebase_pr_branch_for_auto_merge(task_a, "pr-a")
+    s._rebase_pr_branch_for_auto_merge(task_b, "pr-b")
+
+    assert s._auto_merge_rebase_attempts["att-A"] == 2
+    assert s._auto_merge_rebase_attempts["att-B"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -565,6 +720,8 @@ def _make_soldier_for_gh() -> Soldier:
     s._auto_merge_last_checked = {}
     s._repo_permission_cache = {}
     s.auto_merge_poll_backoff_seconds = 30.0
+    s._auto_merge_rebase_attempts = {}
+    s.auto_merge_max_rebase_attempts = 2
     s._reconcile_last_checked = {}
     s.reconcile_backoff_seconds = 60.0
     return s


### PR DESCRIPTION
## Summary

Two complementary guards so a PR with real merge conflicts can't pin the soldier in an endless rebase loop (#365):

- **`auto_merge.decide()`**: route `(DIRTY|BEHIND)` + `mergeable=CONFLICTING` to `kickback_ci` with `reason="merge_conflict"` BEFORE the rebase arm — the worker fixes the conflict in a fresh attempt instead of the soldier force-pushing the same broken branch every tick.
- **`Soldier._handle_auto_merge_outcome`**: per-`attempt_id` counter (`auto_merge_max_rebase_attempts=2`) bounds rebase retries. Exhaustion emits `auto_merge_kickback` with `reason=auto_merge_rebase_exhausted attempts={N}`. `merge_conflict` kickbacks are tagged `auto_merge_merge_conflict:` so worker review prompts and cascade logs disambiguate from CI failures.

Counter is keyed by `attempt_id`, incremented on non-MERGED rebase outcomes inside `_rebase_pr_branch_for_auto_merge`, and popped on MERGED so retries on a fresh attempt start clean.

## Test plan

- [x] `pytest tests/test_auto_merge.py tests/test_soldier_auto_merge.py -x -q` (57 passed)
- [x] `ruff check .` clean
- [x] New tests added:
  - `test_decide_on_review_pass_dirty_conflicting_kicks_back`
  - `test_decide_on_review_pass_dirty_mergeable_still_rebases`
  - `test_decide_on_review_pass_behind_mergeable_rebases`
  - `test_decide_on_review_pass_and_ci_green_dirty_conflicting_kicks_back`
  - `test_conflicting_triggers_kickback_no_rebase`
  - `test_rebase_attempts_counter_increments_then_kicks_back`
  - `test_rebase_attempts_counter_clears_on_success`
  - `test_rebase_attempts_counter_keyed_by_attempt_id`
- [x] Existing `test_dirty_triggers_rebase` updated to use `mergeable=MERGEABLE` (CONFLICTING now routes to kickback).

Note: `tests/test_soldier.py::test_run_once_with_review_calls_reconcile_pass` is pre-existing flaky on `main` (verified independently — fails ~1 in 4 runs without my changes); unrelated to this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)