### PR TITLE
fix(soldier,auto_merge): UNSTABLE+failing-check kicks back instead of waiting forever (Closes #381)

### DIFF
--- a/antfarm/core/auto_merge.py
+++ b/antfarm/core/auto_merge.py
@@ -35,12 +35,20 @@ class PRState:
 
     Field names mirror the ``gh pr view --json`` keys so the adapter in
     :func:`parse_pr_state` stays literal.
+
+    ``ci_pending`` and ``ci_failing`` are summary flags derived from the
+    ``statusCheckRollup`` in :func:`parse_pr_state`. They let
+    :func:`decide` disambiguate ``UNSTABLE`` (#381) into "still pending"
+    vs. "already failing terminally" without re-walking the rollup. They
+    default to ``False`` so existing positional/test callers keep working.
     """
 
     mergeStateStatus: str
     mergeable: str
     review_decision: str
     ci_conclusion: str | None
+    ci_pending: bool = False
+    ci_failing: bool = False
 
 
 @dataclass
@@ -161,8 +169,20 @@ def decide(
         if status == "CLEAN":
             return AutoMergeOutcome(action="merge", pr=pr, mode=mode, reason="CLEAN")
         if status == "UNSTABLE":
+            # #381: UNSTABLE conflates "still pending" with "already failed".
+            # Inspect the summarized rollup flags to decide which one we hit.
+            if pr_state.ci_failing:
+                return AutoMergeOutcome(
+                    action="kickback_ci", pr=pr, mode=mode, reason="ci_check_failed"
+                )
+            if pr_state.ci_pending:
+                return AutoMergeOutcome(
+                    action="wait_ci", pr=pr, mode=mode, reason="UNSTABLE ci still pending"
+                )
+            # Defensive: rollup parse failed or pre-existing tests construct
+            # PRState without the new flags. Wait rather than guess wrong.
             return AutoMergeOutcome(
-                action="wait_ci", pr=pr, mode=mode, reason="UNSTABLE ci still pending"
+                action="wait_ci", pr=pr, mode=mode, reason="UNSTABLE ci unknown, waiting"
             )
         if status == "PENDING":
             return AutoMergeOutcome(action="wait_ci", pr=pr, mode=mode, reason="PENDING")
@@ -228,23 +248,50 @@ def parse_pr_state(gh_json_output: str) -> PRState | None:
         return None
 
     rollup = data.get("statusCheckRollup") or []
-    ci_conclusion: str | None = _aggregate_ci(rollup) if isinstance(rollup, list) else None
+    if isinstance(rollup, list):
+        ci_conclusion, ci_pending, ci_failing = _summarize_rollup(rollup)
+    else:
+        ci_conclusion, ci_pending, ci_failing = None, False, False
 
     return PRState(
         mergeStateStatus=str(data.get("mergeStateStatus") or ""),
         mergeable=str(data.get("mergeable") or ""),
         review_decision=str(data.get("reviewDecision") or ""),
         ci_conclusion=ci_conclusion,
+        ci_pending=ci_pending,
+        ci_failing=ci_failing,
     )
 
 
-def _aggregate_ci(rollup: list) -> str | None:
-    """Reduce ``statusCheckRollup`` to a single overall conclusion.
+def _summarize_rollup(rollup: list) -> tuple[str | None, bool, bool]:
+    """Reduce ``statusCheckRollup`` to ``(ci_conclusion, ci_pending, ci_failing)``.
 
-    See :func:`parse_pr_state` docstring for precedence rules.
+    Single pass over the rollup so :func:`decide` can both pick a coarse
+    aggregate conclusion and ALSO see whether any individual check is still
+    in flight or has terminally failed (#381).
+
+    Per-entry classification:
+
+    - ``conclusion`` in ``{FAILURE, TIMED_OUT}`` — terminal failure → set
+      ``saw_failing``.
+    - ``conclusion == "CANCELLED"`` — operators commonly re-trigger
+      cancelled runs, so treat as transient pending rather than terminal
+      failure.
+    - ``conclusion == "PENDING"`` OR ``status`` in
+      ``{IN_PROGRESS, QUEUED}`` — still in flight → set ``saw_pending``.
+    - ``conclusion`` in ``{SUCCESS, NEUTRAL, SKIPPED}`` — counted as
+      success; does not set the failing/pending flags.
+
+    Aggregate ``ci_conclusion`` precedence (most severe wins):
+
+    1. any failing → ``"FAILURE"``
+    2. else any pending → ``"PENDING"``
+    3. else any success → ``"SUCCESS"``
+    4. else → ``None``
     """
     if not rollup:
-        return None
+        return None, False, False
+    saw_failing = False
     saw_pending = False
     saw_success = False
     for entry in rollup:
@@ -252,15 +299,24 @@ def _aggregate_ci(rollup: list) -> str | None:
             continue
         conclusion = str(entry.get("conclusion") or "").upper()
         status = str(entry.get("status") or "").upper()
-        if conclusion == "FAILURE":
-            return "FAILURE"
+        if conclusion in ("FAILURE", "TIMED_OUT"):
+            saw_failing = True
+            continue
+        if conclusion == "CANCELLED":
+            saw_pending = True
+            continue
         if conclusion == "PENDING" or status in ("IN_PROGRESS", "QUEUED"):
             saw_pending = True
             continue
-        if conclusion == "SUCCESS":
+        if conclusion in ("SUCCESS", "NEUTRAL", "SKIPPED"):
             saw_success = True
-    if saw_pending:
-        return "PENDING"
-    if saw_success:
-        return "SUCCESS"
-    return None
+
+    if saw_failing:
+        ci_conclusion: str | None = "FAILURE"
+    elif saw_pending:
+        ci_conclusion = "PENDING"
+    elif saw_success:
+        ci_conclusion = "SUCCESS"
+    else:
+        ci_conclusion = None
+    return ci_conclusion, saw_pending, saw_failing

--- a/docs/antfarm/missions/mission-auth-1.md
+++ b/docs/antfarm/missions/mission-auth-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-auth-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:14:57.234893+00:00
-**Completed:** 2026-05-02T21:14:57.267352+00:00 (0s)
+**Created:** 2026-05-02T21:15:14.517963+00:00
+**Completed:** 2026-05-02T21:15:14.546340+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -21,8 +21,8 @@
 
 ## Timeline highlights
 
-- 21:14:57  mission created
-- 21:14:57  plan ready
-- 21:14:57  task-auth-01 merged
-- 21:14:57  task-auth-02 merged
-- 21:14:57  mission complete
+- 21:15:14  mission created
+- 21:15:14  plan ready
+- 21:15:14  task-auth-01 merged
+- 21:15:14  task-auth-02 merged
+- 21:15:14  mission complete

--- a/docs/antfarm/missions/mission-auth-1.md
+++ b/docs/antfarm/missions/mission-auth-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-auth-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-01T06:45:32.501308+00:00
-**Completed:** 2026-05-01T06:45:32.529895+00:00 (0s)
+**Created:** 2026-05-02T21:14:57.234893+00:00
+**Completed:** 2026-05-02T21:14:57.267352+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -21,8 +21,8 @@
 
 ## Timeline highlights
 
-- 06:45:32  mission created
-- 06:45:32  plan ready
-- 06:45:32  task-auth-01 merged
-- 06:45:32  task-auth-02 merged
-- 06:45:32  mission complete
+- 21:14:57  mission created
+- 21:14:57  plan ready
+- 21:14:57  task-auth-01 merged
+- 21:14:57  task-auth-02 merged
+- 21:14:57  mission complete

--- a/docs/antfarm/missions/mission-blocked-1.md
+++ b/docs/antfarm/missions/mission-blocked-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-blocked-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-01T06:45:33.196093+00:00
-**Completed:** 2026-05-01T06:45:33.229529+00:00 (0s)
+**Created:** 2026-05-02T21:14:57.994696+00:00
+**Completed:** 2026-05-02T21:14:58.028451+00:00 (0s)
 **Outcome:** complete (1/2 merged)
 
 ## Plan
@@ -21,10 +21,10 @@
 
 ## Timeline highlights
 
-- 06:45:33  mission created
-- 06:45:33  plan ready
-- 06:45:33  task-blocked-02 merged
-- 06:45:33  task-blocked-01 kicked back (kickback)
-- 06:45:33  task-blocked-01 kicked back (kickback)
-- 06:45:33  task-blocked-01 kicked back (kickback)
-- 06:45:33  mission complete
+- 21:14:57  mission created
+- 21:14:57  plan ready
+- 21:14:58  task-blocked-02 merged
+- 21:14:58  task-blocked-01 kicked back (kickback)
+- 21:14:58  task-blocked-01 kicked back (kickback)
+- 21:14:58  task-blocked-01 kicked back (kickback)
+- 21:14:58  mission complete

--- a/docs/antfarm/missions/mission-blocked-1.md
+++ b/docs/antfarm/missions/mission-blocked-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-blocked-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:14:57.994696+00:00
-**Completed:** 2026-05-02T21:14:58.028451+00:00 (0s)
+**Created:** 2026-05-02T21:15:15.205140+00:00
+**Completed:** 2026-05-02T21:15:15.240340+00:00 (0s)
 **Outcome:** complete (1/2 merged)
 
 ## Plan
@@ -21,10 +21,10 @@
 
 ## Timeline highlights
 
-- 21:14:57  mission created
-- 21:14:57  plan ready
-- 21:14:58  task-blocked-02 merged
-- 21:14:58  task-blocked-01 kicked back (kickback)
-- 21:14:58  task-blocked-01 kicked back (kickback)
-- 21:14:58  task-blocked-01 kicked back (kickback)
-- 21:14:58  mission complete
+- 21:15:15  mission created
+- 21:15:15  plan ready
+- 21:15:15  task-blocked-02 merged
+- 21:15:15  task-blocked-01 kicked back (kickback)
+- 21:15:15  task-blocked-01 kicked back (kickback)
+- 21:15:15  task-blocked-01 kicked back (kickback)
+- 21:15:15  mission complete

--- a/docs/antfarm/missions/mission-budget-cancel.md
+++ b/docs/antfarm/missions/mission-budget-cancel.md
@@ -1,8 +1,8 @@
 # Mission: mission-budget-cancel
 
 **Spec:** `(inline)`
-**Created:** 2026-05-01T06:45:42.774753+00:00
-**Completed:** 2026-05-01T06:45:42.776682+00:00 (0s)
+**Created:** 2026-05-02T21:15:24.560976+00:00
+**Completed:** 2026-05-02T21:15:24.563037+00:00 (0s)
 **Outcome:** cancelled (0/0 merged)
 
 ## Plan
@@ -20,5 +20,5 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 06:45:42  mission created
-- 06:45:42  mission cancelled
+- 21:15:24  mission created
+- 21:15:24  mission cancelled

--- a/docs/antfarm/missions/mission-replan-1.md
+++ b/docs/antfarm/missions/mission-replan-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-replan-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-01T06:45:33.825732+00:00
-**Completed:** 2026-05-01T06:45:33.864126+00:00 (0s)
+**Created:** 2026-05-02T21:14:58.635858+00:00
+**Completed:** 2026-05-02T21:14:58.674756+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -27,8 +27,8 @@ The plan above is the final accepted version. Earlier rejected drafts can be rec
 
 ## Timeline highlights
 
-- 06:45:33  mission created
-- 06:45:33  plan ready
-- 06:45:33  task-replan-01 merged
-- 06:45:33  task-replan-02 merged
-- 06:45:33  mission complete
+- 21:14:58  mission created
+- 21:14:58  plan ready
+- 21:14:58  task-replan-01 merged
+- 21:14:58  task-replan-02 merged
+- 21:14:58  mission complete

--- a/docs/antfarm/missions/mission-replan-1.md
+++ b/docs/antfarm/missions/mission-replan-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-replan-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:14:58.635858+00:00
-**Completed:** 2026-05-02T21:14:58.674756+00:00 (0s)
+**Created:** 2026-05-02T21:15:15.817737+00:00
+**Completed:** 2026-05-02T21:15:15.855872+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -27,8 +27,8 @@ The plan above is the final accepted version. Earlier rejected drafts can be rec
 
 ## Timeline highlights
 
-- 21:14:58  mission created
-- 21:14:58  plan ready
-- 21:14:58  task-replan-01 merged
-- 21:14:58  task-replan-02 merged
-- 21:14:58  mission complete
+- 21:15:15  mission created
+- 21:15:15  plan ready
+- 21:15:15  task-replan-01 merged
+- 21:15:15  task-replan-02 merged
+- 21:15:15  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:15:18.906336+00:00
-**Completed:** 2026-05-02T21:15:18.911547+00:00 (0s)
+**Created:** 2026-05-02T21:15:19.446177+00:00
+**Completed:** 2026-05-02T21:15:19.477139+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -14,7 +14,7 @@
 
 ## Re-plans
 
-Re-plan cycles: **1**.
+Re-plan cycles: **2**.
 
 The plan above is the final accepted version. Earlier rejected drafts can be reconstructed from the plan task's attempt history in `.antfarm/tasks/`.
 
@@ -24,6 +24,6 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 21:15:18  mission created
-- 21:15:18  plan ready
-- 21:15:18  mission failed
+- 21:15:19  mission created
+- 21:15:19  plan ready
+- 21:15:19  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-01T06:45:42.230823+00:00
-**Completed:** 2026-05-01T06:45:42.232504+00:00 (0s)
+**Created:** 2026-05-02T21:15:17.808678+00:00
+**Completed:** 2026-05-02T21:15:17.810123+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -15,5 +15,5 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 06:45:42  mission created
-- 06:45:42  mission failed
+- 21:15:17  mission created
+- 21:15:17  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:15:21.055722+00:00
-**Completed:** 2026-05-02T21:15:21.071885+00:00 (0s)
-**Outcome:** complete (2/2 merged)
+**Created:** 2026-05-02T21:15:21.602183+00:00
+**Completed:** 2026-05-02T21:15:21.618326+00:00 (0s)
+**Outcome:** complete (1/2 merged)
 
 ## Plan
 
@@ -16,13 +16,13 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | https://github.com/test/pr/0 | 1 | pass | 0s | — |
-| task-test-02 | https://github.com/test/pr/1 | 1 | pass | 0s | — |
+| task-test-01 | p | 1 | pass | 0s | — |
+| task-test-02 | — | 1 | blocked | — | blocked |
 
 ## Timeline highlights
 
 - 21:15:21  mission created
 - 21:15:21  plan ready
 - 21:15:21  task-test-01 merged
-- 21:15:21  task-test-02 merged
+- 21:15:21  task-test-02 kicked back (kickback)
 - 21:15:21  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,13 +1,16 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:15:17.808678+00:00
-**Completed:** 2026-05-02T21:15:17.810123+00:00 (0s)
+**Created:** 2026-05-02T21:15:18.339623+00:00
+**Completed:** 2026-05-02T21:15:18.342231+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
 
-_(no plan artifact recorded)_
+| ID | Title | Deps | Touches | Complexity |
+|---|---|---|---|---|
+| task-01 | Child task 1 | — | api | M |
+| task-02 | Child task 2 | — | api | M |
 
 ## Tasks
 
@@ -15,5 +18,6 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 21:15:17  mission created
-- 21:15:17  mission failed
+- 21:15:18  mission created
+- 21:15:18  plan ready
+- 21:15:18  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:15:19.446177+00:00
-**Completed:** 2026-05-02T21:15:19.477139+00:00 (0s)
+**Created:** 2026-05-02T21:15:20.521960+00:00
+**Completed:** 2026-05-02T21:15:20.525155+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -12,18 +12,12 @@
 | task-01 | Child task 1 | — | api | M |
 | task-02 | Child task 2 | — | api | M |
 
-## Re-plans
-
-Re-plan cycles: **2**.
-
-The plan above is the final accepted version. Earlier rejected drafts can be reconstructed from the plan task's attempt history in `.antfarm/tasks/`.
-
 ## Tasks
 
 _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 21:15:19  mission created
-- 21:15:19  plan ready
-- 21:15:19  mission failed
+- 21:15:20  mission created
+- 21:15:20  plan ready
+- 21:15:20  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:15:22.787045+00:00
-**Completed:** 2026-05-02T21:15:22.802988+00:00 (0s)
-**Outcome:** complete (1/2 merged)
+**Created:** 2026-05-02T21:15:23.482119+00:00
+**Completed:** 2026-05-02T21:15:23.497249+00:00 (0s)
+**Outcome:** complete (2/2 merged)
 
 ## Plan
 
@@ -16,12 +16,13 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | p | 1 | pass | 0s | — |
-| task-test-02 | — | 0 | blocked | — | blocked |
+| task-test-01 | https://example.com/pr/0 | 1 | pass | 0s | — |
+| task-test-02 | https://example.com/pr/1 | 1 | pass | 0s | — |
 
 ## Timeline highlights
 
-- 21:15:22  mission created
-- 21:15:22  plan ready
-- 21:15:22  task-test-01 merged
-- 21:15:22  mission complete
+- 21:15:23  mission created
+- 21:15:23  plan ready
+- 21:15:23  task-test-01 merged
+- 21:15:23  task-test-02 merged
+- 21:15:23  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:15:21.602183+00:00
-**Completed:** 2026-05-02T21:15:21.618326+00:00 (0s)
-**Outcome:** complete (1/2 merged)
+**Created:** 2026-05-02T21:15:22.216590+00:00
+**Completed:** 2026-05-02T21:15:22.232168+00:00 (0s)
+**Outcome:** failed (0/2 merged)
 
 ## Plan
 
@@ -16,13 +16,11 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | p | 1 | pass | 0s | — |
-| task-test-02 | — | 1 | blocked | — | blocked |
+| task-test-01 | — | 0 | blocked | — | blocked |
+| task-test-02 | — | 0 | blocked | — | blocked |
 
 ## Timeline highlights
 
-- 21:15:21  mission created
-- 21:15:21  plan ready
-- 21:15:21  task-test-01 merged
-- 21:15:21  task-test-02 kicked back (kickback)
-- 21:15:21  mission complete
+- 21:15:22  mission created
+- 21:15:22  plan ready
+- 21:15:22  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:15:22.216590+00:00
-**Completed:** 2026-05-02T21:15:22.232168+00:00 (0s)
-**Outcome:** failed (0/2 merged)
+**Created:** 2026-05-02T21:15:22.787045+00:00
+**Completed:** 2026-05-02T21:15:22.802988+00:00 (0s)
+**Outcome:** complete (1/2 merged)
 
 ## Plan
 
@@ -16,11 +16,12 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | — | 0 | blocked | — | blocked |
+| task-test-01 | p | 1 | pass | 0s | — |
 | task-test-02 | — | 0 | blocked | — | blocked |
 
 ## Timeline highlights
 
 - 21:15:22  mission created
 - 21:15:22  plan ready
-- 21:15:22  mission failed
+- 21:15:22  task-test-01 merged
+- 21:15:22  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:15:20.521960+00:00
-**Completed:** 2026-05-02T21:15:20.525155+00:00 (0s)
-**Outcome:** failed (0/0 merged)
+**Created:** 2026-05-02T21:15:21.055722+00:00
+**Completed:** 2026-05-02T21:15:21.071885+00:00 (0s)
+**Outcome:** complete (2/2 merged)
 
 ## Plan
 
@@ -14,10 +14,15 @@
 
 ## Tasks
 
-_(no implementation tasks)_
+| ID | PR | Attempts | Verdict | Wall | Notes |
+|---|---|---|---|---|---|
+| task-test-01 | https://github.com/test/pr/0 | 1 | pass | 0s | — |
+| task-test-02 | https://github.com/test/pr/1 | 1 | pass | 0s | — |
 
 ## Timeline highlights
 
-- 21:15:20  mission created
-- 21:15:20  plan ready
-- 21:15:20  mission failed
+- 21:15:21  mission created
+- 21:15:21  plan ready
+- 21:15:21  task-test-01 merged
+- 21:15:21  task-test-02 merged
+- 21:15:21  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:15:18.339623+00:00
-**Completed:** 2026-05-02T21:15:18.342231+00:00 (0s)
+**Created:** 2026-05-02T21:15:18.906336+00:00
+**Completed:** 2026-05-02T21:15:18.911547+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -11,6 +11,12 @@
 |---|---|---|---|---|
 | task-01 | Child task 1 | — | api | M |
 | task-02 | Child task 2 | — | api | M |
+
+## Re-plans
+
+Re-plan cycles: **1**.
+
+The plan above is the final accepted version. Earlier rejected drafts can be reconstructed from the plan task's attempt history in `.antfarm/tasks/`.
 
 ## Tasks
 

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,28 +1,19 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:15:23.482119+00:00
-**Completed:** 2026-05-02T21:15:23.497249+00:00 (0s)
-**Outcome:** complete (2/2 merged)
+**Created:** 2026-05-02T21:15:24.036766+00:00
+**Completed:** 2026-05-02T21:15:24.038527+00:00 (0s)
+**Outcome:** failed (0/0 merged)
 
 ## Plan
 
-| ID | Title | Deps | Touches | Complexity |
-|---|---|---|---|---|
-| task-01 | Child task 1 | — | api | M |
-| task-02 | Child task 2 | — | api | M |
+_(no plan artifact recorded)_
 
 ## Tasks
 
-| ID | PR | Attempts | Verdict | Wall | Notes |
-|---|---|---|---|---|---|
-| task-test-01 | https://example.com/pr/0 | 1 | pass | 0s | — |
-| task-test-02 | https://example.com/pr/1 | 1 | pass | 0s | — |
+_(no implementation tasks)_
 
 ## Timeline highlights
 
-- 21:15:23  mission created
-- 21:15:23  plan ready
-- 21:15:23  task-test-01 merged
-- 21:15:23  task-test-02 merged
-- 21:15:23  mission complete
+- 21:15:24  mission created
+- 21:15:24  mission failed

--- a/docs/antfarm/missions/mission-zero-cap.md
+++ b/docs/antfarm/missions/mission-zero-cap.md
@@ -1,8 +1,8 @@
 # Mission: mission-zero-cap
 
 **Spec:** `(inline)`
-**Created:** 2026-05-01T06:45:38.011078+00:00
-**Completed:** 2026-05-01T06:45:38.013954+00:00 (0s)
+**Created:** 2026-05-02T21:15:20.007602+00:00
+**Completed:** 2026-05-02T21:15:20.010692+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -18,6 +18,6 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 06:45:38  mission created
-- 06:45:38  plan ready
-- 06:45:38  mission failed
+- 21:15:20  mission created
+- 21:15:20  plan ready
+- 21:15:20  mission failed

--- a/tests/test_auto_merge.py
+++ b/tests/test_auto_merge.py
@@ -15,12 +15,16 @@ def _state(
     mergeable: str = "MERGEABLE",
     review_decision: str = "APPROVED",
     ci_conclusion: str | None = "SUCCESS",
+    ci_pending: bool = False,
+    ci_failing: bool = False,
 ) -> PRState:
     return PRState(
         mergeStateStatus=mergeStateStatus,
         mergeable=mergeable,
         review_decision=review_decision,
         ci_conclusion=ci_conclusion,
+        ci_pending=ci_pending,
+        ci_failing=ci_failing,
     )
 
 
@@ -177,7 +181,8 @@ def test_decide_on_review_pass_and_ci_green_clean_merges():
     assert out.action == "merge"
 
 
-def test_decide_on_review_pass_and_ci_green_unstable_waits():
+def test_decide_on_review_pass_and_ci_green_unstable_defensive_waits():
+    """No flags set (defensive fallback) — wait rather than guess wrong."""
     out = decide(
         "on-review-pass-and-ci-green",
         verdict_passed=True,
@@ -185,6 +190,56 @@ def test_decide_on_review_pass_and_ci_green_unstable_waits():
         pr="p",
     )
     assert out.action == "wait_ci"
+    assert "unknown" in out.reason
+
+
+def test_decide_on_review_pass_and_ci_green_unstable_with_failing_check_kicks_back():
+    """#381: UNSTABLE + a terminal-failed check must escalate to kickback."""
+    out = decide(
+        "on-review-pass-and-ci-green",
+        verdict_passed=True,
+        pr_state=_state(
+            mergeStateStatus="UNSTABLE",
+            ci_conclusion="FAILURE",
+            ci_failing=True,
+        ),
+        pr="p",
+    )
+    assert out.action == "kickback_ci"
+    assert out.reason == "ci_check_failed"
+
+
+def test_decide_on_review_pass_and_ci_green_unstable_with_pending_only_waits():
+    """#381: UNSTABLE with only pending checks keeps existing wait behavior."""
+    out = decide(
+        "on-review-pass-and-ci-green",
+        verdict_passed=True,
+        pr_state=_state(
+            mergeStateStatus="UNSTABLE",
+            ci_conclusion="PENDING",
+            ci_pending=True,
+        ),
+        pr="p",
+    )
+    assert out.action == "wait_ci"
+    assert "still pending" in out.reason
+
+
+def test_decide_on_review_pass_and_ci_green_unstable_with_mixed_failing_and_pending_kicks_back():
+    """#381: failing dominates — even with concurrent pending, kick back."""
+    out = decide(
+        "on-review-pass-and-ci-green",
+        verdict_passed=True,
+        pr_state=_state(
+            mergeStateStatus="UNSTABLE",
+            ci_conclusion="FAILURE",
+            ci_failing=True,
+            ci_pending=True,
+        ),
+        pr="p",
+    )
+    assert out.action == "kickback_ci"
+    assert out.reason == "ci_check_failed"
 
 
 def test_decide_on_review_pass_and_ci_green_pending_waits():
@@ -390,3 +445,78 @@ def test_parse_pr_state_missing_fields_coerced_to_empty():
     assert state.mergeable == ""
     assert state.review_decision == ""
     assert state.ci_conclusion is None
+    assert state.ci_pending is False
+    assert state.ci_failing is False
+
+
+def test_parse_pr_state_extracts_ci_pending_and_ci_failing_flags():
+    """#381: parse_pr_state must surface pending/failing summary flags."""
+    failing_with_in_progress = """
+    {
+      "mergeStateStatus": "UNSTABLE",
+      "mergeable": "MERGEABLE",
+      "reviewDecision": "APPROVED",
+      "statusCheckRollup": [
+        {"conclusion": "FAILURE", "status": "COMPLETED"},
+        {"conclusion": "", "status": "IN_PROGRESS"}
+      ]
+    }
+    """
+    state = parse_pr_state(failing_with_in_progress)
+    assert state is not None
+    assert state.ci_conclusion == "FAILURE"
+    assert state.ci_failing is True
+    assert state.ci_pending is True
+
+    only_pending = """
+    {
+      "mergeStateStatus": "UNSTABLE",
+      "mergeable": "MERGEABLE",
+      "reviewDecision": "APPROVED",
+      "statusCheckRollup": [
+        {"conclusion": "", "status": "IN_PROGRESS"},
+        {"conclusion": "PENDING", "status": "QUEUED"}
+      ]
+    }
+    """
+    state = parse_pr_state(only_pending)
+    assert state is not None
+    assert state.ci_conclusion == "PENDING"
+    assert state.ci_pending is True
+    assert state.ci_failing is False
+
+    all_success = """
+    {
+      "mergeStateStatus": "CLEAN",
+      "mergeable": "MERGEABLE",
+      "reviewDecision": "APPROVED",
+      "statusCheckRollup": [
+        {"conclusion": "SUCCESS", "status": "COMPLETED"},
+        {"conclusion": "SUCCESS", "status": "COMPLETED"}
+      ]
+    }
+    """
+    state = parse_pr_state(all_success)
+    assert state is not None
+    assert state.ci_conclusion == "SUCCESS"
+    assert state.ci_pending is False
+    assert state.ci_failing is False
+
+
+def test_summarize_rollup_treats_cancelled_as_pending():
+    """#381 deviation: CANCELLED is transient (operator re-triggers), not terminal."""
+    payload = """
+    {
+      "mergeStateStatus": "UNSTABLE",
+      "mergeable": "MERGEABLE",
+      "reviewDecision": "APPROVED",
+      "statusCheckRollup": [
+        {"conclusion": "CANCELLED", "status": "COMPLETED"}
+      ]
+    }
+    """
+    state = parse_pr_state(payload)
+    assert state is not None
+    assert state.ci_pending is True
+    assert state.ci_failing is False
+    assert state.ci_conclusion == "PENDING"

--- a/tests/test_soldier_auto_merge.py
+++ b/tests/test_soldier_auto_merge.py
@@ -179,7 +179,9 @@ def test_ci_green_mode_unstable_waits(monkeypatch):
     monkeypatch.setattr(
         s,
         "_query_pr_state",
-        lambda pr: PRState("UNSTABLE", "MERGEABLE", "APPROVED", "PENDING"),
+        # #381: ci_pending=True explicit so wait_ci branch fires (not the
+        # defensive fallback) — fixture mirrors what parse_pr_state would set.
+        lambda pr: PRState("UNSTABLE", "MERGEABLE", "APPROVED", "PENDING", ci_pending=True),
     )
     monkeypatch.setattr(s, "_resolve_repo_slug", lambda: "org/repo")
     monkeypatch.setattr(s, "_query_viewer_permission", lambda: "ADMIN")
@@ -505,7 +507,10 @@ def test_poll_backoff_suppresses_redundant_polls(monkeypatch):
 
     def fake_state(pr):
         state_calls.append(pr)
-        return PRState("UNSTABLE", "MERGEABLE", "APPROVED", "PENDING")
+        # #381: ci_pending=True so the first call resolves to wait_ci, not
+        # the defensive fallback — backoff suppression then short-circuits
+        # the second call.
+        return PRState("UNSTABLE", "MERGEABLE", "APPROVED", "PENDING", ci_pending=True)
 
     monkeypatch.setattr(s, "_query_pr_state", fake_state)
 


### PR DESCRIPTION
## Summary
- When a PR's `mergeStateStatus=UNSTABLE` and at least one check has terminally failed, `on-review-pass-and-ci-green` mode now escalates to `kickback_ci` (`reason=ci_check_failed`) instead of waiting forever.
- Genuinely pending UNSTABLE keeps the existing `wait_ci` behavior. `CANCELLED` is treated as transient pending (operators re-trigger), not terminal failure.
- `PRState` gains `ci_pending`/`ci_failing` summary flags (default `False`, so positional callers still work). `_aggregate_ci` is replaced by `_summarize_rollup` returning a tuple in one pass.

## Test plan
- [x] `pytest tests/test_auto_merge.py tests/test_soldier_auto_merge.py -x -q` (71 passed)
- [x] `pytest tests/ -q` (1527 passed; 1 pre-existing flaky `test_tmux_pm_adopt_existing` deselected — fails on `main` too because it picks up real tmux sessions on the dev host)
- [x] `ruff check .` clean
- [x] New tests cover: UNSTABLE+failing → kickback, UNSTABLE+pending → wait, mixed → kickback (failing dominates), `parse_pr_state` flag extraction (3 variants), CANCELLED → pending, defensive fallback waits.

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)