### PR TITLE
feat(tui,cli): quiet activity defaults + sticky 'Now' status line

### DIFF
--- a/antfarm/core/tui.py
+++ b/antfarm/core/tui.py
@@ -69,6 +69,10 @@ class AntfarmTUI:
         self._activity_cursor: int = 0
         self._activity_epoch: str = ""
         self._activity_status: str = "connected"
+        # Sticky "Now" line state (#385): the most recent worker_activity
+        # event whose actor is *not* a subsystem (colony/queen/autoscaler/
+        # soldier/doctor). Cleared visually when older than 90s.
+        self._latest_worker_activity: dict | None = None
         self._activity_lock = threading.Lock()
         self._activity_thread: threading.Thread | None = None
         if autostart_activity:
@@ -162,6 +166,10 @@ class AntfarmTUI:
         If the event carries an epoch that differs from the one we've been
         tracking, the colony restarted — zero the cursor so we replay events
         from the new server's id=1 onward (#306).
+
+        Also pins the most recent ``worker_activity`` event from a non-
+        subsystem actor as ``_latest_worker_activity`` so the Activity panel
+        can render a sticky "Now" header (#385).
         """
         with self._activity_lock:
             incoming_epoch = event.get("epoch", "")
@@ -178,6 +186,14 @@ class AntfarmTUI:
             eid = event.get("id", 0)
             if isinstance(eid, int) and eid > self._activity_cursor:
                 self._activity_cursor = eid
+            # Pin the latest real worker_activity event for the "Now" header.
+            # Subsystem actors (colony/queen/autoscaler/soldier/doctor) are
+            # excluded — the Now line is specifically for "what is a worker
+            # doing right now".
+            if event.get("type") == "worker_activity":
+                actor = event.get("actor") or ""
+                if actor and actor not in self._NON_WORKER_ACTORS:
+                    self._latest_worker_activity = event
 
     def run(self) -> None:
         """Main loop using rich.live.Live."""
@@ -239,7 +255,9 @@ class AntfarmTUI:
             Layout(name="review", size=12),
             Layout(name="merge_ready", size=6),
             Layout(name="merged", size=6),
-            Layout(name="activity", size=22),
+            # +2 over the legacy 22-row size: room for the sticky "Now"
+            # header line plus a thin separator above the event tail (#385).
+            Layout(name="activity", size=24),
         ]
         if snap.warnings:
             column_slices.insert(0, Layout(name="warnings", size=warnings_size))
@@ -996,10 +1014,96 @@ class AntfarmTUI:
         h = sum(ord(c) for c in actor)
         return self._WORKER_PALETTE[h % len(self._WORKER_PALETTE)]
 
-    def _render_activity(self, max_rows: int = 6) -> Text:
-        """Render the tail of the activity event deque as timestamped lines.
+    # Stale TTL for the "Now" header — events older than this collapse to
+    # ``Now: --`` so the panel doesn't lie about live state when workers
+    # have gone idle (#385).
+    _NOW_LINE_STALE_SECONDS: int = 90
 
-        Two row formats coexist:
+    @staticmethod
+    def _format_elapsed_seconds(iso_timestamp: str, now: datetime | None = None) -> str:
+        """Format elapsed time as ``Ns``, ``NmMs``, or ``NhMm``.
+
+        Returns ``""`` if the timestamp is missing or unparseable. Used by
+        the sticky "Now" header so very-recent activity reads as ``10s``
+        and longer-running tool calls read as ``4m12s``.
+        """
+        if not iso_timestamp:
+            return ""
+        try:
+            start = datetime.fromisoformat(iso_timestamp)
+            if start.tzinfo is None:
+                start = start.replace(tzinfo=UTC)
+            current = now or datetime.now(UTC)
+            secs = int((current - start).total_seconds())
+        except (ValueError, TypeError):
+            return ""
+        if secs < 0:
+            secs = 0
+        if secs < 60:
+            return f"{secs}s"
+        if secs < 3600:
+            mins, rem = divmod(secs, 60)
+            return f"{mins}m{rem}s"
+        hrs, rem_secs = divmod(secs, 3600)
+        mins = rem_secs // 60
+        return f"{hrs}h{mins}m"
+
+    def _render_now_line(self, now: datetime | None = None) -> Text:
+        """Render the sticky ``Now: <actor>  <text>  (<elapsed>)`` header.
+
+        Returns ``Now: --`` (dim) when the most recent worker_activity is
+        absent or older than :attr:`_NOW_LINE_STALE_SECONDS`. Otherwise the
+        actor segment is colored via :meth:`_color_for_worker` so the eye
+        can lock onto whichever worker is currently active (#385).
+        """
+        text = Text()
+        text.append("Now: ", style="bold")
+
+        with self._activity_lock:
+            latest = self._latest_worker_activity
+
+        ts_raw = (latest or {}).get("ts") or ""
+        elapsed = self._format_elapsed_seconds(ts_raw, now=now)
+
+        # Determine staleness. A missing/bad timestamp is treated as stale
+        # so we never show a Now line we can't age-check.
+        is_stale = True
+        if latest and ts_raw:
+            try:
+                start = datetime.fromisoformat(ts_raw)
+                if start.tzinfo is None:
+                    start = start.replace(tzinfo=UTC)
+                current = now or datetime.now(UTC)
+                age = (current - start).total_seconds()
+                is_stale = age > self._NOW_LINE_STALE_SECONDS
+            except (ValueError, TypeError):
+                is_stale = True
+
+        if not latest or is_stale:
+            text.append("--", style="dim")
+            return text
+
+        actor_raw = str(latest.get("actor") or "")
+        detail = str(latest.get("detail") or "-")
+        text.append(actor_raw, style=self._color_for_worker(actor_raw))
+        text.append("  ")
+        text.append(detail)
+        if elapsed:
+            text.append(f"  ({elapsed})", style="dim")
+        return text
+
+    def _render_activity(self, max_rows: int = 6) -> Text:
+        """Render the activity panel.
+
+        Layout (#385):
+
+        * Line 1 — sticky ``Now: <actor>  <text>  (<elapsed>)`` header that
+          mirrors the most recent ``worker_activity`` from a non-subsystem
+          actor. Collapses to ``Now: --`` after 90s of silence.
+        * Line 2 — thin separator made of box-drawing ``─`` chars.
+        * Lines 3+ — event tail (up to ``max_rows`` rows).
+
+        Two row formats coexist in the tail:
 
         * ``worker_activity`` events render as ``HH:MM:SS  actor  text`` --
           the live per-worker action feed (#372). The ``text`` comes from
@@ -1017,6 +1121,13 @@ class AntfarmTUI:
             events = list(self._activity_events)
 
         text = Text()
+        # Sticky "Now" header — always rendered, even when the event deque
+        # is empty, so the panel has consistent shape across colony states.
+        text.append_text(self._render_now_line())
+        text.append("\n")
+        text.append("─" * 40, style="dim")
+        text.append("\n")
+
         if not events:
             text.append("(waiting for events\u2026)", style="dim")
             return text

--- a/antfarm/core/watch_format.py
+++ b/antfarm/core/watch_format.py
@@ -63,7 +63,17 @@ _HEARTBEAT_VERBS: frozenset[str] = frozenset(
     {"heartbeat", "polling", "idle", "scanning", "cleanup"}
 )
 LOW_SIGNAL_TYPES: frozenset[str] = frozenset(
-    {"heartbeat", "scanning", "idle", "polling", "cleanup"}
+    {
+        "heartbeat",
+        "scanning",
+        "idle",
+        "polling",
+        "cleanup",
+        # Autoscaler spawn/retire events are infrastructure noise during
+        # short missions / idle periods (#385). Verbose mode keeps them.
+        "worker_spawned",
+        "worker_retired",
+    }
 )
 
 

--- a/docs/antfarm/missions/mission-auth-1.md
+++ b/docs/antfarm/missions/mission-auth-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-auth-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:01:05.405754+00:00
-**Completed:** 2026-05-04T07:01:05.435778+00:00 (0s)
+**Created:** 2026-05-06T05:52:55.558408+00:00
+**Completed:** 2026-05-06T05:52:55.589363+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -21,8 +21,8 @@
 
 ## Timeline highlights
 
-- 07:01:05  mission created
-- 07:01:05  plan ready
-- 07:01:05  task-auth-01 merged
-- 07:01:05  task-auth-02 merged
-- 07:01:05  mission complete
+- 05:52:55  mission created
+- 05:52:55  plan ready
+- 05:52:55  task-auth-01 merged
+- 05:52:55  task-auth-02 merged
+- 05:52:55  mission complete

--- a/docs/antfarm/missions/mission-auth-1.md
+++ b/docs/antfarm/missions/mission-auth-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-auth-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-06T05:52:55.558408+00:00
-**Completed:** 2026-05-06T05:52:55.589363+00:00 (0s)
+**Created:** 2026-05-06T05:53:17.626116+00:00
+**Completed:** 2026-05-06T05:53:17.654241+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -21,8 +21,8 @@
 
 ## Timeline highlights
 
-- 05:52:55  mission created
-- 05:52:55  plan ready
-- 05:52:55  task-auth-01 merged
-- 05:52:55  task-auth-02 merged
-- 05:52:55  mission complete
+- 05:53:17  mission created
+- 05:53:17  plan ready
+- 05:53:17  task-auth-01 merged
+- 05:53:17  task-auth-02 merged
+- 05:53:17  mission complete

--- a/docs/antfarm/missions/mission-blocked-1.md
+++ b/docs/antfarm/missions/mission-blocked-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-blocked-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:01:06.077692+00:00
-**Completed:** 2026-05-04T07:01:06.111006+00:00 (0s)
+**Created:** 2026-05-06T05:52:56.316023+00:00
+**Completed:** 2026-05-06T05:52:56.348135+00:00 (0s)
 **Outcome:** complete (1/2 merged)
 
 ## Plan
@@ -21,10 +21,10 @@
 
 ## Timeline highlights
 
-- 07:01:06  mission created
-- 07:01:06  plan ready
-- 07:01:06  task-blocked-02 merged
-- 07:01:06  task-blocked-01 kicked back (kickback)
-- 07:01:06  task-blocked-01 kicked back (kickback)
-- 07:01:06  task-blocked-01 kicked back (kickback)
-- 07:01:06  mission complete
+- 05:52:56  mission created
+- 05:52:56  plan ready
+- 05:52:56  task-blocked-02 merged
+- 05:52:56  task-blocked-01 kicked back (kickback)
+- 05:52:56  task-blocked-01 kicked back (kickback)
+- 05:52:56  task-blocked-01 kicked back (kickback)
+- 05:52:56  mission complete

--- a/docs/antfarm/missions/mission-blocked-1.md
+++ b/docs/antfarm/missions/mission-blocked-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-blocked-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-06T05:52:56.316023+00:00
-**Completed:** 2026-05-06T05:52:56.348135+00:00 (0s)
+**Created:** 2026-05-06T05:53:18.363753+00:00
+**Completed:** 2026-05-06T05:53:18.397063+00:00 (0s)
 **Outcome:** complete (1/2 merged)
 
 ## Plan
@@ -21,10 +21,10 @@
 
 ## Timeline highlights
 
-- 05:52:56  mission created
-- 05:52:56  plan ready
-- 05:52:56  task-blocked-02 merged
-- 05:52:56  task-blocked-01 kicked back (kickback)
-- 05:52:56  task-blocked-01 kicked back (kickback)
-- 05:52:56  task-blocked-01 kicked back (kickback)
-- 05:52:56  mission complete
+- 05:53:18  mission created
+- 05:53:18  plan ready
+- 05:53:18  task-blocked-02 merged
+- 05:53:18  task-blocked-01 kicked back (kickback)
+- 05:53:18  task-blocked-01 kicked back (kickback)
+- 05:53:18  task-blocked-01 kicked back (kickback)
+- 05:53:18  mission complete

--- a/docs/antfarm/missions/mission-budget-cancel.md
+++ b/docs/antfarm/missions/mission-budget-cancel.md
@@ -1,8 +1,8 @@
 # Mission: mission-budget-cancel
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:01:18.896182+00:00
-**Completed:** 2026-05-04T07:01:18.898144+00:00 (0s)
+**Created:** 2026-05-06T05:53:28.450116+00:00
+**Completed:** 2026-05-06T05:53:28.452069+00:00 (0s)
 **Outcome:** cancelled (0/0 merged)
 
 ## Plan
@@ -20,5 +20,5 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 07:01:18  mission created
-- 07:01:18  mission cancelled
+- 05:53:28  mission created
+- 05:53:28  mission cancelled

--- a/docs/antfarm/missions/mission-replan-1.md
+++ b/docs/antfarm/missions/mission-replan-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-replan-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:01:06.832277+00:00
-**Completed:** 2026-05-04T07:01:06.871643+00:00 (0s)
+**Created:** 2026-05-06T05:52:56.951202+00:00
+**Completed:** 2026-05-06T05:52:56.989291+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -27,8 +27,8 @@ The plan above is the final accepted version. Earlier rejected drafts can be rec
 
 ## Timeline highlights
 
-- 07:01:06  mission created
-- 07:01:06  plan ready
-- 07:01:06  task-replan-01 merged
-- 07:01:06  task-replan-02 merged
-- 07:01:06  mission complete
+- 05:52:56  mission created
+- 05:52:56  plan ready
+- 05:52:56  task-replan-01 merged
+- 05:52:56  task-replan-02 merged
+- 05:52:56  mission complete

--- a/docs/antfarm/missions/mission-replan-1.md
+++ b/docs/antfarm/missions/mission-replan-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-replan-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-06T05:52:56.951202+00:00
-**Completed:** 2026-05-06T05:52:56.989291+00:00 (0s)
+**Created:** 2026-05-06T05:53:19.085803+00:00
+**Completed:** 2026-05-06T05:53:19.125282+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -27,8 +27,8 @@ The plan above is the final accepted version. Earlier rejected drafts can be rec
 
 ## Timeline highlights
 
-- 05:52:56  mission created
-- 05:52:56  plan ready
-- 05:52:56  task-replan-01 merged
-- 05:52:56  task-replan-02 merged
-- 05:52:56  mission complete
+- 05:53:19  mission created
+- 05:53:19  plan ready
+- 05:53:19  task-replan-01 merged
+- 05:53:19  task-replan-02 merged
+- 05:53:19  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,13 +1,16 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-06T05:53:21.075259+00:00
-**Completed:** 2026-05-06T05:53:21.076820+00:00 (0s)
+**Created:** 2026-05-06T05:53:21.717588+00:00
+**Completed:** 2026-05-06T05:53:21.720109+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
 
-_(no plan artifact recorded)_
+| ID | Title | Deps | Touches | Complexity |
+|---|---|---|---|---|
+| task-01 | Child task 1 | — | api | M |
+| task-02 | Child task 2 | — | api | M |
 
 ## Tasks
 
@@ -16,4 +19,5 @@ _(no implementation tasks)_
 ## Timeline highlights
 
 - 05:53:21  mission created
+- 05:53:21  plan ready
 - 05:53:21  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-06T05:53:25.420696+00:00
-**Completed:** 2026-05-06T05:53:25.436155+00:00 (0s)
-**Outcome:** complete (1/2 merged)
+**Created:** 2026-05-06T05:53:26.039626+00:00
+**Completed:** 2026-05-06T05:53:26.055230+00:00 (0s)
+**Outcome:** failed (0/2 merged)
 
 ## Plan
 
@@ -16,13 +16,11 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | p | 1 | pass | 0s | — |
-| task-test-02 | — | 1 | blocked | — | blocked |
+| task-test-01 | — | 0 | blocked | — | blocked |
+| task-test-02 | — | 0 | blocked | — | blocked |
 
 ## Timeline highlights
 
-- 05:53:25  mission created
-- 05:53:25  plan ready
-- 05:53:25  task-test-01 merged
-- 05:53:25  task-test-02 kicked back (kickback)
-- 05:53:25  mission complete
+- 05:53:26  mission created
+- 05:53:26  plan ready
+- 05:53:26  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-06T05:53:24.241643+00:00
-**Completed:** 2026-05-06T05:53:24.244635+00:00 (0s)
-**Outcome:** failed (0/0 merged)
+**Created:** 2026-05-06T05:53:24.854940+00:00
+**Completed:** 2026-05-06T05:53:24.870712+00:00 (0s)
+**Outcome:** complete (2/2 merged)
 
 ## Plan
 
@@ -14,10 +14,15 @@
 
 ## Tasks
 
-_(no implementation tasks)_
+| ID | PR | Attempts | Verdict | Wall | Notes |
+|---|---|---|---|---|---|
+| task-test-01 | https://github.com/test/pr/0 | 1 | pass | 0s | — |
+| task-test-02 | https://github.com/test/pr/1 | 1 | pass | 0s | — |
 
 ## Timeline highlights
 
 - 05:53:24  mission created
 - 05:53:24  plan ready
-- 05:53:24  mission failed
+- 05:53:24  task-test-01 merged
+- 05:53:24  task-test-02 merged
+- 05:53:24  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:01:18.093754+00:00
-**Completed:** 2026-05-04T07:01:18.095363+00:00 (0s)
+**Created:** 2026-05-06T05:53:21.075259+00:00
+**Completed:** 2026-05-06T05:53:21.076820+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -15,5 +15,5 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 07:01:18  mission created
-- 07:01:18  mission failed
+- 05:53:21  mission created
+- 05:53:21  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-06T05:53:26.621547+00:00
-**Completed:** 2026-05-06T05:53:26.636981+00:00 (0s)
-**Outcome:** complete (1/2 merged)
+**Created:** 2026-05-06T05:53:27.304736+00:00
+**Completed:** 2026-05-06T05:53:27.319314+00:00 (0s)
+**Outcome:** complete (2/2 merged)
 
 ## Plan
 
@@ -16,12 +16,13 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | p | 1 | pass | 0s | — |
-| task-test-02 | — | 0 | blocked | — | blocked |
+| task-test-01 | https://example.com/pr/0 | 1 | pass | 0s | — |
+| task-test-02 | https://example.com/pr/1 | 1 | pass | 0s | — |
 
 ## Timeline highlights
 
-- 05:53:26  mission created
-- 05:53:26  plan ready
-- 05:53:26  task-test-01 merged
-- 05:53:26  mission complete
+- 05:53:27  mission created
+- 05:53:27  plan ready
+- 05:53:27  task-test-01 merged
+- 05:53:27  task-test-02 merged
+- 05:53:27  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,28 +1,19 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-06T05:53:27.304736+00:00
-**Completed:** 2026-05-06T05:53:27.319314+00:00 (0s)
-**Outcome:** complete (2/2 merged)
+**Created:** 2026-05-06T05:53:27.846787+00:00
+**Completed:** 2026-05-06T05:53:27.848604+00:00 (0s)
+**Outcome:** failed (0/0 merged)
 
 ## Plan
 
-| ID | Title | Deps | Touches | Complexity |
-|---|---|---|---|---|
-| task-01 | Child task 1 | — | api | M |
-| task-02 | Child task 2 | — | api | M |
+_(no plan artifact recorded)_
 
 ## Tasks
 
-| ID | PR | Attempts | Verdict | Wall | Notes |
-|---|---|---|---|---|---|
-| task-test-01 | https://example.com/pr/0 | 1 | pass | 0s | — |
-| task-test-02 | https://example.com/pr/1 | 1 | pass | 0s | — |
+_(no implementation tasks)_
 
 ## Timeline highlights
 
 - 05:53:27  mission created
-- 05:53:27  plan ready
-- 05:53:27  task-test-01 merged
-- 05:53:27  task-test-02 merged
-- 05:53:27  mission complete
+- 05:53:27  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-06T05:53:22.279656+00:00
-**Completed:** 2026-05-06T05:53:22.284361+00:00 (0s)
+**Created:** 2026-05-06T05:53:23.136136+00:00
+**Completed:** 2026-05-06T05:53:23.143688+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -14,7 +14,7 @@
 
 ## Re-plans
 
-Re-plan cycles: **1**.
+Re-plan cycles: **2**.
 
 The plan above is the final accepted version. Earlier rejected drafts can be reconstructed from the plan task's attempt history in `.antfarm/tasks/`.
 
@@ -24,6 +24,6 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 05:53:22  mission created
-- 05:53:22  plan ready
-- 05:53:22  mission failed
+- 05:53:23  mission created
+- 05:53:23  plan ready
+- 05:53:23  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-06T05:53:24.854940+00:00
-**Completed:** 2026-05-06T05:53:24.870712+00:00 (0s)
-**Outcome:** complete (2/2 merged)
+**Created:** 2026-05-06T05:53:25.420696+00:00
+**Completed:** 2026-05-06T05:53:25.436155+00:00 (0s)
+**Outcome:** complete (1/2 merged)
 
 ## Plan
 
@@ -16,13 +16,13 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | https://github.com/test/pr/0 | 1 | pass | 0s | — |
-| task-test-02 | https://github.com/test/pr/1 | 1 | pass | 0s | — |
+| task-test-01 | p | 1 | pass | 0s | — |
+| task-test-02 | — | 1 | blocked | — | blocked |
 
 ## Timeline highlights
 
-- 05:53:24  mission created
-- 05:53:24  plan ready
-- 05:53:24  task-test-01 merged
-- 05:53:24  task-test-02 merged
-- 05:53:24  mission complete
+- 05:53:25  mission created
+- 05:53:25  plan ready
+- 05:53:25  task-test-01 merged
+- 05:53:25  task-test-02 kicked back (kickback)
+- 05:53:25  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-06T05:53:21.717588+00:00
-**Completed:** 2026-05-06T05:53:21.720109+00:00 (0s)
+**Created:** 2026-05-06T05:53:22.279656+00:00
+**Completed:** 2026-05-06T05:53:22.284361+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -12,12 +12,18 @@
 | task-01 | Child task 1 | — | api | M |
 | task-02 | Child task 2 | — | api | M |
 
+## Re-plans
+
+Re-plan cycles: **1**.
+
+The plan above is the final accepted version. Earlier rejected drafts can be reconstructed from the plan task's attempt history in `.antfarm/tasks/`.
+
 ## Tasks
 
 _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 05:53:21  mission created
-- 05:53:21  plan ready
-- 05:53:21  mission failed
+- 05:53:22  mission created
+- 05:53:22  plan ready
+- 05:53:22  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-06T05:53:26.039626+00:00
-**Completed:** 2026-05-06T05:53:26.055230+00:00 (0s)
-**Outcome:** failed (0/2 merged)
+**Created:** 2026-05-06T05:53:26.621547+00:00
+**Completed:** 2026-05-06T05:53:26.636981+00:00 (0s)
+**Outcome:** complete (1/2 merged)
 
 ## Plan
 
@@ -16,11 +16,12 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | — | 0 | blocked | — | blocked |
+| task-test-01 | p | 1 | pass | 0s | — |
 | task-test-02 | — | 0 | blocked | — | blocked |
 
 ## Timeline highlights
 
 - 05:53:26  mission created
 - 05:53:26  plan ready
-- 05:53:26  mission failed
+- 05:53:26  task-test-01 merged
+- 05:53:26  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-06T05:53:23.136136+00:00
-**Completed:** 2026-05-06T05:53:23.143688+00:00 (0s)
+**Created:** 2026-05-06T05:53:24.241643+00:00
+**Completed:** 2026-05-06T05:53:24.244635+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -12,18 +12,12 @@
 | task-01 | Child task 1 | — | api | M |
 | task-02 | Child task 2 | — | api | M |
 
-## Re-plans
-
-Re-plan cycles: **2**.
-
-The plan above is the final accepted version. Earlier rejected drafts can be reconstructed from the plan task's attempt history in `.antfarm/tasks/`.
-
 ## Tasks
 
 _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 05:53:23  mission created
-- 05:53:23  plan ready
-- 05:53:23  mission failed
+- 05:53:24  mission created
+- 05:53:24  plan ready
+- 05:53:24  mission failed

--- a/docs/antfarm/missions/mission-zero-cap.md
+++ b/docs/antfarm/missions/mission-zero-cap.md
@@ -1,8 +1,8 @@
 # Mission: mission-zero-cap
 
 **Spec:** `(inline)`
-**Created:** 2026-05-04T07:01:13.520444+00:00
-**Completed:** 2026-05-04T07:01:13.523578+00:00 (0s)
+**Created:** 2026-05-06T05:53:23.678269+00:00
+**Completed:** 2026-05-06T05:53:23.681334+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -18,6 +18,6 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 07:01:13  mission created
-- 07:01:13  plan ready
-- 07:01:13  mission failed
+- 05:53:23  mission created
+- 05:53:23  plan ready
+- 05:53:23  mission failed

--- a/tests/test_tui.py
+++ b/tests/test_tui.py
@@ -1238,15 +1238,18 @@ def test_render_activity_formats_rows():
     rendered = tui._render_activity()
     plain = rendered.plain
 
-    # Two rows, newest last (auto-scroll)
+    # Layout (#385): Now header + separator + event tail. Skip the two
+    # header rows before asserting on body content.
     lines = plain.split("\n")
-    assert len(lines) == 2
-    assert "soldier" in lines[0]
-    assert "merging task-001 to main" in lines[0]
-    assert "queen" in lines[1]
-    assert "created plan plan-v061" in lines[1]
+    assert lines[0].startswith("Now: ")
+    body = lines[2:]
+    assert len(body) == 2
+    assert "soldier" in body[0]
+    assert "merging task-001 to main" in body[0]
+    assert "queen" in body[1]
+    assert "created plan plan-v061" in body[1]
     # Actor column is fixed-width 12
-    assert lines[0].split("  ")[1].startswith("soldier")
+    assert body[0].split("  ")[1].startswith("soldier")
 
 
 def test_render_activity_uses_tail_when_over_max_rows():
@@ -1264,10 +1267,13 @@ def test_render_activity_uses_tail_when_over_max_rows():
     rendered = tui._render_activity(max_rows=4)
     plain = rendered.plain
     lines = plain.split("\n")
-    assert len(lines) == 4
+    # Layout (#385): Now header + separator + 4-row tail.
+    assert lines[0].startswith("Now: ")
+    body = lines[2:]
+    assert len(body) == 4
     # Newest (event-10) rendered last
-    assert "event-10" in lines[-1]
-    assert "event-7" in lines[0]
+    assert "event-10" in body[-1]
+    assert "event-7" in body[0]
 
 
 def test_render_activity_failed_type_is_red():
@@ -1578,10 +1584,13 @@ def test_render_activity_max_rows_20():
         )
     rendered = tui._render_activity(max_rows=20)
     lines = rendered.plain.split("\n")
-    assert len(lines) == 20
+    # Layout (#385): Now header + separator + 20-row tail.
+    assert lines[0].startswith("Now: ")
+    body = lines[2:]
+    assert len(body) == 20
     # Newest event ends up last.
-    assert "edit-25" in lines[-1]
-    assert "edit-6" in lines[0]
+    assert "edit-25" in body[-1]
+    assert "edit-6" in body[0]
 
 
 def test_render_activity_colors_only_workers_not_colony():
@@ -1631,4 +1640,135 @@ def test_render_activity_colors_only_workers_not_colony():
     )
     assert all(not any(c in s for c in palette) for s in soldier_styles), (
         f"soldier actor span unexpectedly colored: {soldier_styles}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Activity Feed: sticky "Now" line (#385)
+# ---------------------------------------------------------------------------
+
+
+def _now_iso(seconds_ago: int = 0) -> str:
+    """ISO 8601 timestamp ``seconds_ago`` seconds before now (UTC)."""
+    from datetime import UTC, datetime, timedelta
+
+    return (datetime.now(UTC) - timedelta(seconds=seconds_ago)).isoformat()
+
+
+def test_render_activity_shows_now_line_when_recent_worker_activity():
+    """Recent worker_activity from a non-subsystem actor pins the Now line."""
+    tui = _make_tui()
+    tui._ingest_event(
+        {
+            "id": 1,
+            "type": "worker_activity",
+            "actor": "node1/worker-3",
+            "detail": "editing src/foo.py",
+            "task_id": "",
+            "ts": _now_iso(seconds_ago=10),
+        }
+    )
+    rendered = tui._render_activity()
+    plain = rendered.plain
+    first_line = plain.split("\n")[0]
+    assert first_line.startswith("Now: ")
+    assert "node1/worker-3" in first_line
+    assert "editing src/foo.py" in first_line
+
+
+def test_render_activity_now_line_clears_when_stale():
+    """worker_activity older than 90s collapses the Now line to ``Now: --``."""
+    tui = _make_tui()
+    tui._ingest_event(
+        {
+            "id": 1,
+            "type": "worker_activity",
+            "actor": "node1/worker-3",
+            "detail": "editing src/foo.py",
+            "task_id": "",
+            "ts": _now_iso(seconds_ago=100),
+        }
+    )
+    rendered = tui._render_activity()
+    first_line = rendered.plain.split("\n")[0]
+    assert first_line.strip() == "Now: --"
+
+
+def test_render_activity_now_line_ignores_subsystem_actors():
+    """Subsystem actors (soldier/doctor/colony/queen/autoscaler) never pin the
+    Now line — it's reserved for actual workers (#385)."""
+    tui = _make_tui()
+    # Pin the Now line with a real worker first.
+    tui._ingest_event(
+        {
+            "id": 1,
+            "type": "worker_activity",
+            "actor": "node1/worker-3",
+            "detail": "editing src/foo.py",
+            "task_id": "",
+            "ts": _now_iso(seconds_ago=5),
+        }
+    )
+    # Subsystem worker_activity events must NOT overwrite the Now line.
+    for actor in ("soldier", "doctor", "colony", "queen", "autoscaler"):
+        tui._ingest_event(
+            {
+                "id": 2,
+                "type": "worker_activity",
+                "actor": actor,
+                "detail": f"{actor} is doing thing",
+                "task_id": "",
+                "ts": _now_iso(seconds_ago=1),
+            }
+        )
+    first_line = tui._render_activity().plain.split("\n")[0]
+    assert "node1/worker-3" in first_line
+    assert "editing src/foo.py" in first_line
+    for actor in ("soldier", "doctor", "colony", "queen", "autoscaler"):
+        assert f"{actor} is doing thing" not in first_line
+
+    # And: when no real worker activity has ever been seen, only subsystem
+    # noise has streamed in -> Now line stays at "--".
+    tui2 = _make_tui()
+    tui2._ingest_event(
+        {
+            "id": 1,
+            "type": "worker_activity",
+            "actor": "soldier",
+            "detail": "merging",
+            "task_id": "",
+            "ts": _now_iso(seconds_ago=1),
+        }
+    )
+    first2 = tui2._render_activity().plain.split("\n")[0]
+    assert first2.strip() == "Now: --"
+
+
+def test_render_activity_now_line_uses_palette_color():
+    """The Now line's actor segment is colored via _color_for_worker."""
+    tui = _make_tui()
+    actor = "node1/worker-3"
+    tui._ingest_event(
+        {
+            "id": 1,
+            "type": "worker_activity",
+            "actor": actor,
+            "detail": "editing src/foo.py",
+            "task_id": "",
+            "ts": _now_iso(seconds_ago=5),
+        }
+    )
+    rendered = tui._render_activity()
+    expected = tui._color_for_worker(actor)
+
+    # Locate the span covering the actor substring on the Now line and
+    # confirm its style carries the expected palette color.
+    actor_styles: list[str] = []
+    for span in rendered.spans:
+        substr = rendered.plain[span.start : span.end]
+        if substr == actor:
+            actor_styles.append(str(span.style))
+    assert actor_styles, "actor span not found on the Now line"
+    assert any(expected in s for s in actor_styles), (
+        f"Now-line actor missing palette color {expected}: {actor_styles}"
     )

--- a/tests/test_watch_format.py
+++ b/tests/test_watch_format.py
@@ -70,6 +70,39 @@ def test_is_low_signal_high_signal_events():
         assert watch_format.is_low_signal({"type": t}) is False
 
 
+def test_is_low_signal_filters_worker_spawned():
+    """Autoscaler worker_spawned events are filtered by default (#385)."""
+    ev = {"type": "worker_spawned", "actor": "autoscaler"}
+    assert watch_format.is_low_signal(ev) is True
+
+
+def test_is_low_signal_filters_worker_retired():
+    """Autoscaler worker_retired events are filtered by default (#385)."""
+    ev = {"type": "worker_retired", "actor": "autoscaler"}
+    assert watch_format.is_low_signal(ev) is True
+
+
+def test_format_event_human_skips_worker_spawned_via_is_low_signal():
+    """Confirm the filter+formatter chain works for worker_spawned (#385).
+
+    ``scout --watch`` drops events where ``is_low_signal`` returns True
+    *before* calling the formatter. We assert both halves of that contract:
+    the filter returns True for worker_spawned, and the formatter still
+    produces a clean row if anyone bypasses the gate (e.g. ``--verbose``).
+    """
+    ev = {
+        "type": "worker_spawned",
+        "actor": "autoscaler",
+        "task_id": "",
+        "detail": "role=builder name=builder-1",
+        "ts": "2026-04-16T14:32:11+00:00",
+    }
+    assert watch_format.is_low_signal(ev) is True
+    out = watch_format.format_event_human(ev, use_color=False)
+    assert "spawned worker" in out
+    assert "autoscaler" in out
+
+
 # ---------------------------------------------------------------------------
 # Timestamp formatting
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #385.

- **Quiet defaults**: `scout --tui` and `scout --watch` now hide autoscaler `worker_spawned` / `worker_retired` events by adding both types to `watch_format.LOW_SIGNAL_TYPES`. `-v / --verbose` still includes them (filter chain is bypassed there — no change).
- **Sticky "Now" line**: the TUI Activity panel gains a one-line header above the event tail showing the most recent active worker + verb + target + elapsed:
  ```
  Now: worker-3  editing src/foo.py  (4m12s)
  ────────────────────────────────────────
  [tail of last 20 events]
  ```
  Cleared to `Now: --` after 90s of silence. Actor segment colored via `_color_for_worker` (matches the rest of the activity feed). Subsystem actors (colony / queen / autoscaler / soldier / doctor) never pin the Now line — it's reserved for real workers.
- Activity panel size bumped from 22 to 24 rows so the header + separator don't eat any tail rows.

## Test Plan

- [x] `pytest tests/ -x -q` green (1546 passed, 1 deselected — pre-existing flaky `test_tmux_pm_adopt_existing` that reads the host's live tmux server, unrelated to this PR).
- [x] `ruff check .` clean.
- [x] New tests:
  - `tests/test_watch_format.py`:
    - `test_is_low_signal_filters_worker_spawned`
    - `test_is_low_signal_filters_worker_retired`
    - `test_format_event_human_skips_worker_spawned_via_is_low_signal`
  - `tests/test_tui.py`:
    - `test_render_activity_shows_now_line_when_recent_worker_activity`
    - `test_render_activity_now_line_clears_when_stale`
    - `test_render_activity_now_line_ignores_subsystem_actors`
    - `test_render_activity_now_line_uses_palette_color`
- [x] Existing TUI render tests updated to skip the new 2-line header before asserting on body content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)