### PR TITLE
fix(cli): add --test-command flag to mission create + update (Closes #363)

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -1425,6 +1425,18 @@ def mission():
     show_default=True,
     help="Action taken when the budget is exceeded.",
 )
+@click.option(
+    "--test-command",
+    "test_command",
+    multiple=True,
+    default=None,
+    help=(
+        "Override the test command (repeat the flag for each token: "
+        "--test-command pytest --test-command -x --test-command -q). "
+        "Mission soldier runs this on the merge gate. Defaults to the "
+        "soldier's built-in command."
+    ),
+)
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def mission_create(
@@ -1440,6 +1452,7 @@ def mission_create(
     max_cost_usd: float | None,
     max_tokens: int | None,
     budget_action: str,
+    test_command: tuple[str, ...],
     colony_url: str,
     token: str | None,
 ):
@@ -1467,6 +1480,8 @@ def mission_create(
         config["max_cost_usd"] = max_cost_usd
     if max_tokens is not None:
         config["max_tokens"] = max_tokens
+    if test_command:
+        config["test_command"] = list(test_command)
     # Always thread budget_action — even when budgets are unset it's harmless
     # and keeps round-trips deterministic.
     config["budget_action"] = budget_action
@@ -1645,6 +1660,18 @@ def mission_report(mission_id: str, fmt: str, colony_url: str, token: str | None
     default=None,
     help="Max re-plan cycles before mission fails. Overrides Queen-wide default.",
 )
+@click.option(
+    "--test-command",
+    "test_command",
+    multiple=True,
+    default=None,
+    help=(
+        "Override the test command (repeat the flag for each token: "
+        "--test-command pytest --test-command -x --test-command -q). "
+        "Mission soldier runs this on the merge gate. Defaults to the "
+        "soldier's built-in command."
+    ),
+)
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def mission_update(
@@ -1652,6 +1679,7 @@ def mission_update(
     auto_merge: str | None,
     allow_auto_merge_on_external: bool | None,
     max_re_plans: int | None,
+    test_command: tuple[str, ...],
     colony_url: str,
     token: str | None,
 ):
@@ -1663,11 +1691,14 @@ def mission_update(
         partial["allow_auto_merge_on_external"] = bool(allow_auto_merge_on_external)
     if max_re_plans is not None:
         partial["max_re_plans"] = max_re_plans
+    if test_command:
+        partial["test_command"] = list(test_command)
 
     if not partial:
         click.echo(
             "No updates specified. "
-            "Use --auto-merge, --allow-auto-merge-on-external, or --max-re-plans."
+            "Use --auto-merge, --allow-auto-merge-on-external, "
+            "--max-re-plans, or --test-command."
         )
         return
 

--- a/tests/test_mission_cli.py
+++ b/tests/test_mission_cli.py
@@ -509,6 +509,169 @@ def test_mission_status_prints_auto_merge_line():
 
 
 # ---------------------------------------------------------------------------
+# mission create / update --test-command (#363)
+# ---------------------------------------------------------------------------
+
+
+def test_mission_create_test_command_flag_sets_config(tmp_path: Path):
+    """--test-command repeated tokens are collected into a list in config."""
+    spec_file = tmp_path / "spec.md"
+    spec_file.write_text("spec")
+
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"mission_id": "m1"}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission",
+                "create",
+                "--spec",
+                str(spec_file),
+                "--test-command",
+                "pytest",
+                "--test-command",
+                "-x",
+                "--test-command",
+                "-q",
+                "--colony-url",
+                "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+        assert payload["config"]["test_command"] == ["pytest", "-x", "-q"]
+
+
+def test_mission_create_test_command_with_bash_c_form(tmp_path: Path):
+    """--test-command preserves multi-token shell forms like `bash -c "..."`."""
+    spec_file = tmp_path / "spec.md"
+    spec_file.write_text("spec")
+
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"mission_id": "m1"}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission",
+                "create",
+                "--spec",
+                str(spec_file),
+                "--test-command",
+                "bash",
+                "--test-command",
+                "-c",
+                "--test-command",
+                "pytest && mypy",
+                "--colony-url",
+                "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+        assert payload["config"]["test_command"] == ["bash", "-c", "pytest && mypy"]
+
+
+def test_mission_create_no_test_command_omits_key(tmp_path: Path):
+    """Without --test-command, the key is absent from config."""
+    spec_file = tmp_path / "spec.md"
+    spec_file.write_text("spec")
+
+    runner = CliRunner()
+
+    with patch("antfarm.core.cli.httpx.post") as mock_post:
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"mission_id": "m1"}
+        mock_post.return_value = mock_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission",
+                "create",
+                "--spec",
+                str(spec_file),
+                "--colony-url",
+                "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1]["json"]
+        assert "test_command" not in payload.get("config", {})
+
+
+def test_mission_update_test_command_patches_config():
+    """mission update --test-command GETs, merges, then PATCHes config preserving fields."""
+    runner = CliRunner()
+
+    current_mission = {
+        "mission_id": "m1",
+        "status": "building",
+        "config": {
+            "completion_mode": "best_effort",
+            "max_parallel_builders": 4,
+            "auto_merge": "never",
+        },
+        "task_ids": [],
+        "created_at": "2026-04-20T00:00:00Z",
+    }
+
+    with (
+        patch("antfarm.core.cli.httpx.get") as mock_get,
+        patch("antfarm.core.cli.httpx.patch") as mock_patch,
+    ):
+        mock_get_resp = MagicMock()
+        mock_get_resp.status_code = 200
+        mock_get_resp.json.return_value = current_mission
+        mock_get.return_value = mock_get_resp
+
+        mock_patch_resp = MagicMock()
+        mock_patch_resp.status_code = 200
+        mock_patch_resp.json.return_value = {"ok": True}
+        mock_patch.return_value = mock_patch_resp
+
+        result = runner.invoke(
+            main,
+            [
+                "mission",
+                "update",
+                "m1",
+                "--test-command",
+                "pytest",
+                "--test-command",
+                "-x",
+                "--colony-url",
+                "http://localhost:7433",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        payload = mock_patch.call_args.kwargs.get("json") or mock_patch.call_args[1]["json"]
+        merged_config = payload["updates"]["config"]
+        # Existing fields preserved
+        assert merged_config["completion_mode"] == "best_effort"
+        assert merged_config["max_parallel_builders"] == 4
+        assert merged_config["auto_merge"] == "never"
+        # New test_command applied
+        assert merged_config["test_command"] == ["pytest", "-x"]
+
+
+# ---------------------------------------------------------------------------
 # carry --mission
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Adds repeatable `--test-command` flag to `antfarm mission create` and `antfarm mission update`, mapping to `MissionConfig.test_command`.
- Operators can now override the soldier's default pytest command from the CLI (e.g. `--test-command vitest --test-command --run`) without POSTing raw JSON to `/missions`.
- Mirrors the existing `--auto-merge` / `--max-re-plans` plumbing pattern.

## Test plan
- [x] `pytest tests/ -x -q` — 1459 passed
- [x] `ruff check .` — clean
- [x] New tests cover: simple token list, `bash -c "..."` form preserved, key omitted when flag absent, update PATCH preserves existing config fields.

Closes #363