### PR TITLE
feat(tui,worker): live Activity Feed panel + richer hook payloads (Closes #372)

### DIFF
--- a/antfarm/adapters/claude_code/hooks/pre_tool.sh
+++ b/antfarm/adapters/claude_code/hooks/pre_tool.sh
@@ -4,8 +4,11 @@
 # See: https://docs.claude.ai/en/docs/claude-code/hooks (PreToolUse)
 #
 # Emits {action, target, source:"hook"} so the colony server can synthesize
-# a human-readable line like "editing src/foo.py" or "running pytest -x"
+# a human-readable line like "editing foo.py" or "running pytest -x"
 # and store it in the worker's current_action field (#348).
+#
+# Targets are tuned for the live Activity Feed (#372): file basenames,
+# longer Bash command prefixes, host+path for URLs, and quoted patterns.
 #
 # Graceful fallback: without jq, action/target stay empty and the server
 # clamps to sensible defaults. curl with || true ensures the hook never fails.
@@ -21,21 +24,23 @@ if command -v jq >/dev/null 2>&1 && [ -n "$HOOK_INPUT" ]; then
   TOOL_NAME=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_name // ""' 2>/dev/null || echo "")
   case "$TOOL_NAME" in
     Edit|Write)
-      TARGET=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null || echo "")
+      # Basename only — full repo paths waste activity-feed columns.
+      TARGET=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.file_path | split("/") | .[-1] // ""' 2>/dev/null || echo "")
       ACTION=editing
       ;;
     Read)
-      TARGET=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null || echo "")
+      TARGET=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.file_path | split("/") | .[-1] // ""' 2>/dev/null || echo "")
       ACTION=reading
       ;;
     Bash)
-      # First three space-separated tokens of the command — enough to show
-      # what's running without leaking args/secrets.
-      TARGET=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.command // "" | split(" ") | .[0:3] | join(" ")' 2>/dev/null || echo "")
+      # First 60 chars of the command — enough context for the feed without
+      # blowing past the activity column. Server also clamps to 60.
+      TARGET=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.command // "" | .[:60]' 2>/dev/null || echo "")
       ACTION=running
       ;;
     WebFetch)
-      TARGET=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.url // ""' 2>/dev/null || echo "")
+      # Strip scheme + query string — the host+path is what's interesting.
+      TARGET=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.url // "" | sub("^https?://"; "") | sub("\\?.*"; "")' 2>/dev/null || echo "")
       ACTION=searching
       ;;
     WebSearch)
@@ -43,7 +48,8 @@ if command -v jq >/dev/null 2>&1 && [ -n "$HOOK_INPUT" ]; then
       ACTION=searching
       ;;
     Glob|Grep)
-      TARGET=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.pattern // .tool_input.path // ""' 2>/dev/null || echo "")
+      # Single-quote the pattern so it's visually distinct in the feed.
+      TARGET=$(printf '%s' "$HOOK_INPUT" | jq -r '.tool_input.pattern // .tool_input.path // ""' 2>/dev/null | sed "s/^\(.*\)$/'\1'/" || echo "")
       ACTION=scanning
       ;;
     TodoWrite)

--- a/antfarm/core/serve.py
+++ b/antfarm/core/serve.py
@@ -96,11 +96,40 @@ def _set_colony_activity(kind: str, action: str, target: str = "") -> None:
                 _doctor_activity = {
                     "action": action, "target": target, "text": text, "since": since
                 }
+            else:
+                # Unknown kind — don't emit an SSE event for it either.
+                return
+        # Mirror onto the SSE bus so the Activity panel surfaces soldier/doctor
+        # work alongside per-worker actions (#372). Emitted outside the
+        # _colony_activity_lock to avoid holding two locks.
+        #
+        # Filter out heartbeat-style verbs that fire on every soldier/doctor
+        # tick. They would drown the feed in noise without communicating
+        # anything actionable. The /status/full sidecar still surfaces them
+        # for the dedicated soldier_activity / doctor_activity panels.
+        #
+        # - "polling" / "idle": every soldier loop iteration
+        # - "scanning":         12+ per doctor sweep (one per check group)
+        # - "cleanup":          per-merge git housekeeping
+        if action not in {"polling", "idle", "scanning", "cleanup"}:
+            _emit_event(
+                "worker_activity",
+                task_id="",
+                detail=text,
+                actor=kind,
+                data={"action": action, "target": target, "text": text},
+            )
     except Exception:
         logger.debug("_set_colony_activity(%s) failed", kind, exc_info=True)
 
 
-def _emit_event(event_type: str, task_id: str, detail: str = "", actor: str = "colony") -> None:
+def _emit_event(
+    event_type: str,
+    task_id: str,
+    detail: str = "",
+    actor: str = "colony",
+    data: dict | None = None,
+) -> None:
     """Append an event to the SSE event bus.
 
     Thread-safe: counter increment and queue append are performed under
@@ -114,21 +143,30 @@ def _emit_event(event_type: str, task_id: str, detail: str = "", actor: str = "c
         actor: Subsystem emitting the event (e.g. "colony", "queen", "autoscaler",
             "soldier", "doctor", "worker"). Defaults to "colony" for legacy emitters
             inside colony HTTP handlers.
+        data: Optional structured payload merged into the event dict. Keys in
+            ``data`` take precedence over the canonical fields above only if
+            they don't collide; reserved keys (id, epoch, actor, type, task_id,
+            detail, ts) are never overwritten. Used by the live Activity Feed
+            (#372) to ship structured fields like ``action``/``target`` without
+            stuffing them into the freeform ``detail`` string.
     """
     global _event_counter
     with _event_lock:
         _event_counter += 1
-        _event_queue.append(
-            {
-                "id": _event_counter,
-                "epoch": _server_epoch,
-                "actor": actor,
-                "type": event_type,
-                "task_id": task_id,
-                "detail": detail,
-                "ts": _now_iso(),
-            }
-        )
+        event: dict = {
+            "id": _event_counter,
+            "epoch": _server_epoch,
+            "actor": actor,
+            "type": event_type,
+            "task_id": task_id,
+            "detail": detail,
+            "ts": _now_iso(),
+        }
+        if data:
+            for k, v in data.items():
+                if k not in event:
+                    event[k] = v
+        _event_queue.append(event)
 
 
 def _warn_if_data_dir_not_gitignored(repo_path: str, data_dir_name: str) -> None:
@@ -696,6 +734,21 @@ def get_app(
             # prior behavior for freeform callers like legacy hooks.
             resolved = synthesized if synthesized is not None else req.action
         _backend.update_worker_activity(worker_id, resolved)
+        # Emit on SSE so the TUI Activity panel can render a live feed of
+        # per-worker actions (#372). Skip clears (resolved is None) — they are
+        # uninteresting noise in the feed.
+        if resolved is not None:
+            _emit_event(
+                "worker_activity",
+                task_id="",
+                detail=resolved,
+                actor=worker_id,
+                data={
+                    "action": req.action,
+                    "target": req.target,
+                    "text": resolved,
+                },
+            )
         return {"ok": True}
 
     @app.get("/workers", status_code=200)

--- a/antfarm/core/tui.py
+++ b/antfarm/core/tui.py
@@ -239,7 +239,7 @@ class AntfarmTUI:
             Layout(name="review", size=12),
             Layout(name="merge_ready", size=6),
             Layout(name="merged", size=6),
-            Layout(name="activity", size=8),
+            Layout(name="activity", size=22),
         ]
         if snap.warnings:
             column_slices.insert(0, Layout(name="warnings", size=warnings_size))
@@ -375,7 +375,7 @@ class AntfarmTUI:
 
         layout["activity"].update(
             Panel(
-                self._render_activity(max_rows=6),
+                self._render_activity(max_rows=20),
                 title="[bold white]Activity[/bold white]",
             )
         )
@@ -962,8 +962,57 @@ class AntfarmTUI:
         self._add_overflow_hint(table, len(tasks), max_shown)
         return table
 
+    # Subsystem actors are *not* worker_ids; render them in the row's default
+    # column color (no per-worker palette mapping). Anything else is treated
+    # as a worker_id for coloring purposes (#372).
+    _NON_WORKER_ACTORS: frozenset[str] = frozenset(
+        {"colony", "queen", "autoscaler", "soldier", "doctor"}
+    )
+
+    # Deterministic palette so the same worker always gets the same color
+    # across renders and across colony restarts (#372).
+    _WORKER_PALETTE: tuple[str, ...] = (
+        "cyan",
+        "magenta",
+        "green",
+        "yellow",
+        "blue",
+        "bright_cyan",
+        "bright_magenta",
+        "bright_green",
+    )
+
+    def _color_for_worker(self, actor: str) -> str:
+        """Return a deterministic color for a worker_id from a small palette.
+
+        Hash-mod-N over the actor string. Same actor -> same color forever.
+        Used by the Activity panel so the eye can quickly cluster lines that
+        belong to the same worker (#372).
+        """
+        if not actor:
+            return self._WORKER_PALETTE[0]
+        # Built-in hash() varies by process (PYTHONHASHSEED); use a stable
+        # checksum so the test suite and live session agree on colors.
+        h = sum(ord(c) for c in actor)
+        return self._WORKER_PALETTE[h % len(self._WORKER_PALETTE)]
+
     def _render_activity(self, max_rows: int = 6) -> Text:
-        """Render the tail of the activity event deque as timestamped lines."""
+        """Render the tail of the activity event deque as timestamped lines.
+
+        Two row formats coexist:
+
+        * ``worker_activity`` events render as ``HH:MM:SS  actor  text`` --
+          the live per-worker action feed (#372). The ``text`` comes from
+          the event's ``detail`` field (the synthesized line like
+          ``editing src/foo.py``).
+        * Every other event type keeps the legacy
+          ``time  actor  type  task  detail`` layout used by harvest, merge,
+          and kickback rows.
+
+        Worker actors get a deterministic color via ``_color_for_worker``.
+        Subsystem actors (colony, soldier, doctor, queen, autoscaler) keep
+        the default style so they stay visually distinct from workers.
+        """
         with self._activity_lock:
             events = list(self._activity_events)
 
@@ -981,22 +1030,49 @@ class AntfarmTUI:
             except (ValueError, TypeError):
                 time_str = "--:--:--"
 
-            actor = (ev.get("actor") or "-")[:12].ljust(12)
-            event_type = (ev.get("type") or "-")[:16].ljust(16)
-            raw_tid = ev.get("task_id") or ""
-            tid_short = (raw_tid.rsplit("-", 1)[-1] if raw_tid else "")[:8].ljust(10)
-            detail = ev.get("detail") or "-"
+            event_type_raw = ev.get("type") or "-"
+            actor_raw = ev.get("actor") or "-"
+            actor = actor_raw[:12].ljust(12)
 
-            if "failed" in event_type:
-                style = "red"
-            elif "kick" in event_type:
-                style = "yellow"
-            else:
-                style = ""
-            text.append(
-                f"{time_str}  {actor}  {event_type}  {tid_short}  {detail}",
-                style=style,
+            # Per-worker color: applies for explicit worker_activity events
+            # OR when the actor isn't a known subsystem (heuristic - covers
+            # legacy events that pre-date the worker_activity type).
+            actor_is_worker = (
+                event_type_raw == "worker_activity"
+                or actor_raw not in self._NON_WORKER_ACTORS
             )
+
+            # Row-level style for special event kinds - overrides actor color
+            # so the entire line is unmistakably red/yellow.
+            if "failed" in event_type_raw:
+                row_style = "red"
+            elif "kick" in event_type_raw:
+                row_style = "yellow"
+            else:
+                row_style = ""
+
+            text.append(f"{time_str}  ", style=row_style)
+            if actor_is_worker and not row_style:
+                text.append(actor, style=self._color_for_worker(actor_raw))
+            else:
+                text.append(actor, style=row_style)
+
+            if event_type_raw == "worker_activity":
+                # Compact two-column layout: actor + text. The synthesized
+                # text already encodes the verb+target, so we drop the type
+                # and task_id columns here for readability.
+                detail = ev.get("detail") or "-"
+                text.append(f"  {detail}", style=row_style)
+            else:
+                event_type = event_type_raw[:16].ljust(16)
+                raw_tid = ev.get("task_id") or ""
+                tid_short = (raw_tid.rsplit("-", 1)[-1] if raw_tid else "")[:8].ljust(10)
+                detail = ev.get("detail") or "-"
+                text.append(
+                    f"  {event_type}  {tid_short}  {detail}",
+                    style=row_style,
+                )
+
             if i < len(tail) - 1:
                 text.append("\n")
 

--- a/tests/test_serve.py
+++ b/tests/test_serve.py
@@ -1437,3 +1437,146 @@ def test_emit_event_ordering_preserved_under_concurrency():
     ids = [e["id"] for e in serve_mod._event_queue]
     assert len(set(ids)) == len(ids)
     assert ids == sorted(ids), "deque insertion order does not match id order"
+
+
+# ---------------------------------------------------------------------------
+# Activity Feed SSE emission (#372)
+# ---------------------------------------------------------------------------
+
+
+def _worker_activity_events_for(actor: str) -> list[dict]:
+    """Filter the SSE queue down to worker_activity events for ``actor``.
+
+    The process-wide _event_queue can contain noise from background daemon
+    threads spawned by other tests in the same session (notably the Soldier
+    singleton from ``test_soldier_singleton_guard``). Filtering by actor lets
+    each test assert only on the events it actually generated.
+    """
+    return [
+        e
+        for e in serve_mod._event_queue
+        if e.get("type") == "worker_activity" and e.get("actor") == actor
+    ]
+
+
+def test_worker_activity_emits_sse_event(client):
+    """POST /workers/{id}/activity emits a worker_activity SSE event."""
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+    _register_worker(client, "worker-feed")
+
+    r = client.post(
+        "/workers/worker-feed/activity",
+        json={"action": "editing", "target": "foo.py"},
+    )
+    assert r.status_code == 200
+
+    events = _worker_activity_events_for("worker-feed")
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["actor"] == "worker-feed"
+    assert ev["detail"] == "editing foo.py"
+    assert ev["task_id"] == ""
+
+
+def test_worker_activity_clear_does_not_emit(client):
+    """Clearing activity (action=null) must NOT emit an SSE event."""
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+    _register_worker(client, "worker-clr")
+
+    r = client.post("/workers/worker-clr/activity", json={"action": None})
+    assert r.status_code == 200
+
+    assert _worker_activity_events_for("worker-clr") == []
+
+
+def test_worker_activity_event_includes_data_blob(client):
+    """worker_activity SSE event carries structured action/target/text fields."""
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+    _register_worker(client, "worker-data")
+
+    r = client.post(
+        "/workers/worker-data/activity",
+        json={"action": "editing", "target": "x.py"},
+    )
+    assert r.status_code == 200
+
+    events = _worker_activity_events_for("worker-data")
+    assert len(events) == 1
+    ev = events[0]
+    # Data blob fields are merged into the event dict.
+    assert ev["action"] == "editing"
+    assert ev["target"] == "x.py"
+    assert ev["text"] == "editing x.py"
+
+
+def test_set_colony_activity_emits_sse_for_soldier():
+    """_set_colony_activity('soldier', ...) mirrors onto the SSE bus."""
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+    serve_mod._soldier_activity = None
+
+    serve_mod._set_colony_activity("soldier", "merging", "task-007")
+
+    events = [
+        e
+        for e in serve_mod._event_queue
+        if e.get("type") == "worker_activity"
+        and e.get("actor") == "soldier"
+        and e.get("target") == "task-007"
+    ]
+    assert len(events) == 1
+    ev = events[0]
+    assert ev["detail"] == "merging task-007"
+    assert ev.get("action") == "merging"
+
+
+def test_set_colony_activity_emits_sse_for_doctor():
+    """_set_colony_activity('doctor', ...) mirrors onto the SSE bus.
+
+    Uses a non-heartbeat action ("checking") so the filter doesn't drop it.
+    """
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+    serve_mod._doctor_activity = None
+
+    serve_mod._set_colony_activity("doctor", "checking", "tasks")
+
+    events = [
+        e
+        for e in serve_mod._event_queue
+        if e.get("type") == "worker_activity"
+        and e.get("actor") == "doctor"
+        and e.get("target") == "tasks"
+    ]
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.get("action") == "checking"
+
+
+def test_set_colony_activity_filters_heartbeat_verbs():
+    """Heartbeat-style verbs do NOT emit SSE events.
+
+    Soldier calls ``_set_colony_activity('soldier', 'polling', '')`` on every
+    loop tick; Doctor calls ``_set_colony_activity('doctor', 'scanning', ...)``
+    a dozen times per sweep. Emitting SSE for those would drown the Activity
+    Feed in noise. They still flow into the dedicated soldier_activity /
+    doctor_activity panels via ``/status/full`` (#372).
+    """
+    serve_mod._event_queue.clear()
+    serve_mod._event_counter = 0
+
+    for kind, action in [
+        ("soldier", "polling"),
+        ("soldier", "cleanup"),
+        ("doctor", "idle"),
+        ("doctor", "scanning"),
+    ]:
+        serve_mod._set_colony_activity(kind, action, "")
+
+    events = [
+        e for e in serve_mod._event_queue if e.get("type") == "worker_activity"
+    ]
+    assert events == []

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1515,3 +1515,120 @@ def test_activity_loop_resets_backoff_on_success(monkeypatch):
 
     # Failure -> backoff 1.0s; success -> 0.5s rate-limit; failure -> 1.0s again.
     assert sleeps == [1.0, 0.5, 1.0]
+
+
+# ---------------------------------------------------------------------------
+# Activity Feed: worker_activity rendering + worker color palette (#372)
+# ---------------------------------------------------------------------------
+
+
+def test_render_activity_renders_worker_activity_event():
+    """worker_activity events render as 'HH:MM:SS  actor  text' (no type/task cols)."""
+    tui = _make_tui()
+    tui._ingest_event(
+        {
+            "id": 1,
+            "type": "worker_activity",
+            "actor": "node1/worker-a",
+            "detail": "editing src/foo.py",
+            "task_id": "",
+            "ts": "2026-04-16T14:32:11+00:00",
+        }
+    )
+    rendered = tui._render_activity()
+    plain = rendered.plain
+
+    # Synthesized text appears verbatim.
+    assert "editing src/foo.py" in plain
+    # Type column ("worker_activity") is suppressed in the compact layout.
+    assert "worker_activity" not in plain
+    # Actor (truncated/padded to 12) is on the line.
+    assert "node1/worker" in plain
+
+
+def test_color_for_worker_is_deterministic():
+    """Same actor -> same palette entry, every call. Two distinct actors may
+    collide (mod 8) — that's expected; we only assert determinism here."""
+    tui = _make_tui()
+    a1 = tui._color_for_worker("node1/worker-a")
+    a2 = tui._color_for_worker("node1/worker-a")
+    assert a1 == a2
+    # Empty actor still returns a valid palette entry, deterministically.
+    e1 = tui._color_for_worker("")
+    e2 = tui._color_for_worker("")
+    assert e1 == e2
+    # All returned colors are members of the declared palette.
+    assert a1 in tui._WORKER_PALETTE
+    assert e1 in tui._WORKER_PALETTE
+
+
+def test_render_activity_max_rows_20():
+    """Activity panel renders up to 20 rows when max_rows=20 (#372)."""
+    tui = _make_tui()
+    for i in range(1, 26):
+        tui._ingest_event(
+            {
+                "id": i,
+                "type": "worker_activity",
+                "actor": "node1/worker-a",
+                "detail": f"edit-{i}",
+                "task_id": "",
+                "ts": "2026-04-16T14:32:11+00:00",
+            }
+        )
+    rendered = tui._render_activity(max_rows=20)
+    lines = rendered.plain.split("\n")
+    assert len(lines) == 20
+    # Newest event ends up last.
+    assert "edit-25" in lines[-1]
+    assert "edit-6" in lines[0]
+
+
+def test_render_activity_colors_only_workers_not_colony():
+    """For non-worker_activity events, the heuristic distinguishes worker actors
+    (colored from the palette) from subsystem actors (colony, soldier, doctor,
+    queen, autoscaler — kept in default style)."""
+    tui = _make_tui()
+    tui._ingest_event(
+        {
+            "id": 1,
+            "type": "harvested",
+            "actor": "node1/worker-a",
+            "detail": "pr=https://x/y/1",
+            "task_id": "task-001",
+            "ts": "2026-04-16T14:32:11+00:00",
+        }
+    )
+    tui._ingest_event(
+        {
+            "id": 2,
+            "type": "merged",
+            "actor": "soldier",
+            "detail": "merged task-001",
+            "task_id": "task-001",
+            "ts": "2026-04-16T14:32:12+00:00",
+        }
+    )
+    rendered = tui._render_activity()
+    palette = set(tui._WORKER_PALETTE)
+    expected_color = tui._color_for_worker("node1/worker-a")
+
+    # Find the actor span for the worker line — it should carry the palette
+    # color. The soldier line's actor span must NOT carry a palette color
+    # (subsystems are exempt from the per-worker palette).
+    worker_styles: list[str] = []
+    soldier_styles: list[str] = []
+    for span in rendered.spans:
+        substr = rendered.plain[span.start : span.end]
+        style_str = str(span.style)
+        if "node1/worker" in substr:
+            worker_styles.append(style_str)
+        if substr.startswith("soldier"):
+            soldier_styles.append(style_str)
+
+    assert any(expected_color in s for s in worker_styles), (
+        f"worker actor span missing palette color: {worker_styles}"
+    )
+    assert all(not any(c in s for c in palette) for s in soldier_styles), (
+        f"soldier actor span unexpectedly colored: {soldier_styles}"
+    )


### PR DESCRIPTION
## Summary
- Live per-worker Activity Feed: `/workers/{id}/activity` now emits a `worker_activity` SSE event with a structured `data` blob (`action`, `target`, `text`); `_set_colony_activity` mirrors soldier/doctor work onto the same bus, filtering heartbeat verbs (`polling` / `idle` / `scanning` / `cleanup`) so the feed stays signal-rich.
- TUI Activity panel grows to 22 rows / 20 visible events; `worker_activity` rows render as a compact `HH:MM:SS  actor  text`; a deterministic per-worker color palette (`_color_for_worker`) lets the eye cluster lines from the same worker. Subsystem actors (`colony`, `soldier`, `doctor`, `queen`, `autoscaler`) keep the default style. Other event kinds keep the legacy `time | actor | type | task | detail` layout.
- Claude Code `pre_tool.sh` now sends tighter targets: file basenames for `Edit` / `Write` / `Read`, a 60-char `Bash` command prefix, host+path (no scheme, no query) for `WebFetch`, and single-quoted patterns for `Grep` / `Glob`.

## Test plan
- [x] `pytest tests/ -x -q` — 1446 passed
- [x] `ruff check .` — clean
- [x] New tests cover SSE emission, the `data` blob, the heartbeat-verb filter, worker-color determinism, `max_rows=20`, and the worker-vs-subsystem coloring heuristic.
- [x] `bash -n` validates the rewritten hook; spot-checked each jq expression against representative hook payloads.

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)