### PR TITLE
feat(cli): human-readable scout --watch output (Closes #377)

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -643,20 +643,33 @@ def _render_scout(status: dict, prev: dict | None) -> None:
 
 
 def _format_event(event: dict) -> str:
-    """Format an SSE event dict as an activity-feed line: ``HH:MM:SS  <actor:12>  <detail>``."""
-    ts = event.get("ts", "") or ""
-    time_part = ts.split("T", 1)[1][:8] if "T" in ts else ts[:8]
-    actor = str(event.get("actor") or event.get("type") or "")
-    detail = event.get("detail", "")
-    return f"{time_part}  {actor:<12}  {detail}"
+    """Format an SSE event dict as an activity-feed line.
+
+    Thin wrapper that delegates to :mod:`antfarm.core.watch_format` so the
+    pure formatting logic lives in a tested module and the CLI keeps only
+    httpx/click wiring (#377).
+    """
+    from antfarm.core import watch_format
+
+    return watch_format.format_event_human(event)
 
 
-def _scout_watch(colony_url: str, token: str | None) -> None:
+def _scout_watch(colony_url: str, token: str | None, json_mode: bool, verbose: bool) -> None:
     """Stream ``/events`` via SSE, printing one formatted line per event.
 
     Reconnects on connection close and carries the cursor forward so no events
     are lost across reconnects. Exits cleanly on KeyboardInterrupt.
+
+    Args:
+        colony_url: Base URL of the colony API.
+        token: Optional bearer token.
+        json_mode: When True, emit raw SSE JSON passthrough (no human
+            reformatting, no filtering). Useful for piping to ``jq``.
+        verbose: When True, include low-signal events (heartbeat, polling,
+            idle, scanning, cleanup). Default hides them.
     """
+    from antfarm.core import watch_format
+
     events_url = f"{colony_url.rstrip('/')}/events"
     headers = _auth_headers(token)
     cursor = 0
@@ -679,10 +692,17 @@ def _scout_watch(colony_url: str, token: str | None) -> None:
                             event = json.loads(raw)
                         except json.JSONDecodeError:
                             continue
+                        # Cursor advance happens BEFORE filtering so reconnects
+                        # don't replay events we've already seen and dropped.
                         event_id = event.get("id")
                         if isinstance(event_id, int) and event_id > cursor:
                             cursor = event_id
-                        click.echo(_format_event(event))
+                        if json_mode:
+                            click.echo(raw)
+                            continue
+                        if not verbose and watch_format.is_low_signal(event):
+                            continue
+                        click.echo(watch_format.format_event_human(event))
             except httpx.HTTPError:
                 # Brief backoff before reconnect; cursor is preserved.
                 time.sleep(1)
@@ -704,12 +724,28 @@ def _scout_watch(colony_url: str, token: str | None) -> None:
     show_default=True,
     help="Seconds between TUI refreshes (with --tui).",
 )
+@click.option(
+    "--json",
+    "json_mode",
+    is_flag=True,
+    default=False,
+    help="With --watch, emit raw SSE JSON passthrough (no human reformatting).",
+)
+@click.option(
+    "-v",
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="With --watch, include low-signal events (heartbeat, polling, idle).",
+)
 @COLONY_URL_OPTION
 @TOKEN_OPTION
 def scout(
     watch: bool,
     tui: bool,
     refresh: float,
+    json_mode: bool,
+    verbose: bool,
     colony_url: str,
     token: str | None,
 ):
@@ -722,7 +758,7 @@ def scout(
         return
 
     if watch:
-        _scout_watch(colony_url, token)
+        _scout_watch(colony_url, token, json_mode=json_mode, verbose=verbose)
         return
 
     status = _get(colony_url, "/status", token=token)

--- a/antfarm/core/watch_format.py
+++ b/antfarm/core/watch_format.py
@@ -1,0 +1,471 @@
+"""Human-readable formatter for ``scout --watch`` SSE event lines.
+
+Pure module — no httpx, no click handlers, no IO. Each function takes a raw
+event dict (as produced by ``serve._emit_event``) and returns either a
+formatted string, a parsed sub-dict, or a boolean classification.
+
+Public surface:
+
+* :data:`NON_WORKER_ACTORS`  — actors that are subsystems (not worker_ids).
+* :data:`SUBSYSTEM_COLORS`   — color per subsystem actor.
+* :data:`WORKER_PALETTE`     — deterministic palette (mirror of
+  :class:`antfarm.core.tui.AntfarmTUI` ``_WORKER_PALETTE``).
+* :data:`LOW_SIGNAL_TYPES`   — event types suppressed unless ``--verbose``.
+* :func:`color_for_worker`   — palette pick by stable hash.
+* :func:`palette_color`      — actor -> color (subsystem-aware).
+* :func:`is_low_signal`      — True if event should be hidden by default.
+* :func:`format_event_human` — single-line ``HH:MM:SS  actor  detail`` row.
+
+The formatter is defensive: every event-type-specific helper is wrapped so
+unknown shapes degrade gracefully to a generic ``type detail`` fallback.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import click
+
+# Subsystem actors are *not* worker_ids; they get a fixed color rather than
+# a hash-derived per-worker color (mirrors tui.AntfarmTUI._NON_WORKER_ACTORS).
+NON_WORKER_ACTORS: frozenset[str] = frozenset(
+    {"colony", "queen", "autoscaler", "soldier", "doctor"}
+)
+
+# Per-subsystem coloring. ``autoscaler`` uses ``bright_black`` so its noisy
+# spawn/retire chatter is visually de-emphasised vs the more interesting
+# soldier/queen/doctor lines.
+SUBSYSTEM_COLORS: dict[str, str] = {
+    "soldier": "yellow",
+    "doctor": "green",
+    "queen": "blue",
+    "autoscaler": "bright_black",
+    "colony": "white",
+}
+
+# Deterministic palette, same order as tui.AntfarmTUI._WORKER_PALETTE so that
+# a worker shows the same color in the TUI dashboard and in ``scout --watch``.
+WORKER_PALETTE: tuple[str, ...] = (
+    "cyan",
+    "magenta",
+    "green",
+    "yellow",
+    "blue",
+    "bright_cyan",
+    "bright_magenta",
+    "bright_green",
+)
+
+# worker_activity actions and event types that fire on every poll loop tick.
+# Hidden by default so the live feed surfaces only meaningful state changes.
+# Pass ``-v`` / ``--verbose`` to ``scout --watch`` to include them.
+_HEARTBEAT_VERBS: frozenset[str] = frozenset(
+    {"heartbeat", "polling", "idle", "scanning", "cleanup"}
+)
+LOW_SIGNAL_TYPES: frozenset[str] = frozenset(
+    {"heartbeat", "scanning", "idle", "polling", "cleanup"}
+)
+
+
+# ---------------------------------------------------------------------------
+# Color selection
+# ---------------------------------------------------------------------------
+
+
+def color_for_worker(actor: str) -> str:
+    """Return a deterministic palette color for an actor string.
+
+    Hash-mod-N over the actor — same actor maps to the same color every
+    time, across processes (stable, not Python's salted ``hash()``).
+    Mirrors :meth:`antfarm.core.tui.AntfarmTUI._color_for_worker`.
+    """
+    if not actor:
+        return WORKER_PALETTE[0]
+    h = sum(ord(c) for c in actor)
+    return WORKER_PALETTE[h % len(WORKER_PALETTE)]
+
+
+def palette_color(actor: str) -> str:
+    """Return the color to use for ``actor`` in the formatted event row.
+
+    Subsystem actors (``soldier``, ``doctor``, ``queen``, ``autoscaler``,
+    ``colony``) get their fixed :data:`SUBSYSTEM_COLORS` entry. Anything
+    else is treated as a worker_id and colored via
+    :func:`color_for_worker`.
+    """
+    if actor in NON_WORKER_ACTORS:
+        return SUBSYSTEM_COLORS.get(actor, "white")
+    return color_for_worker(actor)
+
+
+# ---------------------------------------------------------------------------
+# Low-signal classifier
+# ---------------------------------------------------------------------------
+
+
+def is_low_signal(event: dict) -> bool:
+    """Return True if ``event`` is heartbeat-grade noise.
+
+    An event is low-signal if either:
+
+    * Its ``type`` is in :data:`LOW_SIGNAL_TYPES`, OR
+    * Its ``type`` is ``"worker_activity"`` and its ``data.action`` is one
+      of the heartbeat verbs (``polling``, ``idle``, ``scanning``,
+      ``cleanup``, ``heartbeat``).
+
+    Default scout-watch behavior hides these. ``--verbose`` shows them.
+    """
+    event_type = event.get("type") or ""
+    if event_type in LOW_SIGNAL_TYPES:
+        return True
+    if event_type == "worker_activity":
+        data = event.get("data") or {}
+        action = (data.get("action") or "").strip()
+        if action in _HEARTBEAT_VERBS:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _kv(detail: str) -> dict[str, str]:
+    """Parse ``key=value key=value`` strings into a dict.
+
+    Whitespace-delimited. Tokens missing ``=`` are dropped. Defensive:
+    never raises on weird input — just returns whatever it could parse.
+    """
+    out: dict[str, str] = {}
+    if not detail:
+        return out
+    for token in detail.split():
+        if "=" not in token:
+            continue
+        k, _, v = token.partition("=")
+        if k:
+            out[k] = v
+    return out
+
+
+def _format_timestamp(ts: str) -> str:
+    """Return ``HH:MM:SS`` from an ISO 8601 timestamp.
+
+    Falls back to ``--:--:--`` for empty / malformed values.
+    """
+    if not ts:
+        return "--:--:--"
+    try:
+        dt = datetime.fromisoformat(ts)
+        return dt.astimezone().strftime("%H:%M:%S")
+    except (ValueError, TypeError):
+        return "--:--:--"
+
+
+def _short_task(task_id: str) -> str:
+    """Shorten a task id for the activity feed (last segment after ``-``)."""
+    if not task_id:
+        return ""
+    # task-mission-slug-01 → task-mission-slug-01 (we do not abbreviate task
+    # ids in the watch feed; the field is rendered inline in the detail).
+    return task_id
+
+
+# ---------------------------------------------------------------------------
+# Per-event-type formatters
+#
+# Each helper returns the *detail* portion only (no timestamp, no actor).
+# Wrap parsing in defensive try/except — unknown shapes fall through to the
+# generic fallback in ``format_event_human``.
+# ---------------------------------------------------------------------------
+
+
+def _fmt_worker_activity(event: dict) -> str:
+    """worker_activity already carries a synthesized line in ``detail``."""
+    return event.get("detail") or "-"
+
+
+def _fmt_harvested(event: dict) -> str:
+    """``harvested task-1 → PR 42`` (branch dropped — PR number is enough)."""
+    task_id = event.get("task_id") or ""
+    fields = _kv(event.get("detail") or "")
+    pr = fields.get("pr", "")
+    pr_part = f" → PR {pr}" if pr else ""
+    if task_id:
+        return f"harvested {task_id}{pr_part}"
+    return f"harvested{pr_part}"
+
+
+def _fmt_merged(event: dict) -> str:
+    """``merged task-1 (auto)`` — adds ``(auto)`` for auto-merge events."""
+    task_id = event.get("task_id") or ""
+    fields = _kv(event.get("detail") or "")
+    auto = fields.get("auto_merged") == "1" or fields.get("mode") in {"auto", "squash"}
+    suffix = " (auto)" if auto else ""
+    if task_id:
+        return f"merged {task_id}{suffix}"
+    return f"merged{suffix}"
+
+
+def _fmt_kickback(event: dict) -> str:
+    """``kickback task-1: <reason>`` — trims the reason to a single line."""
+    task_id = event.get("task_id") or ""
+    reason = (event.get("detail") or "").splitlines()[0] if event.get("detail") else ""
+    if task_id and reason:
+        return f"kickback {task_id}: {reason}"
+    if task_id:
+        return f"kickback {task_id}"
+    return f"kickback {reason}".strip()
+
+
+def _fmt_auto_merged(event: dict) -> str:
+    """``auto-merged task-1 → PR 42 (mode=squash)``."""
+    task_id = event.get("task_id") or ""
+    fields = _kv(event.get("detail") or "")
+    pr = fields.get("pr", "")
+    mode = fields.get("mode", "")
+    pr_part = f" → PR {pr}" if pr else ""
+    mode_part = f" (mode={mode})" if mode else ""
+    return f"auto-merged {task_id}{pr_part}{mode_part}".strip()
+
+
+def _fmt_auto_merge_rebasing(event: dict) -> str:
+    """``rebasing task-1 PR 42 — <reason>``."""
+    task_id = event.get("task_id") or ""
+    fields = _kv(event.get("detail") or "")
+    pr = fields.get("pr", "")
+    reason = fields.get("reason", "")
+    pr_part = f" PR {pr}" if pr else ""
+    reason_part = f" — {reason}" if reason else ""
+    return f"rebasing {task_id}{pr_part}{reason_part}".strip()
+
+
+def _fmt_auto_merge_waiting_ci(event: dict) -> str:
+    """``waiting on CI for task-1 PR 42``."""
+    task_id = event.get("task_id") or ""
+    fields = _kv(event.get("detail") or "")
+    pr = fields.get("pr", "")
+    pr_part = f" PR {pr}" if pr else ""
+    return f"waiting on CI for {task_id}{pr_part}".strip()
+
+
+def _fmt_auto_merge_kickback(event: dict) -> str:
+    """``auto-merge kickback task-1 PR 42 — <reason>``."""
+    task_id = event.get("task_id") or ""
+    fields = _kv(event.get("detail") or "")
+    pr = fields.get("pr", "")
+    reason = fields.get("reason", "")
+    pr_part = f" PR {pr}" if pr else ""
+    reason_part = f" — {reason}" if reason else ""
+    return f"auto-merge kickback {task_id}{pr_part}{reason_part}".strip()
+
+
+def _fmt_repo_dirty(event: dict) -> str:
+    """``repo dirty (task-1): <detail>``."""
+    task_id = event.get("task_id") or ""
+    detail = event.get("detail") or ""
+    if task_id and detail:
+        return f"repo dirty ({task_id}): {detail}"
+    if task_id:
+        return f"repo dirty ({task_id})"
+    return f"repo dirty: {detail}".strip()
+
+
+def _fmt_merge_failed(event: dict) -> str:
+    """``merge failed task-1 — <reason>``."""
+    task_id = event.get("task_id") or ""
+    fields = _kv(event.get("detail") or "")
+    reason = fields.get("reason") or (event.get("detail") or "")
+    reason_part = f" — {reason}" if reason else ""
+    return f"merge failed {task_id}{reason_part}".strip()
+
+
+def _fmt_merge_succeeded(event: dict) -> str:
+    """``merge succeeded task-1 (<branch>)``."""
+    task_id = event.get("task_id") or ""
+    detail = event.get("detail") or ""
+    branch_part = f" ({detail})" if detail else ""
+    return f"merge succeeded {task_id}{branch_part}".strip()
+
+
+def _fmt_reconciled_external(event: dict) -> str:
+    """``reconciled external merge: task-1 PR 42``."""
+    task_id = event.get("task_id") or ""
+    fields = _kv(event.get("detail") or "")
+    pr = fields.get("pr", "")
+    pr_part = f" PR {pr}" if pr else ""
+    return f"reconciled external merge: {task_id}{pr_part}".strip()
+
+
+def _fmt_worker_spawned(event: dict) -> str:
+    """``spawned worker (role=builder name=builder-1)``."""
+    detail = event.get("detail") or ""
+    return f"spawned worker ({detail})".strip() if detail else "spawned worker"
+
+
+def _fmt_worker_retired(event: dict) -> str:
+    """``retired worker (role=builder name=builder-1)``."""
+    detail = event.get("detail") or ""
+    return f"retired worker ({detail})".strip() if detail else "retired worker"
+
+
+def _fmt_worktree_pruned(event: dict) -> str:
+    """``pruned worktree: <path>``."""
+    detail = event.get("detail") or ""
+    return f"pruned worktree: {detail}".strip() if detail else "pruned worktree"
+
+
+def _fmt_worktree_reclaimed(event: dict) -> str:
+    """``reclaimed worktree: <path>``."""
+    fields = _kv(event.get("detail") or "")
+    path = fields.get("path") or (event.get("detail") or "")
+    return f"reclaimed worktree: {path}".strip() if path else "reclaimed worktree"
+
+
+def _fmt_mission_complete(event: dict) -> str:
+    """``mission complete: <id>``."""
+    fields = _kv(event.get("detail") or "")
+    mid = fields.get("mission") or (event.get("detail") or "")
+    return f"mission complete: {mid}".strip() if mid else "mission complete"
+
+
+def _fmt_mission_failed(event: dict) -> str:
+    """``mission failed: <id> — <reason>``."""
+    fields = _kv(event.get("detail") or "")
+    mid = fields.get("mission") or ""
+    reason = fields.get("reason") or ""
+    if mid and reason:
+        return f"mission failed: {mid} — {reason}"
+    if mid:
+        return f"mission failed: {mid}"
+    return f"mission failed: {event.get('detail') or ''}".strip()
+
+
+def _fmt_mission_budget_exceeded(event: dict) -> str:
+    """``mission budget exceeded: <id> action=<pause|cancel>``."""
+    fields = _kv(event.get("detail") or "")
+    mid = fields.get("mission") or ""
+    action = fields.get("action") or ""
+    if mid and action:
+        return f"mission budget exceeded: {mid} ({action})"
+    if mid:
+        return f"mission budget exceeded: {mid}"
+    return "mission budget exceeded"
+
+
+def _fmt_plan_approved(event: dict) -> str:
+    """``plan approved: <mission> (<n> tasks)``."""
+    fields = _kv(event.get("detail") or "")
+    mid = fields.get("mission") or ""
+    tasks = fields.get("tasks") or ""
+    if mid and tasks:
+        return f"plan approved: {mid} ({tasks} tasks)"
+    if mid:
+        return f"plan approved: {mid}"
+    return "plan approved"
+
+
+def _fmt_plan_ready(event: dict) -> str:
+    """``plan ready: <mission>`` — defensive (event type may not yet exist)."""
+    fields = _kv(event.get("detail") or "")
+    mid = fields.get("mission") or (event.get("detail") or "")
+    return f"plan ready: {mid}".strip() if mid else "plan ready"
+
+
+def _fmt_retry_pattern(event: dict) -> str:
+    """``retry pattern detected: <detail>`` — defensive."""
+    detail = event.get("detail") or ""
+    return f"retry pattern: {detail}".strip() if detail else "retry pattern detected"
+
+
+def _fmt_fallback(event: dict) -> str:
+    """``fallback: <detail>`` — defensive."""
+    detail = event.get("detail") or ""
+    return f"fallback: {detail}".strip() if detail else "fallback"
+
+
+# Dispatch table. Keep ordering stable for readability.
+_FORMATTERS: dict[str, callable] = {
+    "worker_activity": _fmt_worker_activity,
+    "harvested": _fmt_harvested,
+    "merged": _fmt_merged,
+    "kickback": _fmt_kickback,
+    "auto_merged": _fmt_auto_merged,
+    "auto_merge_rebasing": _fmt_auto_merge_rebasing,
+    "auto_merge_waiting_ci": _fmt_auto_merge_waiting_ci,
+    "auto_merge_kickback": _fmt_auto_merge_kickback,
+    "repo_dirty": _fmt_repo_dirty,
+    "merge_failed": _fmt_merge_failed,
+    "merge_succeeded": _fmt_merge_succeeded,
+    "reconciled_external": _fmt_reconciled_external,
+    "worker_spawned": _fmt_worker_spawned,
+    "worker_retired": _fmt_worker_retired,
+    "worktree_pruned": _fmt_worktree_pruned,
+    "worktree_reclaimed": _fmt_worktree_reclaimed,
+    "mission_complete": _fmt_mission_complete,
+    "mission_failed": _fmt_mission_failed,
+    "mission_budget_exceeded": _fmt_mission_budget_exceeded,
+    "plan_approved": _fmt_plan_approved,
+    "plan_ready": _fmt_plan_ready,
+    "retry_pattern": _fmt_retry_pattern,
+    "fallback": _fmt_fallback,
+}
+
+
+def _fmt_unknown(event: dict) -> str:
+    """Fallback for unknown event types: ``<type> <task_id> <detail>``."""
+    event_type = event.get("type") or "-"
+    task_id = event.get("task_id") or ""
+    detail = event.get("detail") or ""
+    parts = [event_type]
+    if task_id:
+        parts.append(task_id)
+    if detail:
+        parts.append(detail)
+    return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Top-level entry point
+# ---------------------------------------------------------------------------
+
+
+def format_event_human(event: dict, *, use_color: bool = True) -> str:
+    """Format a single SSE event dict as a one-line activity row.
+
+    Layout: ``HH:MM:SS  actor  detail``
+
+    Color rules (mirror ``tui.AntfarmTUI._render_activity``):
+
+    * If the event type contains ``"failed"`` -> entire line red.
+    * Else if the event type contains ``"kick"`` -> entire line yellow.
+    * Else the actor column is colored via :func:`palette_color`.
+
+    With ``use_color=False`` no ANSI escapes are emitted (used by tests
+    that assert plain substrings; not currently exposed via the CLI).
+    """
+    time_part = _format_timestamp(event.get("ts") or "")
+
+    actor_raw = str(event.get("actor") or event.get("type") or "")
+    actor_col = actor_raw[:12].ljust(12)
+
+    event_type = event.get("type") or ""
+
+    formatter = _FORMATTERS.get(event_type, _fmt_unknown)
+    try:
+        detail = formatter(event)
+    except Exception:
+        detail = _fmt_unknown(event)
+
+    if not use_color:
+        return f"{time_part}  {actor_col}  {detail}"
+
+    # Row-wide color overrides for failure / kickback events.
+    if "failed" in event_type:
+        return click.style(f"{time_part}  {actor_col}  {detail}", fg="red")
+    if "kick" in event_type:
+        return click.style(f"{time_part}  {actor_col}  {detail}", fg="yellow")
+
+    actor_styled = click.style(actor_col, fg=palette_color(actor_raw))
+    return f"{time_part}  {actor_styled}  {detail}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -250,12 +250,16 @@ def test_scout_watch_streams_events():
         )
 
     assert result.exit_code == 0, result.output
-    assert "14:32:11" in result.output
+    # Timestamps render in local TZ; assert the stable seconds field instead
+    # of the literal hour. Formatter output is human form, not raw key=value.
+    assert ":32:11" in result.output
     assert "runner" in result.output
-    assert "pr=42 branch=feat/x" in result.output
-    assert "14:33:02" in result.output
+    assert "harvested" in result.output
+    assert "task-1" in result.output
+    assert "PR 42" in result.output
+    assert ":33:02" in result.output
     assert "soldier" in result.output
-    assert "attempt=att-001" in result.output
+    assert "merged" in result.output
 
 
 def test_scout_watch_tracks_cursor_across_reconnects():
@@ -302,8 +306,11 @@ def test_scout_watch_tracks_cursor_across_reconnects():
     assert result.exit_code == 0, result.output
     assert calls[0].get("after") == 0
     assert calls[1].get("after") == 3
-    assert "d1" in result.output
-    assert "d2" in result.output
+    # Each batch is rendered via the human formatter; assert task ids and
+    # event keywords (the raw d1/d2 detail blobs no longer appear verbatim).
+    assert "task-a" in result.output
+    assert "harvested" in result.output
+    assert "merged" in result.output
 
 
 def test_scout_watch_ctrl_c_exits_cleanly():
@@ -366,6 +373,134 @@ def test_scout_watch_reconnects_on_http_error():
     assert calls[1].get("after") == 5
     # Third call (after HTTPError backoff) retains the advanced cursor.
     assert calls[2].get("after") == 5
+
+
+def test_scout_watch_json_passthrough():
+    """``--watch --json`` echoes raw SSE JSON without human reformatting."""
+    runner = CliRunner()
+
+    events = [
+        {
+            "id": 1,
+            "type": "harvested",
+            "actor": "runner",
+            "task_id": "task-1",
+            "detail": "pr=42 branch=feat/x",
+            "ts": "2026-04-16T14:32:11+00:00",
+        }
+    ]
+    lines = [f"data: {json.dumps(e)}" for e in events]
+
+    call_count = {"n": 0}
+
+    def fake_stream(method, url, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return _make_stream_ctx(lines)
+        raise KeyboardInterrupt
+
+    with patch("antfarm.core.cli.httpx.stream", side_effect=fake_stream):
+        result = runner.invoke(
+            main,
+            ["scout", "--watch", "--json", "--colony-url", "http://localhost:7433"],
+        )
+
+    assert result.exit_code == 0, result.output
+    # Raw JSON object passes through verbatim — the human formatter is bypassed.
+    assert '"type": "harvested"' in result.output
+    assert '"pr=42 branch=feat/x"' in result.output
+    # No human-reformatting sentinel.
+    assert "PR 42" not in result.output
+
+
+def test_scout_watch_filters_low_signal_by_default():
+    """Default ``--watch`` suppresses heartbeat-grade noise (polling/idle/etc)."""
+    runner = CliRunner()
+
+    events = [
+        {
+            "id": 1,
+            "type": "polling",
+            "actor": "soldier",
+            "task_id": "",
+            "detail": "tick",
+            "ts": "2026-04-16T14:32:00+00:00",
+        },
+        {
+            "id": 2,
+            "type": "harvested",
+            "actor": "runner",
+            "task_id": "task-1",
+            "detail": "pr=42 branch=feat/x",
+            "ts": "2026-04-16T14:32:11+00:00",
+        },
+    ]
+    lines = [f"data: {json.dumps(e)}" for e in events]
+
+    call_count = {"n": 0}
+
+    def fake_stream(method, url, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return _make_stream_ctx(lines)
+        raise KeyboardInterrupt
+
+    with patch("antfarm.core.cli.httpx.stream", side_effect=fake_stream):
+        result = runner.invoke(
+            main,
+            ["scout", "--watch", "--colony-url", "http://localhost:7433"],
+        )
+
+    assert result.exit_code == 0, result.output
+    # Heartbeat-grade event is hidden.
+    assert "polling" not in result.output
+    # High-signal event is shown.
+    assert "harvested" in result.output
+    assert "PR 42" in result.output
+
+
+def test_scout_watch_verbose_includes_low_signal():
+    """``-v`` / ``--verbose`` keeps heartbeat-grade events in the stream."""
+    runner = CliRunner()
+
+    events = [
+        {
+            "id": 1,
+            "type": "polling",
+            "actor": "soldier",
+            "task_id": "",
+            "detail": "tick",
+            "ts": "2026-04-16T14:32:00+00:00",
+        },
+        {
+            "id": 2,
+            "type": "harvested",
+            "actor": "runner",
+            "task_id": "task-1",
+            "detail": "pr=42 branch=feat/x",
+            "ts": "2026-04-16T14:32:11+00:00",
+        },
+    ]
+    lines = [f"data: {json.dumps(e)}" for e in events]
+
+    call_count = {"n": 0}
+
+    def fake_stream(method, url, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return _make_stream_ctx(lines)
+        raise KeyboardInterrupt
+
+    with patch("antfarm.core.cli.httpx.stream", side_effect=fake_stream):
+        result = runner.invoke(
+            main,
+            ["scout", "--watch", "-v", "--colony-url", "http://localhost:7433"],
+        )
+
+    assert result.exit_code == 0, result.output
+    # Both event types make it through.
+    assert "polling" in result.output
+    assert "harvested" in result.output
 
 
 def test_scout_oneshot_unchanged():

--- a/tests/test_watch_format.py
+++ b/tests/test_watch_format.py
@@ -1,0 +1,433 @@
+"""Tests for ``antfarm.core.watch_format``.
+
+Pure unit tests: no httpx, no FileBackend, no click runner. Covers per-event
+formatters, color rules, low-signal classification, and timestamp parsing.
+"""
+
+from __future__ import annotations
+
+from antfarm.core import watch_format
+
+# ---------------------------------------------------------------------------
+# color_for_worker / palette_color
+# ---------------------------------------------------------------------------
+
+
+def test_color_for_worker_is_deterministic():
+    """Same actor string -> same color across calls (process-stable)."""
+    a = watch_format.color_for_worker("builder-1")
+    b = watch_format.color_for_worker("builder-1")
+    assert a == b
+    assert a in watch_format.WORKER_PALETTE
+
+
+def test_color_for_worker_empty_returns_first_palette_entry():
+    """Empty actor string falls back to palette[0] (mirrors tui.py)."""
+    assert watch_format.color_for_worker("") == watch_format.WORKER_PALETTE[0]
+
+
+def test_palette_color_for_subsystems():
+    """Each subsystem actor has a fixed color from SUBSYSTEM_COLORS."""
+    assert watch_format.palette_color("soldier") == "yellow"
+    assert watch_format.palette_color("doctor") == "green"
+    assert watch_format.palette_color("queen") == "blue"
+    assert watch_format.palette_color("autoscaler") == "bright_black"
+    assert watch_format.palette_color("colony") == "white"
+
+
+def test_palette_color_for_worker_uses_palette():
+    """Non-subsystem actors get a palette color via hash-mod-N."""
+    color = watch_format.palette_color("builder-1")
+    assert color in watch_format.WORKER_PALETTE
+
+
+# ---------------------------------------------------------------------------
+# is_low_signal
+# ---------------------------------------------------------------------------
+
+
+def test_is_low_signal_for_typed_events():
+    """Events with type in LOW_SIGNAL_TYPES are filtered."""
+    for t in ("heartbeat", "scanning", "idle", "polling", "cleanup"):
+        assert watch_format.is_low_signal({"type": t}) is True
+
+
+def test_is_low_signal_worker_activity_with_heartbeat_action():
+    """worker_activity events with heartbeat-grade actions are low-signal."""
+    ev = {"type": "worker_activity", "data": {"action": "polling"}}
+    assert watch_format.is_low_signal(ev) is True
+
+
+def test_is_low_signal_worker_activity_with_real_action_is_signal():
+    """worker_activity with editing/running etc is high-signal (kept)."""
+    ev = {"type": "worker_activity", "data": {"action": "editing"}}
+    assert watch_format.is_low_signal(ev) is False
+
+
+def test_is_low_signal_high_signal_events():
+    """Real state changes are never low-signal."""
+    for t in ("harvested", "merged", "kickback", "auto_merged", "merge_failed"):
+        assert watch_format.is_low_signal({"type": t}) is False
+
+
+# ---------------------------------------------------------------------------
+# Timestamp formatting
+# ---------------------------------------------------------------------------
+
+
+def test_format_timestamp_extracts_hh_mm_ss():
+    """A normal ISO timestamp yields HH:MM:SS in local TZ."""
+    ev = {
+        "type": "harvested",
+        "actor": "runner",
+        "task_id": "task-1",
+        "detail": "pr=42 branch=feat/x",
+        "ts": "2026-04-16T14:32:11+00:00",
+    }
+    out = watch_format.format_event_human(ev, use_color=False)
+    # We can't assert literal "14:32:11" because astimezone() shifts to local
+    # time; assert the H:M:S shape and the seconds field.
+    parts = out.split()
+    assert len(parts[0]) == 8
+    assert parts[0].count(":") == 2
+    assert parts[0].endswith(":11")
+
+
+def test_format_timestamp_empty_yields_dashes():
+    """Missing timestamp degrades to ``--:--:--``."""
+    out = watch_format.format_event_human({"type": "harvested"}, use_color=False)
+    assert out.startswith("--:--:--")
+
+
+def test_format_timestamp_malformed_yields_dashes():
+    """Malformed timestamps degrade gracefully."""
+    out = watch_format.format_event_human(
+        {"type": "harvested", "ts": "not-a-timestamp"},
+        use_color=False,
+    )
+    assert out.startswith("--:--:--")
+
+
+# ---------------------------------------------------------------------------
+# Per-event-type formatters
+# ---------------------------------------------------------------------------
+
+
+def _row_detail(ev: dict) -> str:
+    """Strip timestamp + actor prefix, return only the detail portion.
+
+    Layout: ``HH:MM:SS  actor[12]  detail`` — the actor column is space-padded
+    to width 12. The simplest robust slice is "everything after the first
+    8 (timestamp) + 2 (gap) + 12 (actor) + 2 (gap) characters".
+    """
+    out = watch_format.format_event_human(ev, use_color=False)
+    return out[8 + 2 + 12 + 2 :]
+
+
+def test_worker_activity_uses_detail_verbatim():
+    ev = {"type": "worker_activity", "actor": "builder-1", "detail": "editing src/foo.py"}
+    assert _row_detail(ev) == "editing src/foo.py"
+
+
+def test_harvested_renders_pr_arrow():
+    ev = {
+        "type": "harvested",
+        "actor": "runner",
+        "task_id": "task-1",
+        "detail": "pr=42 branch=feat/x",
+    }
+    assert _row_detail(ev) == "harvested task-1 → PR 42"
+
+
+def test_harvested_without_pr():
+    ev = {"type": "harvested", "actor": "runner", "task_id": "task-1", "detail": ""}
+    assert _row_detail(ev) == "harvested task-1"
+
+
+def test_merged_basic():
+    ev = {"type": "merged", "actor": "soldier", "task_id": "task-1", "detail": "attempt=att-001"}
+    assert _row_detail(ev) == "merged task-1"
+
+
+def test_merged_auto_suffix():
+    """auto_merged=1 in detail adds the (auto) marker."""
+    ev = {
+        "type": "merged",
+        "actor": "soldier",
+        "task_id": "task-1",
+        "detail": "attempt=att-001 auto_merged=1",
+    }
+    assert _row_detail(ev) == "merged task-1 (auto)"
+
+
+def test_kickback_with_reason():
+    ev = {
+        "type": "kickback",
+        "actor": "soldier",
+        "task_id": "task-1",
+        "detail": "merge conflict on src/foo.py",
+    }
+    assert _row_detail(ev) == "kickback task-1: merge conflict on src/foo.py"
+
+
+def test_kickback_multiline_reason_trimmed():
+    """Only the first line of a multi-line reason is kept."""
+    ev = {
+        "type": "kickback",
+        "actor": "soldier",
+        "task_id": "task-1",
+        "detail": "first line\nsecond line\nthird",
+    }
+    assert _row_detail(ev) == "kickback task-1: first line"
+
+
+def test_auto_merged_renders_pr_and_mode():
+    ev = {
+        "type": "auto_merged",
+        "actor": "soldier",
+        "task_id": "task-1",
+        "detail": "pr=42 mode=squash reason=clean",
+    }
+    assert _row_detail(ev) == "auto-merged task-1 → PR 42 (mode=squash)"
+
+
+def test_auto_merge_rebasing():
+    ev = {
+        "type": "auto_merge_rebasing",
+        "actor": "soldier",
+        "task_id": "task-1",
+        "detail": "pr=42 mode=squash reason=behind_base",
+    }
+    assert _row_detail(ev) == "rebasing task-1 PR 42 — behind_base"
+
+
+def test_auto_merge_waiting_ci():
+    ev = {
+        "type": "auto_merge_waiting_ci",
+        "actor": "soldier",
+        "task_id": "task-1",
+        "detail": "pr=42 mode=squash reason=ci_pending",
+    }
+    assert _row_detail(ev) == "waiting on CI for task-1 PR 42"
+
+
+def test_auto_merge_kickback():
+    ev = {
+        "type": "auto_merge_kickback",
+        "actor": "soldier",
+        "task_id": "task-1",
+        "detail": "pr=42 mode=squash reason=ci_failed",
+    }
+    assert _row_detail(ev) == "auto-merge kickback task-1 PR 42 — ci_failed"
+
+
+def test_repo_dirty():
+    ev = {
+        "type": "repo_dirty",
+        "actor": "soldier",
+        "task_id": "task-1",
+        "detail": "preflight=fail attempting=recover",
+    }
+    assert _row_detail(ev) == "repo dirty (task-1): preflight=fail attempting=recover"
+
+
+def test_merge_failed_with_reason_kv():
+    ev = {
+        "type": "merge_failed",
+        "actor": "soldier",
+        "task_id": "task-1",
+        "detail": "reason=test_failed_pytest",
+    }
+    assert _row_detail(ev) == "merge failed task-1 — test_failed_pytest"
+
+
+def test_merge_succeeded_includes_branch():
+    ev = {
+        "type": "merge_succeeded",
+        "actor": "soldier",
+        "task_id": "task-1",
+        "detail": "feat/task-1",
+    }
+    assert _row_detail(ev) == "merge succeeded task-1 (feat/task-1)"
+
+
+def test_reconciled_external():
+    ev = {
+        "type": "reconciled_external",
+        "actor": "soldier",
+        "task_id": "task-1",
+        "detail": "pr=42",
+    }
+    assert _row_detail(ev) == "reconciled external merge: task-1 PR 42"
+
+
+def test_worker_spawned():
+    ev = {
+        "type": "worker_spawned",
+        "actor": "autoscaler",
+        "task_id": "",
+        "detail": "role=builder name=builder-1",
+    }
+    assert _row_detail(ev) == "spawned worker (role=builder name=builder-1)"
+
+
+def test_worker_retired():
+    ev = {
+        "type": "worker_retired",
+        "actor": "autoscaler",
+        "task_id": "",
+        "detail": "role=builder name=builder-1",
+    }
+    assert _row_detail(ev) == "retired worker (role=builder name=builder-1)"
+
+
+def test_worktree_pruned():
+    ev = {
+        "type": "worktree_pruned",
+        "actor": "doctor",
+        "task_id": "",
+        "detail": "/tmp/orphan-worktree",
+    }
+    assert _row_detail(ev) == "pruned worktree: /tmp/orphan-worktree"
+
+
+def test_worktree_reclaimed():
+    ev = {
+        "type": "worktree_reclaimed",
+        "actor": "soldier",
+        "task_id": "",
+        "detail": "path=/tmp/orphan",
+    }
+    assert _row_detail(ev) == "reclaimed worktree: /tmp/orphan"
+
+
+def test_mission_complete():
+    ev = {
+        "type": "mission_complete",
+        "actor": "queen",
+        "task_id": "",
+        "detail": "mission=mission-001",
+    }
+    assert _row_detail(ev) == "mission complete: mission-001"
+
+
+def test_mission_failed_defensive():
+    """mission_failed event type isn't yet emitted by the codebase, but the
+    formatter must still render it cleanly when it appears."""
+    ev = {
+        "type": "mission_failed",
+        "actor": "queen",
+        "task_id": "",
+        "detail": "mission=mission-001 reason=stalled",
+    }
+    assert _row_detail(ev) == "mission failed: mission-001 — stalled"
+
+
+def test_mission_budget_exceeded_pause():
+    ev = {
+        "type": "mission_budget_exceeded",
+        "actor": "queen",
+        "task_id": "",
+        "detail": "mission=mission-001 action=pause cost=1.50 tokens=42",
+    }
+    assert _row_detail(ev) == "mission budget exceeded: mission-001 (pause)"
+
+
+def test_plan_approved():
+    ev = {
+        "type": "plan_approved",
+        "actor": "queen",
+        "task_id": "plan-mission-001",
+        "detail": "mission=mission-001 tasks=5",
+    }
+    assert _row_detail(ev) == "plan approved: mission-001 (5 tasks)"
+
+
+def test_plan_ready_defensive():
+    ev = {
+        "type": "plan_ready",
+        "actor": "queen",
+        "task_id": "",
+        "detail": "mission=mission-001",
+    }
+    assert _row_detail(ev) == "plan ready: mission-001"
+
+
+def test_retry_pattern_defensive():
+    ev = {
+        "type": "retry_pattern",
+        "actor": "doctor",
+        "task_id": "task-1",
+        "detail": "failures=3 reason=lint",
+    }
+    assert _row_detail(ev) == "retry pattern: failures=3 reason=lint"
+
+
+def test_fallback_defensive():
+    ev = {
+        "type": "fallback",
+        "actor": "queen",
+        "task_id": "",
+        "detail": "model=opus->sonnet",
+    }
+    assert _row_detail(ev) == "fallback: model=opus->sonnet"
+
+
+def test_unknown_event_falls_back_to_generic():
+    """Unknown event types render as ``<type> <task_id> <detail>``."""
+    ev = {
+        "type": "some_new_event",
+        "actor": "colony",
+        "task_id": "task-1",
+        "detail": "info",
+    }
+    detail = _row_detail(ev)
+    assert "some_new_event" in detail
+    assert "task-1" in detail
+    assert "info" in detail
+
+
+# ---------------------------------------------------------------------------
+# Color rules
+# ---------------------------------------------------------------------------
+
+
+def test_failed_event_renders_red_full_line():
+    ev = {
+        "type": "merge_failed",
+        "actor": "soldier",
+        "task_id": "task-1",
+        "detail": "reason=test_failed",
+    }
+    out = watch_format.format_event_human(ev, use_color=True)
+    # Click's red ANSI prefix.
+    assert "\x1b[31m" in out
+
+
+def test_kick_event_renders_yellow_full_line():
+    ev = {
+        "type": "kickback",
+        "actor": "soldier",
+        "task_id": "task-1",
+        "detail": "merge conflict",
+    }
+    out = watch_format.format_event_human(ev, use_color=True)
+    # Click's yellow ANSI prefix.
+    assert "\x1b[33m" in out
+
+
+def test_normal_event_uses_actor_color():
+    """Non-failure events colorize only the actor column."""
+    ev = {
+        "type": "harvested",
+        "actor": "soldier",
+        "task_id": "task-1",
+        "detail": "pr=42",
+    }
+    out = watch_format.format_event_human(ev, use_color=True)
+    # Soldier's subsystem color is yellow (\x1b[33m), but it should appear
+    # only once around the actor column — the timestamp and detail must be
+    # bare. Detect by counting escape resets (\x1b[0m).
+    assert "\x1b[33m" in out  # actor styled yellow
+    # detail must be plain text, not styled red.
+    assert "\x1b[31m" not in out


### PR DESCRIPTION
## Summary
- New `antfarm/core/watch_format.py` pure module: per-event-type formatters that turn SSE events into human-friendly lines (`harvested task-1 → PR 42`, `rebasing task-1 PR 42 — behind_base`, `mission complete: mission-001`, …) with color rules mirroring the TUI (failure → red, kickback → yellow, subsystem actors get fixed colors, workers get deterministic palette picks).
- `scout --watch` now also accepts `--json` (raw SSE passthrough, no reformatting) and `-v / --verbose` (include heartbeat-grade noise: polling/idle/scanning/cleanup/heartbeat).
- CLI delegates formatting via `_format_event` → `watch_format.format_event_human` so the only logic in `cli.py` is httpx/click wiring.

Closes #377.

## Test plan
- [x] `pytest tests/test_watch_format.py -x -q` — 41 new pure unit tests cover every per-event-type formatter, palette/subsystem coloring, low-signal classification, timestamp parsing, failure/kickback color rules, and unknown-event fallback.
- [x] `pytest tests/test_cli.py -x -q` — existing watch tests updated for the new human form (`harvested`, `task-1`, `PR 42`, `:32:11` instead of `pr=42 branch=feat/x`); three new tests cover `--json` passthrough, default low-signal filtering, and `-v` verbose mode.
- [x] `pytest tests/ -x -q` — full suite green (1503 passed).
- [x] `ruff check .` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)