### PR TITLE
fix(autoscaler): filter terminal-mission tasks from reviewer/builder demand (Closes #383)

### DIFF
--- a/antfarm/core/autoscaler.py
+++ b/antfarm/core/autoscaler.py
@@ -60,21 +60,49 @@ def _emit(event_type: str, task_id: str, detail: str = "") -> None:
 # ---------------------------------------------------------------------------
 
 
-def count_ready_unblocked(tasks: list[dict]) -> int:
+_TERMINAL_MISSION_STATUSES: frozenset[str] = frozenset(
+    {"complete", "failed", "cancelled", "paused"}
+)
+
+
+def _is_task_in_terminal_mission(task: dict, missions_by_id: dict[str, dict]) -> bool:
+    """Return True if the task belongs to a mission in a terminal state.
+
+    Conservative: tasks without ``mission_id``, or with a ``mission_id`` not in
+    the provided dict, return False (assumed live). This preserves backward
+    compatibility for callers that don't supply a missions list — empty
+    ``missions_by_id`` ⇒ no filtering.
+    """
+    mission_id = task.get("mission_id")
+    if not mission_id:
+        return False
+    mission = missions_by_id.get(mission_id)
+    if mission is None:
+        return False
+    return str(mission.get("status", "")).lower() in _TERMINAL_MISSION_STATUSES
+
+
+def count_ready_unblocked(tasks: list[dict], missions: list[dict] | None = None) -> int:
     """Count ready, non-infra, dependency-met build tasks.
 
     A task counts toward builder demand when:
     - ``status == "ready"``
     - It is NOT an infra task (id does not start with ``plan-`` or ``review-``)
     - All ``depends_on`` entries are in ``done_task_ids`` or ``merged_task_ids``
+    - Its mission (if any) is NOT in a terminal state (issue #383)
 
     ``merged_task_ids`` here is the set of task ids whose current attempt has
     ``status == "merged"``. ``done_task_ids`` is every task currently in
     ``done`` (a merged task is still in ``done``, so this union is safe).
+
+    ``missions`` is optional; when None or empty, no terminal-mission filtering
+    is applied (backward compatible).
     """
     done_task_ids = {t["id"] for t in tasks if t["status"] == "done"}
     merged_task_ids = {t["id"] for t in tasks if has_merged_attempt(t)}
     unblocked_ids = done_task_ids | merged_task_ids
+
+    missions_by_id = {m["mission_id"]: m for m in (missions or []) if "mission_id" in m}
 
     count = 0
     for t in tasks:
@@ -89,6 +117,8 @@ def count_ready_unblocked(tasks: list[dict]) -> int:
             continue
         deps = t.get("depends_on") or []
         if any(d not in unblocked_ids for d in deps):
+            continue
+        if _is_task_in_terminal_mission(t, missions_by_id):
             continue
         count += 1
     return count
@@ -112,19 +142,33 @@ def compute_depth_aware_target(ready_unblocked: int, config: AutoscalerConfig) -
 
 
 def compute_desired(
-    tasks: list[dict], workers: list[dict], config: AutoscalerConfig
+    tasks: list[dict],
+    workers: list[dict],
+    config: AutoscalerConfig,
+    missions: list[dict] | None = None,
 ) -> dict[str, int]:
     """Compute desired worker counts by role.
 
     Shared by single-host and multi-node autoscalers.
+
+    ``missions`` is optional; when supplied, tasks belonging to missions in a
+    terminal state (``complete``/``failed``/``cancelled``/``paused``) are
+    excluded from reviewer and builder demand. This prevents the autoscaler
+    from respawning reviewers indefinitely after a mission has finished
+    (issue #383). When None or empty, no filtering is applied (backward
+    compatible).
     """
+    missions_by_id = {m["mission_id"]: m for m in (missions or []) if "mission_id" in m}
+
     ready_plan = [
         t for t in tasks if t["status"] == "ready" and "plan" in t.get("capabilities_required", [])
     ]
     ready_review = [
         t
         for t in tasks
-        if t["status"] == "ready" and "review" in t.get("capabilities_required", [])
+        if t["status"] == "ready"
+        and "review" in t.get("capabilities_required", [])
+        and not _is_task_in_terminal_mission(t, missions_by_id)
     ]
     done_unreviewed = [
         t
@@ -134,9 +178,10 @@ def compute_desired(
         and not t.get("cancelled_at")
         and not has_verdict(t)
         and not has_merged_attempt(t)
+        and not _is_task_in_terminal_mission(t, missions_by_id)
     ]
 
-    ready_unblocked = count_ready_unblocked(tasks)
+    ready_unblocked = count_ready_unblocked(tasks, missions=missions)
     desired_builders = compute_depth_aware_target(ready_unblocked, config)
 
     active_builders = [
@@ -321,9 +366,16 @@ class Autoscaler:
         self._cleanup_exited()
         tasks = self.backend.list_tasks()
         workers = self.backend.list_workers()
-        desired = self._compute_desired(tasks, workers)
+        # Fetch missions once per reconcile so we can filter out tasks that
+        # belong to terminal missions (issue #383). Tolerate backends that
+        # don't implement list_missions yet — treat as no filtering.
+        try:
+            missions = self.backend.list_missions()
+        except (AttributeError, NotImplementedError):
+            missions = []
+        desired = self._compute_desired(tasks, workers, missions=missions)
         actual = self._count_actual()
-        ready_unblocked = count_ready_unblocked(tasks)
+        ready_unblocked = count_ready_unblocked(tasks, missions=missions)
         self._update_builder_idle_tracking(workers)
         for role in ("planner", "builder", "reviewer"):
             if role == "builder":
@@ -331,8 +383,13 @@ class Autoscaler:
             else:
                 self._reconcile_role(role, desired[role], actual.get(role, 0))
 
-    def _compute_desired(self, tasks: list[dict], workers: list[dict]) -> dict[str, int]:
-        return compute_desired(tasks, workers, self.config)
+    def _compute_desired(
+        self,
+        tasks: list[dict],
+        workers: list[dict],
+        missions: list[dict] | None = None,
+    ) -> dict[str, int]:
+        return compute_desired(tasks, workers, self.config, missions=missions)
 
     @staticmethod
     def _count_scope_groups(tasks: list[dict]) -> int:
@@ -625,8 +682,12 @@ class MultiNodeAutoscaler:
 
         tasks = self.backend.list_tasks()
         workers = self.backend.list_workers()
+        try:
+            missions = self.backend.list_missions()
+        except (AttributeError, NotImplementedError):
+            missions = []
         nodes = self._get_node_capacities()
-        desired_total = compute_desired(tasks, workers, self.config)
+        desired_total = compute_desired(tasks, workers, self.config, missions=missions)
         placement = compute_placement(desired_total, nodes)
         self._generation += 1
         for node_id, desired in placement.items():

--- a/docs/antfarm/missions/mission-auth-1.md
+++ b/docs/antfarm/missions/mission-auth-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-auth-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:00:47.345767+00:00
-**Completed:** 2026-05-04T07:00:47.383621+00:00 (0s)
+**Created:** 2026-05-04T07:01:05.405754+00:00
+**Completed:** 2026-05-04T07:01:05.435778+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -21,8 +21,8 @@
 
 ## Timeline highlights
 
-- 07:00:47  mission created
-- 07:00:47  plan ready
-- 07:00:47  task-auth-01 merged
-- 07:00:47  task-auth-02 merged
-- 07:00:47  mission complete
+- 07:01:05  mission created
+- 07:01:05  plan ready
+- 07:01:05  task-auth-01 merged
+- 07:01:05  task-auth-02 merged
+- 07:01:05  mission complete

--- a/docs/antfarm/missions/mission-auth-1.md
+++ b/docs/antfarm/missions/mission-auth-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-auth-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:15:14.517963+00:00
-**Completed:** 2026-05-02T21:15:14.546340+00:00 (0s)
+**Created:** 2026-05-04T07:00:47.345767+00:00
+**Completed:** 2026-05-04T07:00:47.383621+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -21,8 +21,8 @@
 
 ## Timeline highlights
 
-- 21:15:14  mission created
-- 21:15:14  plan ready
-- 21:15:14  task-auth-01 merged
-- 21:15:14  task-auth-02 merged
-- 21:15:14  mission complete
+- 07:00:47  mission created
+- 07:00:47  plan ready
+- 07:00:47  task-auth-01 merged
+- 07:00:47  task-auth-02 merged
+- 07:00:47  mission complete

--- a/docs/antfarm/missions/mission-blocked-1.md
+++ b/docs/antfarm/missions/mission-blocked-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-blocked-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:00:48.330220+00:00
-**Completed:** 2026-05-04T07:00:48.364339+00:00 (0s)
+**Created:** 2026-05-04T07:01:06.077692+00:00
+**Completed:** 2026-05-04T07:01:06.111006+00:00 (0s)
 **Outcome:** complete (1/2 merged)
 
 ## Plan
@@ -21,10 +21,10 @@
 
 ## Timeline highlights
 
-- 07:00:48  mission created
-- 07:00:48  plan ready
-- 07:00:48  task-blocked-02 merged
-- 07:00:48  task-blocked-01 kicked back (kickback)
-- 07:00:48  task-blocked-01 kicked back (kickback)
-- 07:00:48  task-blocked-01 kicked back (kickback)
-- 07:00:48  mission complete
+- 07:01:06  mission created
+- 07:01:06  plan ready
+- 07:01:06  task-blocked-02 merged
+- 07:01:06  task-blocked-01 kicked back (kickback)
+- 07:01:06  task-blocked-01 kicked back (kickback)
+- 07:01:06  task-blocked-01 kicked back (kickback)
+- 07:01:06  mission complete

--- a/docs/antfarm/missions/mission-blocked-1.md
+++ b/docs/antfarm/missions/mission-blocked-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-blocked-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:15:15.205140+00:00
-**Completed:** 2026-05-02T21:15:15.240340+00:00 (0s)
+**Created:** 2026-05-04T07:00:48.330220+00:00
+**Completed:** 2026-05-04T07:00:48.364339+00:00 (0s)
 **Outcome:** complete (1/2 merged)
 
 ## Plan
@@ -21,10 +21,10 @@
 
 ## Timeline highlights
 
-- 21:15:15  mission created
-- 21:15:15  plan ready
-- 21:15:15  task-blocked-02 merged
-- 21:15:15  task-blocked-01 kicked back (kickback)
-- 21:15:15  task-blocked-01 kicked back (kickback)
-- 21:15:15  task-blocked-01 kicked back (kickback)
-- 21:15:15  mission complete
+- 07:00:48  mission created
+- 07:00:48  plan ready
+- 07:00:48  task-blocked-02 merged
+- 07:00:48  task-blocked-01 kicked back (kickback)
+- 07:00:48  task-blocked-01 kicked back (kickback)
+- 07:00:48  task-blocked-01 kicked back (kickback)
+- 07:00:48  mission complete

--- a/docs/antfarm/missions/mission-budget-cancel.md
+++ b/docs/antfarm/missions/mission-budget-cancel.md
@@ -1,8 +1,8 @@
 # Mission: mission-budget-cancel
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:15:24.560976+00:00
-**Completed:** 2026-05-02T21:15:24.563037+00:00 (0s)
+**Created:** 2026-05-04T07:01:18.896182+00:00
+**Completed:** 2026-05-04T07:01:18.898144+00:00 (0s)
 **Outcome:** cancelled (0/0 merged)
 
 ## Plan
@@ -20,5 +20,5 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 21:15:24  mission created
-- 21:15:24  mission cancelled
+- 07:01:18  mission created
+- 07:01:18  mission cancelled

--- a/docs/antfarm/missions/mission-replan-1.md
+++ b/docs/antfarm/missions/mission-replan-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-replan-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:00:48.987287+00:00
-**Completed:** 2026-05-04T07:00:49.025981+00:00 (0s)
+**Created:** 2026-05-04T07:01:06.832277+00:00
+**Completed:** 2026-05-04T07:01:06.871643+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -27,8 +27,8 @@ The plan above is the final accepted version. Earlier rejected drafts can be rec
 
 ## Timeline highlights
 
-- 07:00:48  mission created
-- 07:00:49  plan ready
-- 07:00:49  task-replan-01 merged
-- 07:00:49  task-replan-02 merged
-- 07:00:49  mission complete
+- 07:01:06  mission created
+- 07:01:06  plan ready
+- 07:01:06  task-replan-01 merged
+- 07:01:06  task-replan-02 merged
+- 07:01:06  mission complete

--- a/docs/antfarm/missions/mission-replan-1.md
+++ b/docs/antfarm/missions/mission-replan-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-replan-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:15:15.817737+00:00
-**Completed:** 2026-05-02T21:15:15.855872+00:00 (0s)
+**Created:** 2026-05-04T07:00:48.987287+00:00
+**Completed:** 2026-05-04T07:00:49.025981+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -27,8 +27,8 @@ The plan above is the final accepted version. Earlier rejected drafts can be rec
 
 ## Timeline highlights
 
-- 21:15:15  mission created
-- 21:15:15  plan ready
-- 21:15:15  task-replan-01 merged
-- 21:15:15  task-replan-02 merged
-- 21:15:15  mission complete
+- 07:00:48  mission created
+- 07:00:49  plan ready
+- 07:00:49  task-replan-01 merged
+- 07:00:49  task-replan-02 merged
+- 07:00:49  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:01:15.309183+00:00
-**Completed:** 2026-05-04T07:01:15.325918+00:00 (0s)
-**Outcome:** complete (1/2 merged)
+**Created:** 2026-05-04T07:01:15.966152+00:00
+**Completed:** 2026-05-04T07:01:15.981735+00:00 (0s)
+**Outcome:** failed (0/2 merged)
 
 ## Plan
 
@@ -16,13 +16,11 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | p | 1 | pass | 0s | — |
-| task-test-02 | — | 1 | blocked | — | blocked |
+| task-test-01 | — | 0 | blocked | — | blocked |
+| task-test-02 | — | 0 | blocked | — | blocked |
 
 ## Timeline highlights
 
 - 07:01:15  mission created
 - 07:01:15  plan ready
-- 07:01:15  task-test-01 merged
-- 07:01:15  task-test-02 kicked back (kickback)
-- 07:01:15  mission complete
+- 07:01:15  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,28 +1,19 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:01:17.438361+00:00
-**Completed:** 2026-05-04T07:01:17.454165+00:00 (0s)
-**Outcome:** complete (2/2 merged)
+**Created:** 2026-05-04T07:01:18.093754+00:00
+**Completed:** 2026-05-04T07:01:18.095363+00:00 (0s)
+**Outcome:** failed (0/0 merged)
 
 ## Plan
 
-| ID | Title | Deps | Touches | Complexity |
-|---|---|---|---|---|
-| task-01 | Child task 1 | — | api | M |
-| task-02 | Child task 2 | — | api | M |
+_(no plan artifact recorded)_
 
 ## Tasks
 
-| ID | PR | Attempts | Verdict | Wall | Notes |
-|---|---|---|---|---|---|
-| task-test-01 | https://example.com/pr/0 | 1 | pass | 0s | — |
-| task-test-02 | https://example.com/pr/1 | 1 | pass | 0s | — |
+_(no implementation tasks)_
 
 ## Timeline highlights
 
-- 07:01:17  mission created
-- 07:01:17  plan ready
-- 07:01:17  task-test-01 merged
-- 07:01:17  task-test-02 merged
-- 07:01:17  mission complete
+- 07:01:18  mission created
+- 07:01:18  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:01:10.169659+00:00
-**Completed:** 2026-05-04T07:01:10.172986+00:00 (0s)
+**Created:** 2026-05-04T07:01:11.757284+00:00
+**Completed:** 2026-05-04T07:01:11.762510+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -12,12 +12,18 @@
 | task-01 | Child task 1 | — | api | M |
 | task-02 | Child task 2 | — | api | M |
 
+## Re-plans
+
+Re-plan cycles: **1**.
+
+The plan above is the final accepted version. Earlier rejected drafts can be reconstructed from the plan task's attempt history in `.antfarm/tasks/`.
+
 ## Tasks
 
 _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 07:01:10  mission created
-- 07:01:10  plan ready
-- 07:01:10  mission failed
+- 07:01:11  mission created
+- 07:01:11  plan ready
+- 07:01:11  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,13 +1,16 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:01:08.813159+00:00
-**Completed:** 2026-05-04T07:01:08.814587+00:00 (0s)
+**Created:** 2026-05-04T07:01:10.169659+00:00
+**Completed:** 2026-05-04T07:01:10.172986+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
 
-_(no plan artifact recorded)_
+| ID | Title | Deps | Touches | Complexity |
+|---|---|---|---|---|
+| task-01 | Child task 1 | — | api | M |
+| task-02 | Child task 2 | — | api | M |
 
 ## Tasks
 
@@ -15,5 +18,6 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 07:01:08  mission created
-- 07:01:08  mission failed
+- 07:01:10  mission created
+- 07:01:10  plan ready
+- 07:01:10  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:15:24.036766+00:00
-**Completed:** 2026-05-02T21:15:24.038527+00:00 (0s)
+**Created:** 2026-05-04T07:01:08.813159+00:00
+**Completed:** 2026-05-04T07:01:08.814587+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -15,5 +15,5 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 21:15:24  mission created
-- 21:15:24  mission failed
+- 07:01:08  mission created
+- 07:01:08  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:01:14.161141+00:00
-**Completed:** 2026-05-04T07:01:14.164197+00:00 (0s)
-**Outcome:** failed (0/0 merged)
+**Created:** 2026-05-04T07:01:14.783189+00:00
+**Completed:** 2026-05-04T07:01:14.799656+00:00 (0s)
+**Outcome:** complete (2/2 merged)
 
 ## Plan
 
@@ -14,10 +14,15 @@
 
 ## Tasks
 
-_(no implementation tasks)_
+| ID | PR | Attempts | Verdict | Wall | Notes |
+|---|---|---|---|---|---|
+| task-test-01 | https://github.com/test/pr/0 | 1 | pass | 0s | — |
+| task-test-02 | https://github.com/test/pr/1 | 1 | pass | 0s | — |
 
 ## Timeline highlights
 
 - 07:01:14  mission created
 - 07:01:14  plan ready
-- 07:01:14  mission failed
+- 07:01:14  task-test-01 merged
+- 07:01:14  task-test-02 merged
+- 07:01:14  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:01:16.694052+00:00
-**Completed:** 2026-05-04T07:01:16.710118+00:00 (0s)
-**Outcome:** complete (1/2 merged)
+**Created:** 2026-05-04T07:01:17.438361+00:00
+**Completed:** 2026-05-04T07:01:17.454165+00:00 (0s)
+**Outcome:** complete (2/2 merged)
 
 ## Plan
 
@@ -16,12 +16,13 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | p | 1 | pass | 0s | — |
-| task-test-02 | — | 0 | blocked | — | blocked |
+| task-test-01 | https://example.com/pr/0 | 1 | pass | 0s | — |
+| task-test-02 | https://example.com/pr/1 | 1 | pass | 0s | — |
 
 ## Timeline highlights
 
-- 07:01:16  mission created
-- 07:01:16  plan ready
-- 07:01:16  task-test-01 merged
-- 07:01:16  mission complete
+- 07:01:17  mission created
+- 07:01:17  plan ready
+- 07:01:17  task-test-01 merged
+- 07:01:17  task-test-02 merged
+- 07:01:17  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:01:12.903756+00:00
-**Completed:** 2026-05-04T07:01:12.911630+00:00 (0s)
+**Created:** 2026-05-04T07:01:14.161141+00:00
+**Completed:** 2026-05-04T07:01:14.164197+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -12,18 +12,12 @@
 | task-01 | Child task 1 | — | api | M |
 | task-02 | Child task 2 | — | api | M |
 
-## Re-plans
-
-Re-plan cycles: **2**.
-
-The plan above is the final accepted version. Earlier rejected drafts can be reconstructed from the plan task's attempt history in `.antfarm/tasks/`.
-
 ## Tasks
 
 _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 07:01:12  mission created
-- 07:01:12  plan ready
-- 07:01:12  mission failed
+- 07:01:14  mission created
+- 07:01:14  plan ready
+- 07:01:14  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:01:11.757284+00:00
-**Completed:** 2026-05-04T07:01:11.762510+00:00 (0s)
+**Created:** 2026-05-04T07:01:12.903756+00:00
+**Completed:** 2026-05-04T07:01:12.911630+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -14,7 +14,7 @@
 
 ## Re-plans
 
-Re-plan cycles: **1**.
+Re-plan cycles: **2**.
 
 The plan above is the final accepted version. Earlier rejected drafts can be reconstructed from the plan task's attempt history in `.antfarm/tasks/`.
 
@@ -24,6 +24,6 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 07:01:11  mission created
-- 07:01:11  plan ready
-- 07:01:11  mission failed
+- 07:01:12  mission created
+- 07:01:12  plan ready
+- 07:01:12  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:01:14.783189+00:00
-**Completed:** 2026-05-04T07:01:14.799656+00:00 (0s)
-**Outcome:** complete (2/2 merged)
+**Created:** 2026-05-04T07:01:15.309183+00:00
+**Completed:** 2026-05-04T07:01:15.325918+00:00 (0s)
+**Outcome:** complete (1/2 merged)
 
 ## Plan
 
@@ -16,13 +16,13 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | https://github.com/test/pr/0 | 1 | pass | 0s | — |
-| task-test-02 | https://github.com/test/pr/1 | 1 | pass | 0s | — |
+| task-test-01 | p | 1 | pass | 0s | — |
+| task-test-02 | — | 1 | blocked | — | blocked |
 
 ## Timeline highlights
 
-- 07:01:14  mission created
-- 07:01:14  plan ready
-- 07:01:14  task-test-01 merged
-- 07:01:14  task-test-02 merged
-- 07:01:14  mission complete
+- 07:01:15  mission created
+- 07:01:15  plan ready
+- 07:01:15  task-test-01 merged
+- 07:01:15  task-test-02 kicked back (kickback)
+- 07:01:15  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:01:15.966152+00:00
-**Completed:** 2026-05-04T07:01:15.981735+00:00 (0s)
-**Outcome:** failed (0/2 merged)
+**Created:** 2026-05-04T07:01:16.694052+00:00
+**Completed:** 2026-05-04T07:01:16.710118+00:00 (0s)
+**Outcome:** complete (1/2 merged)
 
 ## Plan
 
@@ -16,11 +16,12 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | — | 0 | blocked | — | blocked |
+| task-test-01 | p | 1 | pass | 0s | — |
 | task-test-02 | — | 0 | blocked | — | blocked |
 
 ## Timeline highlights
 
-- 07:01:15  mission created
-- 07:01:15  plan ready
-- 07:01:15  mission failed
+- 07:01:16  mission created
+- 07:01:16  plan ready
+- 07:01:16  task-test-01 merged
+- 07:01:16  mission complete

--- a/docs/antfarm/missions/mission-zero-cap.md
+++ b/docs/antfarm/missions/mission-zero-cap.md
@@ -1,8 +1,8 @@
 # Mission: mission-zero-cap
 
 **Spec:** `(inline)`
-**Created:** 2026-05-02T21:15:20.007602+00:00
-**Completed:** 2026-05-02T21:15:20.010692+00:00 (0s)
+**Created:** 2026-05-04T07:01:13.520444+00:00
+**Completed:** 2026-05-04T07:01:13.523578+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -18,6 +18,6 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 21:15:20  mission created
-- 21:15:20  plan ready
-- 21:15:20  mission failed
+- 07:01:13  mission created
+- 07:01:13  plan ready
+- 07:01:13  mission failed

--- a/tests/test_autoscaler.py
+++ b/tests/test_autoscaler.py
@@ -11,6 +11,7 @@ from antfarm.core.autoscaler import (
     AutoscalerConfig,
     ManagedWorker,
     compute_depth_aware_target,
+    compute_desired,
     count_ready_unblocked,
 )
 
@@ -26,8 +27,9 @@ def _task(
     capabilities_required: list[str] | None = None,
     attempts: list[dict] | None = None,
     current_attempt: str | None = None,
+    mission_id: str | None = None,
 ) -> dict:
-    return {
+    t: dict = {
         "id": task_id,
         "status": status,
         "touches": touches or [],
@@ -35,6 +37,9 @@ def _task(
         "attempts": attempts or [],
         "current_attempt": current_attempt,
     }
+    if mission_id is not None:
+        t["mission_id"] = mission_id
+    return t
 
 
 def _worker(
@@ -226,6 +231,205 @@ class TestComputeDesired:
         ]
         result = a._compute_desired(tasks, [])
         assert result["reviewer"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Terminal-mission filtering (#383)
+# ---------------------------------------------------------------------------
+
+
+class TestTerminalMissionFiltering:
+    """Tasks belonging to missions in terminal states (complete/failed/
+    cancelled/paused) must not drive reviewer or builder demand. Without
+    this filter the autoscaler respawns reviewers indefinitely after a
+    mission completes (issue #383)."""
+
+    def test_compute_desired_filters_done_unreviewed_in_complete_mission(self):
+        """Done unreviewed task in a complete mission → reviewer count = 0."""
+        config = AutoscalerConfig(max_builders=4)
+        tasks = [
+            _task(
+                "t1",
+                status="done",
+                current_attempt="att-1",
+                attempts=[{"attempt_id": "att-1", "status": "done"}],
+                mission_id="m1",
+            ),
+        ]
+        missions = [{"mission_id": "m1", "status": "complete"}]
+        result = compute_desired(tasks, [], config, missions=missions)
+        assert result["reviewer"] == 0
+
+    def test_compute_desired_filters_ready_review_in_failed_mission(self):
+        """Review task in failed mission → reviewer count = 0."""
+        config = AutoscalerConfig(max_builders=4)
+        tasks = [
+            _task(
+                "review-t1",
+                status="ready",
+                capabilities_required=["review"],
+                mission_id="m1",
+            ),
+        ]
+        missions = [{"mission_id": "m1", "status": "failed"}]
+        result = compute_desired(tasks, [], config, missions=missions)
+        assert result["reviewer"] == 0
+
+    def test_compute_desired_filters_ready_review_in_paused_mission(self):
+        """Review task in paused mission → reviewer count = 0."""
+        config = AutoscalerConfig(max_builders=4)
+        tasks = [
+            _task(
+                "review-t1",
+                status="ready",
+                capabilities_required=["review"],
+                mission_id="m1",
+            ),
+        ]
+        missions = [{"mission_id": "m1", "status": "paused"}]
+        result = compute_desired(tasks, [], config, missions=missions)
+        assert result["reviewer"] == 0
+
+    def test_compute_desired_filters_ready_review_in_cancelled_mission(self):
+        """Review task in cancelled mission → reviewer count = 0."""
+        config = AutoscalerConfig(max_builders=4)
+        tasks = [
+            _task(
+                "review-t1",
+                status="ready",
+                capabilities_required=["review"],
+                mission_id="m1",
+            ),
+        ]
+        missions = [{"mission_id": "m1", "status": "cancelled"}]
+        result = compute_desired(tasks, [], config, missions=missions)
+        assert result["reviewer"] == 0
+
+    def test_compute_desired_keeps_done_unreviewed_in_active_mission(self):
+        """Regression: building (non-terminal) mission, no verdict task →
+        reviewer count = 1. The filter must NOT touch live missions."""
+        config = AutoscalerConfig(max_builders=4)
+        tasks = [
+            _task(
+                "t1",
+                status="done",
+                current_attempt="att-1",
+                attempts=[{"attempt_id": "att-1", "status": "done"}],
+                mission_id="m1",
+            ),
+        ]
+        missions = [{"mission_id": "m1", "status": "building"}]
+        result = compute_desired(tasks, [], config, missions=missions)
+        assert result["reviewer"] == 1
+
+    def test_compute_desired_no_filter_when_missions_none(self):
+        """Backward compat: missions=None ⇒ no-op filter, behavior unchanged."""
+        config = AutoscalerConfig(max_builders=4)
+        tasks = [
+            _task(
+                "t1",
+                status="done",
+                current_attempt="att-1",
+                attempts=[{"attempt_id": "att-1", "status": "done"}],
+                mission_id="m1",
+            ),
+        ]
+        result = compute_desired(tasks, [], config, missions=None)
+        assert result["reviewer"] == 1
+
+    def test_compute_desired_no_filter_when_missions_empty(self):
+        """Backward compat: missions=[] ⇒ no-op filter, behavior unchanged."""
+        config = AutoscalerConfig(max_builders=4)
+        tasks = [
+            _task(
+                "t1",
+                status="done",
+                current_attempt="att-1",
+                attempts=[{"attempt_id": "att-1", "status": "done"}],
+                mission_id="m1",
+            ),
+        ]
+        result = compute_desired(tasks, [], config, missions=[])
+        assert result["reviewer"] == 1
+
+    def test_compute_desired_handles_task_without_mission_id(self):
+        """Task lacking a `mission_id` field is treated as live (not filtered)."""
+        config = AutoscalerConfig(max_builders=4)
+        tasks = [
+            _task(
+                "t1",
+                status="done",
+                current_attempt="att-1",
+                attempts=[{"attempt_id": "att-1", "status": "done"}],
+                # no mission_id
+            ),
+        ]
+        # Even with a complete mission listed, this task isn't part of it.
+        missions = [{"mission_id": "m1", "status": "complete"}]
+        result = compute_desired(tasks, [], config, missions=missions)
+        assert result["reviewer"] == 1
+
+    def test_count_ready_unblocked_filters_terminal_mission_tasks(self):
+        """No point spawning builders for terminal-mission tasks either."""
+        tasks = [
+            _task("t1", status="ready", mission_id="m1"),
+            _task("t2", status="ready", mission_id="m2"),
+        ]
+        missions = [
+            {"mission_id": "m1", "status": "complete"},
+            {"mission_id": "m2", "status": "building"},
+        ]
+        # m1 task filtered out, m2 task counted.
+        assert count_ready_unblocked(tasks, missions=missions) == 1
+
+    def test_count_ready_unblocked_no_missions_is_unchanged(self):
+        """Backward compat: missions=None counts all eligible tasks."""
+        tasks = [
+            _task("t1", status="ready"),
+            _task("t2", status="ready"),
+        ]
+        assert count_ready_unblocked(tasks) == 2
+        assert count_ready_unblocked(tasks, missions=None) == 2
+        assert count_ready_unblocked(tasks, missions=[]) == 2
+
+    def test_reconcile_passes_missions_to_compute_desired(self):
+        """_reconcile() must call backend.list_missions() once and pass the
+        result through, so terminal-mission tasks don't drive demand."""
+        pm = _mock_pm()
+        a = _make_autoscaler(_pm=pm, max_builders=4)
+        a.backend.list_tasks.return_value = [
+            _task(
+                "t1",
+                status="done",
+                current_attempt="att-1",
+                attempts=[{"attempt_id": "att-1", "status": "done"}],
+                mission_id="m1",
+            ),
+        ]
+        a.backend.list_workers.return_value = []
+        a.backend.list_missions.return_value = [
+            {"mission_id": "m1", "status": "complete"},
+        ]
+
+        a._reconcile()
+
+        # backend.list_missions() should be called by _reconcile.
+        assert a.backend.list_missions.called
+        # No reviewer should be spawned because the mission is complete.
+        reviewer_starts = [c for c in pm.start.call_args_list if "reviewer" in str(c)]
+        assert len(reviewer_starts) == 0
+
+    def test_reconcile_tolerates_backend_without_list_missions(self):
+        """Backends that don't implement list_missions still work — the
+        autoscaler treats it as 'no filtering' rather than crashing."""
+        pm = _mock_pm()
+        a = _make_autoscaler(_pm=pm, max_builders=4)
+        a.backend.list_tasks.return_value = []
+        a.backend.list_workers.return_value = []
+        a.backend.list_missions.side_effect = AttributeError("list_missions not implemented")
+
+        # Should not raise.
+        a._reconcile()
 
 
 # ---------------------------------------------------------------------------
@@ -848,9 +1052,7 @@ class TestScaleUpThreshold:
         a._reconcile()
 
         # Exactly one builder spawned despite ready_unblocked < threshold.
-        builder_starts = [
-            c for c in pm.start.call_args_list if "builder" in str(c)
-        ]
+        builder_starts = [c for c in pm.start.call_args_list if "builder" in str(c)]
         assert len(builder_starts) == 1
 
     def test_no_spawn_when_actual_zero_and_no_ready_work(self):
@@ -870,9 +1072,7 @@ class TestScaleUpThreshold:
 
         a._reconcile()
 
-        builder_starts = [
-            c for c in pm.start.call_args_list if "builder" in str(c)
-        ]
+        builder_starts = [c for c in pm.start.call_args_list if "builder" in str(c)]
         assert len(builder_starts) == 0
 
     def test_no_spawn_above_baseline_when_below_threshold(self):
@@ -903,9 +1103,7 @@ class TestScaleUpThreshold:
 
         # desired=ceil(1*2.0)=2, actual=1, delta=1. ready_unblocked=1 < threshold=2
         # AND actual != 0, so the anti-flutter branch holds steady.
-        builder_starts = [
-            c for c in pm.start.call_args_list if "builder" in str(c)
-        ]
+        builder_starts = [c for c in pm.start.call_args_list if "builder" in str(c)]
         assert len(builder_starts) == 0
 
     def test_scale_up_above_baseline_when_threshold_met(self):
@@ -933,9 +1131,7 @@ class TestScaleUpThreshold:
 
         a._reconcile()
 
-        builder_starts = [
-            c for c in pm.start.call_args_list if "builder" in str(c)
-        ]
+        builder_starts = [c for c in pm.start.call_args_list if "builder" in str(c)]
         assert len(builder_starts) == 1
 
     def test_first_spawn_respects_max_builders_cap(self):
@@ -955,9 +1151,7 @@ class TestScaleUpThreshold:
 
         a._reconcile()
 
-        builder_starts = [
-            c for c in pm.start.call_args_list if "builder" in str(c)
-        ]
+        builder_starts = [c for c in pm.start.call_args_list if "builder" in str(c)]
         assert len(builder_starts) == 1
 
 


### PR DESCRIPTION
## Summary
- Stops the autoscaler from respawning reviewers every ~5 min after a mission reaches a terminal state (`complete`/`failed`/`cancelled`/`paused`). Without this fix the spawn counter ran to 700+ on long-running colonies.
- Threads an optional `missions` arg through `compute_desired` and `count_ready_unblocked`. When supplied, tasks whose mission is in a terminal state are excluded from reviewer demand (`done_unreviewed` and `ready_review`) and builder demand (`count_ready_unblocked`).
- `Autoscaler._reconcile()` (and `MultiNodeAutoscaler._reconcile()`) call `backend.list_missions()` once per tick and pass it through. Tolerates backends without `list_missions` (treats as no filtering). Default behavior unchanged when `missions` is `None`/`[]` — fully backward compatible.

## Test plan
- [x] `pytest tests/test_autoscaler.py -x -q` — 79 passed (12 new tests covering terminal-mission filtering, backward compat, builder-demand filter, `_reconcile` threading and tolerance for missing `list_missions`).
- [x] `pytest tests/ -q` — 1539 passed (1 deselected: a preexisting tmux test unrelated to this change, fails on `main` too due to leftover host sessions).
- [x] `ruff check .` — clean.
- [x] `ruff format` — clean.

Closes #383