### PR TITLE
feat(soldier): add on-review-pass-and-local-tests auto-merge mode (Closes #374)

### DIFF
--- a/antfarm/core/auto_merge.py
+++ b/antfarm/core/auto_merge.py
@@ -105,8 +105,8 @@ def decide(
 
     Args:
         mode: One of ``never``, ``on-review-pass``,
-            ``on-review-pass-and-ci-green``. Unknown modes collapse to
-            ``skip``.
+            ``on-review-pass-and-ci-green``, ``on-review-pass-and-local-tests``.
+            Unknown modes collapse to ``skip``.
         verdict_passed: Whether the internal antfarm review verdict passed.
         pr_state: Freshly fetched PR mergeability snapshot, or ``None`` when
             the lookup failed.
@@ -121,7 +121,7 @@ def decide(
 
     status = (pr_state.mergeStateStatus or "").upper()
 
-    if mode == "on-review-pass":
+    if mode in ("on-review-pass", "on-review-pass-and-local-tests"):
         if status == "CLEAN":
             return AutoMergeOutcome(action="merge", pr=pr, mode=mode, reason="CLEAN")
         if status == "UNSTABLE":

--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -1395,7 +1395,10 @@ def mission():
     "--auto-merge",
     type=click.Choice(list(VALID_AUTO_MERGE_MODES)),
     default=None,
-    help="Auto-merge policy: never, on-review-pass, on-review-pass-and-ci-green.",
+    help=(
+        "Auto-merge policy: never, on-review-pass, on-review-pass-and-ci-green, "
+        "on-review-pass-and-local-tests."
+    ),
 )
 @click.option(
     "--allow-auto-merge-on-external",
@@ -1625,7 +1628,10 @@ def mission_report(mission_id: str, fmt: str, colony_url: str, token: str | None
     "--auto-merge",
     type=click.Choice(list(VALID_AUTO_MERGE_MODES)),
     default=None,
-    help="Auto-merge policy: never, on-review-pass, on-review-pass-and-ci-green.",
+    help=(
+        "Auto-merge policy: never, on-review-pass, on-review-pass-and-ci-green, "
+        "on-review-pass-and-local-tests."
+    ),
 )
 @click.option(
     "--allow-auto-merge-on-external",

--- a/antfarm/core/missions.py
+++ b/antfarm/core/missions.py
@@ -19,7 +19,12 @@ if TYPE_CHECKING:
 
 VALID_COMPLETION_MODES = ("best_effort", "all_or_nothing")
 VALID_BLOCKED_TIMEOUT_ACTIONS = ("wait", "fail")
-VALID_AUTO_MERGE_MODES = ("never", "on-review-pass", "on-review-pass-and-ci-green")
+VALID_AUTO_MERGE_MODES = (
+    "never",
+    "on-review-pass",
+    "on-review-pass-and-ci-green",
+    "on-review-pass-and-local-tests",
+)
 VALID_BUDGET_ACTIONS = ("pause", "cancel")
 
 # Bounded FIFO of recent UsageEvent IDs kept per-mission for dedup.

--- a/antfarm/core/soldier.py
+++ b/antfarm/core/soldier.py
@@ -112,6 +112,7 @@ _MERGE_FAILED_REASONS = frozenset(
         "checkout_failed",  # could not checkout integration branch / temp
         "repo_dirty",  # soldier clone was dirty and recovery failed
         "auto_merge_ci_failed",  # CI on PR reported FAILURE while mode gated on CI
+        "auto_merge_local_test_failed",  # local pre-merge tests failed (#374)
         "auto_merge_refused",  # security guard refused auto-merge on this repo
         "unknown",  # catch-all for unclassified failures
     }
@@ -132,8 +133,10 @@ _MERGE_FAILED_REASONS = frozenset(
 #   on the next tick.
 # - auto_merge_waiting_ci: ``on-review-pass-and-ci-green`` mode, PR
 #   mergeStateStatus is UNSTABLE or PENDING. Soldier skips this tick.
-# - auto_merge_kickback: mergeStateStatus=BLOCKED with failing CI. Soldier
-#   kicks back the task with reason=auto_merge_ci_failed so the worker
+# - auto_merge_kickback: mergeStateStatus=BLOCKED with failing CI, or local
+#   pre-merge tests failed in ``on-review-pass-and-local-tests`` mode (#374).
+#   Soldier kicks back the task with the appropriate reason
+#   (auto_merge_ci_failed / auto_merge_local_test_failed) so the worker
 #   re-attempts with fixed code.
 # - auto_merge_blocked: mergeStateStatus=BLOCKED with missing reviews or
 #   other unresolved reason. Soldier pauses the parent mission (sets
@@ -2610,6 +2613,93 @@ class Soldier:
         attempt_id = task.get("current_attempt") or ""
 
         if outcome.action == "merge":
+            if outcome.mode == "on-review-pass-and-local-tests":
+                # Pre-merge local test gate (#374). Run the configured
+                # ``test_command`` on the PR branch in the soldier's working
+                # clone before invoking ``gh pr merge --squash``. Any failure
+                # (missing branch, checkout error, non-zero test exit) kicks
+                # back the task with ``auto_merge_local_test_failed``. The
+                # integration branch is restored unconditionally so subsequent
+                # ticks find a clean clone.
+                pretest_branch = self._get_attempt_branch(task) or ""
+                if not pretest_branch:
+                    self.last_failure_reason = (
+                        "auto_merge_local_test_failed: no branch on attempt"
+                    )
+                    _emit(
+                        "auto_merge_kickback",
+                        task_id,
+                        f"pr={outcome.pr} mode={outcome.mode} "
+                        f"reason=auto_merge_local_test_failed",
+                    )
+                    try:
+                        self.kickback_with_cascade(task_id, self.last_failure_reason)
+                    except Exception:
+                        logger.exception("kickback_with_cascade failed for %s", task_id)
+                    return MergeResult.FAILED
+
+                try:
+                    # Fetch the PR branch (it may not be local yet in this clone).
+                    subprocess.run(
+                        ["git", "fetch", "origin", pretest_branch],
+                        cwd=self.repo_path,
+                        capture_output=True,
+                        check=False,
+                    )
+                    co = self._checkout_with_reclaim(
+                        ["checkout", "-B", pretest_branch, f"origin/{pretest_branch}"]
+                    )
+                    if co.returncode != 0:
+                        stderr_text = co.stderr.decode(errors="replace").strip()[:200]
+                        self.last_failure_reason = (
+                            f"auto_merge_local_test_failed: checkout_failed: {stderr_text}"
+                        )
+                        _emit(
+                            "auto_merge_kickback",
+                            task_id,
+                            f"pr={outcome.pr} mode={outcome.mode} "
+                            f"reason=auto_merge_local_test_failed",
+                        )
+                        try:
+                            self.kickback_with_cascade(task_id, self.last_failure_reason)
+                        except Exception:
+                            logger.exception("kickback_with_cascade failed for %s", task_id)
+                        return MergeResult.FAILED
+
+                    _set_activity("running_tests", task_id)
+                    tr = subprocess.run(
+                        self.test_command,
+                        cwd=self.repo_path,
+                        capture_output=True,
+                        check=False,
+                    )
+                    if tr.returncode != 0:
+                        tail = (
+                            (tr.stderr or b"")
+                            .decode("utf-8", errors="replace")
+                            .strip()[-200:]
+                        )
+                        self.last_failure_reason = f"auto_merge_local_test_failed: {tail}"
+                        _emit(
+                            "auto_merge_kickback",
+                            task_id,
+                            f"pr={outcome.pr} mode={outcome.mode} "
+                            f"reason=auto_merge_local_test_failed",
+                        )
+                        try:
+                            self.kickback_with_cascade(task_id, self.last_failure_reason)
+                        except Exception:
+                            logger.exception("kickback_with_cascade failed for %s", task_id)
+                        return MergeResult.FAILED
+                    # tests pass → fall through to the normal gh pr merge path
+                finally:
+                    # ALWAYS restore the integration branch so the next tick
+                    # starts from a known good state.
+                    try:
+                        self._checkout_with_reclaim(["checkout", self.integration_branch])
+                    except Exception:
+                        logger.exception("post-test branch restore failed")
+
             branch = self._get_attempt_branch(task)
             ok, stderr_tail = self._gh_pr_merge_squash(outcome.pr, branch=branch)
             if not ok:

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -245,6 +245,59 @@ def test_decide_on_review_pass_and_ci_green_blocked_missing_reviews_pauses():
     assert out.action == "pause_mission"
 
 
+# ---------------------------------------------------------------------------
+# on-review-pass-and-local-tests — routing mirrors on-review-pass (#374).
+# The local pre-merge test gate is enforced in the soldier handler, NOT in
+# decide(). decide() must classify identically to on-review-pass so the
+# state-machine transitions stay aligned.
+# ---------------------------------------------------------------------------
+
+
+def test_decide_on_review_pass_and_local_tests_clean_merges():
+    out = decide(
+        "on-review-pass-and-local-tests",
+        verdict_passed=True,
+        pr_state=_state(mergeStateStatus="CLEAN"),
+        pr="p",
+    )
+    assert out.action == "merge"
+    assert out.mode == "on-review-pass-and-local-tests"
+
+
+def test_decide_on_review_pass_and_local_tests_dirty_rebase():
+    out = decide(
+        "on-review-pass-and-local-tests",
+        verdict_passed=True,
+        pr_state=_state(mergeStateStatus="DIRTY", mergeable="MERGEABLE"),
+        pr="p",
+    )
+    assert out.action == "rebase"
+
+
+def test_decide_on_review_pass_and_local_tests_blocked_ci_failing_kicks_back():
+    out = decide(
+        "on-review-pass-and-local-tests",
+        verdict_passed=True,
+        pr_state=_state(
+            mergeStateStatus="BLOCKED",
+            review_decision="APPROVED",
+            ci_conclusion="FAILURE",
+        ),
+        pr="p",
+    )
+    assert out.action == "kickback_ci"
+
+
+def test_decide_on_review_pass_and_local_tests_unstable_merges_ci_agnostic():
+    out = decide(
+        "on-review-pass-and-local-tests",
+        verdict_passed=True,
+        pr_state=_state(mergeStateStatus="UNSTABLE"),
+        pr="p",
+    )
+    assert out.action == "merge"
+
+
 def test_decide_has_hooks_is_skip():
     out = decide(
         "on-review-pass",

--- a/tests/test_soldier_auto_merge.py
+++ b/tests/test_soldier_auto_merge.py
@@ -940,5 +940,298 @@ def test_gh_pr_merge_squash_remote_branch_delete_fails(monkeypatch):
     assert tail == ""
 
 
+# ---------------------------------------------------------------------------
+# #374: on-review-pass-and-local-tests pre-merge gate
+# ---------------------------------------------------------------------------
+
+
+def test_local_tests_mode_clean_runs_tests_then_merges(monkeypatch):
+    """CLEAN PR + local tests pass → gh pr merge fires, MergeResult.MERGED,
+    and the integration branch is restored as the last checkout call."""
+    s = _make_soldier()
+    s.test_command = ["pytest", "-x", "-q"]
+    s.colony.get_mission.return_value = _mission(
+        auto_merge="on-review-pass-and-local-tests"
+    )
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: PRState("CLEAN", "MERGEABLE", "APPROVED", "SUCCESS"),
+    )
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+
+    merge_calls: list[tuple[str, str | None]] = []
+
+    def fake_merge(pr: str, branch: str | None = None):
+        merge_calls.append((pr, branch))
+        return True, ""
+
+    monkeypatch.setattr(s, "_gh_pr_merge_squash", fake_merge)
+    monkeypatch.setattr(s, "_sync_integration_branch_after_auto_merge", lambda: None)
+
+    checkout_calls: list[list[str]] = []
+
+    def fake_checkout(args):
+        checkout_calls.append(list(args))
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(s, "_checkout_with_reclaim", fake_checkout)
+
+    run_calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        run_calls.append(list(cmd))
+        # Both git fetch and the test_command return rc=0.
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    task = _task()
+    outcome = s._attempt_auto_merge(task)
+    assert outcome.action == "merge"
+    assert outcome.mode == "on-review-pass-and-local-tests"
+
+    result = s._handle_auto_merge_outcome(outcome, task)
+    assert result == MergeResult.MERGED
+    # gh pr merge invoked once with the expected branch.
+    assert merge_calls == [("https://github.com/org/repo/pull/1", "feat/task-1")]
+    # The test_command was run in the repo (subprocess.run was called with it).
+    assert any(cmd == s.test_command for cmd in run_calls), (
+        f"expected test_command in subprocess.run calls, got {run_calls}"
+    )
+    # Last checkout call must restore the integration branch.
+    assert checkout_calls, "expected at least one _checkout_with_reclaim call"
+    assert checkout_calls[-1] == ["checkout", s.integration_branch]
+
+
+def test_local_tests_mode_clean_test_failure_kicks_back_no_merge(monkeypatch):
+    """CLEAN PR + tests fail (rc=1) → kickback with auto_merge_local_test_failed,
+    gh pr merge NOT called, integration branch still restored."""
+    s = _make_soldier()
+    s.test_command = ["pytest", "-x", "-q"]
+    s.colony.get_mission.return_value = _mission(
+        auto_merge="on-review-pass-and-local-tests"
+    )
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: PRState("CLEAN", "MERGEABLE", "APPROVED", "SUCCESS"),
+    )
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+
+    merge_calls: list[tuple[str, str | None]] = []
+
+    def fake_merge(pr, branch=None):
+        merge_calls.append((pr, branch))
+        return True, ""
+
+    monkeypatch.setattr(s, "_gh_pr_merge_squash", fake_merge)
+    monkeypatch.setattr(s, "_sync_integration_branch_after_auto_merge", lambda: None)
+
+    checkout_calls: list[list[str]] = []
+
+    def fake_checkout(args):
+        checkout_calls.append(list(args))
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(s, "_checkout_with_reclaim", fake_checkout)
+
+    def fake_run(cmd, **kwargs):
+        # git fetch returns 0; test_command returns 1.
+        if cmd[:2] == ["git", "fetch"]:
+            return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+        if list(cmd) == s.test_command:
+            return SimpleNamespace(
+                returncode=1, stdout=b"", stderr=b"E   assert 1 == 2\n"
+            )
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    kickback_calls: list[tuple[str, str]] = []
+
+    def fake_kickback(task_id, reason, **kw):
+        kickback_calls.append((task_id, reason))
+
+    monkeypatch.setattr(s, "kickback_with_cascade", fake_kickback)
+
+    task = _task()
+    outcome = s._attempt_auto_merge(task)
+    assert outcome.action == "merge"
+
+    result = s._handle_auto_merge_outcome(outcome, task)
+    assert result == MergeResult.FAILED
+    assert merge_calls == [], "gh pr merge must not be called on test failure"
+    assert kickback_calls and kickback_calls[0][0] == "task-1"
+    assert kickback_calls[0][1].startswith("auto_merge_local_test_failed")
+    # Integration branch still restored as the LAST checkout call.
+    assert checkout_calls, "expected at least one _checkout_with_reclaim call"
+    assert checkout_calls[-1] == ["checkout", s.integration_branch]
+
+
+def test_local_tests_mode_checkout_failure_kicks_back(monkeypatch):
+    """Checkout to PR branch fails → kickback fires, no test_command run,
+    no gh pr merge."""
+    s = _make_soldier()
+    s.test_command = ["pytest", "-x", "-q"]
+    s.colony.get_mission.return_value = _mission(
+        auto_merge="on-review-pass-and-local-tests"
+    )
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: PRState("CLEAN", "MERGEABLE", "APPROVED", "SUCCESS"),
+    )
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+
+    merge_called: list[tuple[str, str | None]] = []
+
+    def fake_merge(pr, branch=None):
+        merge_called.append((pr, branch))
+        return True, ""
+
+    monkeypatch.setattr(s, "_gh_pr_merge_squash", fake_merge)
+
+    checkout_calls: list[list[str]] = []
+
+    def fake_checkout(args):
+        checkout_calls.append(list(args))
+        # First call (checkout -B PR branch) fails. Subsequent restore call
+        # to integration branch succeeds.
+        if args[:1] == ["checkout"] and len(args) >= 2 and args[1] == "-B":
+            return SimpleNamespace(
+                returncode=1,
+                stdout=b"",
+                stderr=b"error: pathspec 'origin/feat/task-1' did not match\n",
+            )
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(s, "_checkout_with_reclaim", fake_checkout)
+
+    run_calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        run_calls.append(list(cmd))
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    kickback_calls: list[tuple[str, str]] = []
+
+    def fake_kickback(task_id, reason, **kw):
+        kickback_calls.append((task_id, reason))
+
+    monkeypatch.setattr(s, "kickback_with_cascade", fake_kickback)
+
+    task = _task()
+    outcome = s._attempt_auto_merge(task)
+    assert outcome.action == "merge"
+
+    result = s._handle_auto_merge_outcome(outcome, task)
+    assert result == MergeResult.FAILED
+    assert merge_called == [], "gh pr merge must not run after checkout failure"
+    assert kickback_calls and kickback_calls[0][0] == "task-1"
+    assert kickback_calls[0][1].startswith("auto_merge_local_test_failed")
+    assert "checkout_failed" in kickback_calls[0][1]
+    # test_command must NOT have been executed.
+    assert not any(list(cmd) == s.test_command for cmd in run_calls), (
+        f"test_command should not run after checkout failure, got {run_calls}"
+    )
+    # Integration branch restore still attempted.
+    assert checkout_calls[-1] == ["checkout", s.integration_branch]
+
+
+def test_local_tests_mode_dirty_takes_rebase_path_no_extra_pretest(monkeypatch):
+    """DIRTY PR in local-tests mode → rebase path; the new pre-test gate
+    must NOT be entered (no test_command runs, no PR-branch checkout)."""
+    s = _make_soldier()
+    s.test_command = ["pytest", "-x", "-q"]
+    s.colony.get_mission.return_value = _mission(
+        auto_merge="on-review-pass-and-local-tests"
+    )
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: PRState("DIRTY", "MERGEABLE", "APPROVED", "SUCCESS"),
+    )
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+
+    rebase_calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        s,
+        "_rebase_pr_branch_for_auto_merge",
+        lambda task, pr: rebase_calls.append((task["id"], pr)),
+    )
+
+    run_calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        run_calls.append(list(cmd))
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    checkout_calls: list[list[str]] = []
+
+    def fake_checkout(args):
+        checkout_calls.append(list(args))
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(s, "_checkout_with_reclaim", fake_checkout)
+
+    task = _task()
+    outcome = s._attempt_auto_merge(task)
+    assert outcome.action == "rebase"
+
+    result = s._handle_auto_merge_outcome(outcome, task)
+    assert result == MergeResult.NEEDS_REVIEW
+    assert rebase_calls == [("task-1", "https://github.com/org/repo/pull/1")]
+    # Pre-test gate must not have run the test_command.
+    assert not any(list(cmd) == s.test_command for cmd in run_calls), (
+        f"test_command must not run on rebase path, got {run_calls}"
+    )
+
+
+def test_on_review_pass_clean_does_not_run_local_tests_regression(monkeypatch):
+    """Default on-review-pass mode + CLEAN PR must NOT trigger the local
+    test gate. subprocess.run is never called with self.test_command."""
+    s = _make_soldier()
+    s.test_command = ["pytest", "-x", "-q"]
+    s.colony.get_mission.return_value = _mission(auto_merge="on-review-pass")
+    monkeypatch.setattr(
+        s,
+        "_query_pr_state",
+        lambda pr: PRState("CLEAN", "MERGEABLE", "APPROVED", "SUCCESS"),
+    )
+    monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
+    monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
+    monkeypatch.setattr(s, "_gh_pr_merge_squash", lambda pr, branch=None: (True, ""))
+    monkeypatch.setattr(s, "_sync_integration_branch_after_auto_merge", lambda: None)
+
+    run_calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        run_calls.append(list(cmd))
+        return SimpleNamespace(returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    task = _task()
+    outcome = s._attempt_auto_merge(task)
+    assert outcome.action == "merge"
+    assert outcome.mode == "on-review-pass"
+
+    result = s._handle_auto_merge_outcome(outcome, task)
+    assert result == MergeResult.MERGED
+    # Default mode must NOT call subprocess.run with the test_command.
+    assert not any(list(cmd) == s.test_command for cmd in run_calls), (
+        f"on-review-pass mode must not run test_command, got {run_calls}"
+    )
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-x", "-q"])


### PR DESCRIPTION
## Summary
- New auto-merge mode `on-review-pass-and-local-tests`. Routing in `decide()` mirrors `on-review-pass`; the local pre-merge test gate is enforced in `_handle_auto_merge_outcome` only when `outcome.action == "merge"`, so DIRTY/BEHIND/BLOCKED/UNSTABLE paths behave identically to the existing mode.
- On a CLEAN PR + tests passing, the soldier checks out the PR branch in its working clone, runs the configured `test_command`, then proceeds to `gh pr merge --squash`. Any failure (no branch, checkout error, non-zero test exit) kicks back the task with reason `auto_merge_local_test_failed` and emits `auto_merge_kickback`.
- Integration branch is restored unconditionally (try/finally) so subsequent ticks start from a known-good state. `auto_merge_local_test_failed` added to `_MERGE_FAILED_REASONS` and documented in the auto-merge event vocabulary block.
- CLI: `mission create` / `mission update` already pull from `VALID_AUTO_MERGE_MODES`; help strings updated to document the new mode.

## Test plan
- [x] `pytest tests/ -x -q` — 1455 passed (full suite, deterministic order).
- [x] `ruff check .` — clean.
- [x] 4 new tests in `tests/test_auto_merge.py` confirming `decide()` mode routing matches `on-review-pass`.
- [x] 5 new tests in `tests/test_soldier_auto_merge.py`:
  - clean PR runs tests then merges; integration branch restored last
  - test failure kicks back with `auto_merge_local_test_failed`, no `gh pr merge` called
  - checkout failure kicks back, no `test_command` run, no merge
  - DIRTY PR takes the rebase path; pre-test gate not entered
  - regression: `on-review-pass` + CLEAN does NOT invoke `test_command`

Closes #374

🤖 Generated with [Claude Code](https://claude.com/claude-code)