### PR TITLE
feat(tui): mission-scoped narrative panel via scout --tui --mission (Closes #386)

### DIFF
--- a/antfarm/core/cli.py
+++ b/antfarm/core/cli.py
@@ -725,6 +725,15 @@ def _scout_watch(colony_url: str, token: str | None, json_mode: bool, verbose: b
     help="Seconds between TUI refreshes (with --tui).",
 )
 @click.option(
+    "--mission",
+    "mission_id",
+    default=None,
+    help=(
+        "With --tui, replace the global activity panel with a mission-scoped "
+        "per-task progress tree (#386)."
+    ),
+)
+@click.option(
     "--json",
     "json_mode",
     is_flag=True,
@@ -744,6 +753,7 @@ def scout(
     watch: bool,
     tui: bool,
     refresh: float,
+    mission_id: str | None,
     json_mode: bool,
     verbose: bool,
     colony_url: str,
@@ -753,7 +763,29 @@ def scout(
     if tui:
         from antfarm.core.tui import AntfarmTUI
 
-        dashboard = AntfarmTUI(colony_url=colony_url, token=token, refresh_interval=refresh)
+        # Pre-flight check for --mission so we exit cleanly with a helpful
+        # message instead of dropping the user into an empty TUI when the id
+        # is wrong (#386). Connection errors fall through to the TUI's own
+        # error-panel handling.
+        if mission_id:
+            try:
+                resp = httpx.get(
+                    f"{colony_url.rstrip('/')}/missions/{mission_id}",
+                    headers=({"Authorization": f"Bearer {token}"} if token else {}),
+                    timeout=5,
+                )
+            except httpx.HTTPError:
+                resp = None
+            if resp is not None and resp.status_code == 404:
+                click.echo(f"Mission '{mission_id}' not found", err=True)
+                raise SystemExit(1)
+
+        dashboard = AntfarmTUI(
+            colony_url=colony_url,
+            token=token,
+            refresh_interval=refresh,
+            mission_id=mission_id,
+        )
         dashboard.run()
         return
 

--- a/antfarm/core/tui.py
+++ b/antfarm/core/tui.py
@@ -45,6 +45,34 @@ class PipelineSnapshot:
     warnings: list[dict] = field(default_factory=list)
 
 
+@dataclass
+class MissionTaskState:
+    """Per-task state record powering the mission-scoped TUI panel (#386).
+
+    Aggregates the few fields that drive the build/review/merge columns:
+    builder identity, most recent tool action, harvest + PR metadata, review
+    verdict, merge state, and attempt counter. Updated incrementally by
+    ``AntfarmTUI._ingest_event`` as SSE events arrive, then rendered by
+    ``_render_mission_panel``.
+    """
+
+    task_id: str
+    title: str
+    deps: list[str] = field(default_factory=list)
+    builder_worker: str | None = None
+    last_tool_action: str | None = None
+    last_tool_target: str | None = None
+    last_tool_ts: datetime | None = None
+    harvested_at: datetime | None = None
+    pr_url: str | None = None
+    # queued | reviewing | pass | needs_changes
+    review_status: str = "queued"
+    review_verdict: str | None = None
+    # — | waiting_ci | rebasing | merged | failed
+    merge_status: str = "—"
+    attempts: int = 1
+
+
 class AntfarmTUI:
     """Live TUI dashboard for an Antfarm colony.
 
@@ -60,6 +88,7 @@ class AntfarmTUI:
         token: str | None = None,
         refresh_interval: float = 2.0,
         autostart_activity: bool = True,
+        mission_id: str | None = None,
     ):
         self.colony_url = colony_url.rstrip("/")
         self.token = token
@@ -75,6 +104,23 @@ class AntfarmTUI:
         self._latest_worker_activity: dict | None = None
         self._activity_lock = threading.Lock()
         self._activity_thread: threading.Thread | None = None
+
+        # Mission-scoped panel state (#386). When ``mission_id`` is set the
+        # build_display path swaps the global activity panel for the per-task
+        # progress tree fed by ``_mission_task_states``. ``_mission_seeded``
+        # toggles to True after the first successful state seed so we don't
+        # repeatedly clobber live event-driven updates with stale snapshots.
+        # ``_mission_not_found`` is sticky once set (mission was never valid).
+        self._mission_id: str | None = mission_id
+        self._mission_task_states: dict[str, MissionTaskState] = {}
+        self._mission: dict | None = None
+        self._mission_seeded: bool = False
+        self._mission_not_found: bool = False
+        # Maps worker_id -> task_id for the active builder/reviewer claim.
+        # Used to attribute ``worker_activity`` events (which carry empty
+        # task_id) back to the right row in the mission panel.
+        self._worker_to_task: dict[str, str] = {}
+
         if autostart_activity:
             self._start_activity_thread()
 
@@ -195,6 +241,121 @@ class AntfarmTUI:
                 if actor and actor not in self._NON_WORKER_ACTORS:
                     self._latest_worker_activity = event
 
+        # Mission-scoped panel update (#386). Held outside the activity lock
+        # because it touches a separate state map and the activity lock is
+        # already released. Filtered to events that name a task in the
+        # mission, plus worker_activity events whose actor maps to a known
+        # builder via ``_worker_to_task``.
+        if self._mission_id is not None:
+            self._update_mission_state(event)
+
+    def _update_mission_state(self, event: dict) -> None:
+        """Apply a single SSE event to the mission-scoped task state map.
+
+        Events relevant to mission rows fall into three buckets:
+
+        * ``worker_activity`` -- updates ``builder_worker`` and the latest
+          tool action/target/timestamp on the row owned by this worker.
+        * task lifecycle (``harvested``, ``merged``, ``auto_merged``,
+          ``kickback``/``kicked_back``, ``auto_merge_waiting_ci``,
+          ``auto_merge_rebasing``, ``merge_failed``) -- update the matching
+          task row by ``task_id``.
+        * Review verdict events -- update review_status / review_verdict.
+
+        Events that don't match a known task in the mission are ignored.
+        """
+        if not self._mission_task_states:
+            return
+
+        ev_type = event.get("type") or ""
+        task_id = event.get("task_id") or ""
+        actor = event.get("actor") or ""
+        ts = self._parse_event_ts(event.get("ts"))
+
+        # worker_activity has no task_id; map actor -> task via the running
+        # claim record. If we don't know the worker, drop it silently.
+        if ev_type == "worker_activity":
+            if not actor or actor in self._NON_WORKER_ACTORS:
+                return
+            mapped = self._worker_to_task.get(actor)
+            if not mapped or mapped not in self._mission_task_states:
+                return
+            state = self._mission_task_states[mapped]
+            state.builder_worker = actor
+            data = event.get("data") or {}
+            action = data.get("action")
+            target = data.get("target")
+            # Fall back to parsing detail if data dict is absent (older
+            # emitters). The detail string already encodes verb+target so we
+            # store it as ``action`` and leave target empty.
+            if action is None and target is None:
+                detail = event.get("detail") or ""
+                state.last_tool_action = detail or state.last_tool_action
+            else:
+                state.last_tool_action = action or state.last_tool_action
+                state.last_tool_target = target or state.last_tool_target
+            if ts is not None:
+                state.last_tool_ts = ts
+            return
+
+        if not task_id or task_id not in self._mission_task_states:
+            return
+        state = self._mission_task_states[task_id]
+
+        if ev_type == "harvested":
+            state.harvested_at = ts or state.harvested_at
+            state.review_status = "queued"
+            detail = event.get("detail") or ""
+            for chunk in detail.split():
+                if chunk.startswith("pr="):
+                    state.pr_url = chunk[3:]
+                    break
+        elif ev_type in ("merged", "auto_merged"):
+            state.merge_status = "merged"
+            # Keep pr_url if previously captured. Detail may include
+            # "attempt=...". No further mutation needed.
+        elif ev_type in ("kickback", "kicked_back", "task_kicked_back"):
+            state.attempts += 1
+            state.builder_worker = None
+            state.last_tool_action = None
+            state.last_tool_target = None
+            state.last_tool_ts = None
+            state.harvested_at = None
+            state.merge_status = "—"
+            state.review_status = "queued"
+            state.review_verdict = None
+            # Drop any stale worker mapping pointing at this task.
+            for w, t in list(self._worker_to_task.items()):
+                if t == task_id:
+                    self._worker_to_task.pop(w, None)
+        elif ev_type == "auto_merge_waiting_ci":
+            state.merge_status = "waiting_ci"
+        elif ev_type == "auto_merge_rebasing":
+            state.merge_status = "rebasing"
+        elif ev_type == "merge_failed":
+            state.merge_status = "failed"
+        elif ev_type in ("review_started", "review_claimed"):
+            state.review_status = "reviewing"
+        elif ev_type in ("review_verdict", "review_pass", "review_passed"):
+            state.review_status = "pass"
+            state.review_verdict = event.get("detail") or "pass"
+        elif ev_type in ("review_needs_changes", "review_failed"):
+            state.review_status = "needs_changes"
+            state.review_verdict = event.get("detail") or "needs_changes"
+
+    @staticmethod
+    def _parse_event_ts(raw: str | None) -> datetime | None:
+        """Parse an ISO timestamp from an SSE event into an aware datetime."""
+        if not raw:
+            return None
+        try:
+            dt = datetime.fromisoformat(raw)
+        except (ValueError, TypeError):
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
+        return dt
+
     def run(self) -> None:
         """Main loop using rich.live.Live."""
         with Live(self._build_display(), refresh_per_second=1) as live:
@@ -235,6 +396,22 @@ class AntfarmTUI:
             missions = self._fetch("/missions")
         except Exception:
             missions = []
+
+        # Mission-scoped mode (#386): seed/refresh per-task state from the
+        # current snapshot, and replace the activity panel with the mission
+        # progress tree. Connection-error and 404 paths short-circuit before
+        # full panel rendering for a clean error message.
+        if self._mission_id is not None:
+            self._refresh_mission_state(missions, tasks, workers)
+            if self._mission_not_found:
+                layout = Layout()
+                layout.update(
+                    Panel(
+                        f"[red]Mission '{self._mission_id}' not found[/red]",
+                        title="Antfarm TUI",
+                    )
+                )
+                return layout
 
         snap = self._classify_tasks(tasks)
         snap.warnings = full.get("warnings", [])
@@ -391,12 +568,20 @@ class AntfarmTUI:
             )
         )
 
-        layout["activity"].update(
-            Panel(
-                self._render_activity(max_rows=20),
-                title="[bold white]Activity[/bold white]",
+        if self._mission_id is not None and self._mission is not None:
+            layout["activity"].update(
+                Panel(
+                    self._render_mission_panel(self._mission, self._mission_task_states),
+                    title=f"[bold white]Mission: {self._mission_id}[/bold white]",
+                )
             )
-        )
+        else:
+            layout["activity"].update(
+                Panel(
+                    self._render_activity(max_rows=20),
+                    title="[bold white]Activity[/bold white]",
+                )
+            )
 
         return layout
 
@@ -406,6 +591,286 @@ class AntfarmTUI:
         r = httpx.get(f"{self.colony_url}{path}", headers=headers, timeout=5)
         r.raise_for_status()
         return r.json()
+
+    # ------------------------------------------------------------------
+    # Mission-scoped panel (#386)
+    # ------------------------------------------------------------------
+
+    def _refresh_mission_state(
+        self,
+        missions: list[dict],
+        tasks: list[dict],
+        workers: list[dict],
+    ) -> None:
+        """Refresh per-task mission state and worker→task map from a snapshot.
+
+        Called once per ``_build_display`` cycle. Three responsibilities:
+
+        1. Locate the targeted mission. If absent on first refresh, set the
+           ``_mission_not_found`` sticky flag so the next render shows an
+           error panel and exits.
+        2. Seed/refresh ``_mission_task_states`` from the task list. New
+           tasks get a fresh ``MissionTaskState``; already-tracked tasks
+           keep event-driven fields (last_tool_*, etc.) but accept derived
+           updates from the snapshot (merge_status, harvested_at, attempts).
+        3. Rebuild ``_worker_to_task`` so that incoming ``worker_activity``
+           events can be attributed to a row.
+        """
+        target = next(
+            (m for m in (missions or []) if m.get("mission_id") == self._mission_id),
+            None,
+        )
+        if target is None and not self._mission_seeded:
+            self._mission_not_found = True
+            return
+        if target is None:
+            return  # transient — keep the last known state
+
+        self._mission = target
+        task_ids = set(target.get("task_ids", []))
+        # Implementation tasks only — plan/review tasks live as infra-tasks
+        # alongside the mission and would clutter the per-task table.
+        task_by_id = {t.get("id", ""): t for t in tasks if t.get("id") in task_ids}
+        impl_tasks = [t for tid, t in task_by_id.items() if not is_infra_task(t)]
+
+        new_states: dict[str, MissionTaskState] = {}
+        new_worker_to_task: dict[str, str] = {}
+        for task in impl_tasks:
+            tid = task.get("id", "")
+            existing = self._mission_task_states.get(tid)
+            state = existing or MissionTaskState(
+                task_id=tid,
+                title=task.get("title", "") or "",
+            )
+            state.title = task.get("title", "") or state.title
+            state.deps = list(task.get("depends_on", []) or [])
+            state.attempts = max(state.attempts, len(task.get("attempts", []) or []) or 1)
+
+            current_id = task.get("current_attempt")
+            current_attempt = None
+            for att in task.get("attempts", []) or []:
+                if att.get("attempt_id") == current_id:
+                    current_attempt = att
+                    break
+
+            if current_attempt is not None:
+                worker_id = current_attempt.get("worker_id") or None
+                if worker_id and task.get("status") == "active":
+                    state.builder_worker = worker_id
+                    new_worker_to_task[worker_id] = tid
+                # Harvested timestamp — use completed_at on done attempts
+                if current_attempt.get("status") in ("done", "merged"):
+                    completed = current_attempt.get("completed_at")
+                    if completed and state.harvested_at is None:
+                        state.harvested_at = self._parse_event_ts(completed)
+                # PR URL backfill — soldier marks branch+pr on harvest
+                if not state.pr_url:
+                    pr = current_attempt.get("pr") or current_attempt.get("pr_url")
+                    if pr:
+                        state.pr_url = pr
+                # Review verdict on the current attempt seeds the panel even
+                # before the live event arrives (e.g. on TUI restart mid-run).
+                rv = current_attempt.get("review_verdict") or {}
+                if isinstance(rv, dict) and rv:
+                    verdict = rv.get("verdict")
+                    if verdict == "pass" and state.review_status == "queued":
+                        state.review_status = "pass"
+                        state.review_verdict = "pass"
+                    elif verdict == "needs_changes" and state.review_status == "queued":
+                        state.review_status = "needs_changes"
+                        state.review_verdict = rv.get("reason") or "needs_changes"
+                # Merge status — derived from attempt status for snapshot
+                # seeding only. Live events authoritative once stream attaches.
+                if current_attempt.get("status") == "merged":
+                    state.merge_status = "merged"
+
+            new_states[tid] = state
+
+        self._mission_task_states = new_states
+        # Filter the worker map to currently-active claims (drop stale).
+        # Workers with no active assignment are simply absent from the map.
+        live_worker_ids = {w.get("worker_id") for w in (workers or []) if w.get("worker_id")}
+        self._worker_to_task = {
+            w: t for w, t in new_worker_to_task.items() if w in live_worker_ids or not workers
+        }
+        self._mission_seeded = True
+
+    def _render_mission_panel(
+        self,
+        mission: dict,
+        task_states: dict[str, MissionTaskState],
+        now: datetime | None = None,
+    ) -> Table:
+        """Render the per-task mission progress tree.
+
+        Columns: ID | Builder + current activity | Build | Review | Merge.
+        The Builder column folds together the worker_id, the most recent
+        tool action+target, and elapsed seconds since that action started.
+        Build column shows ``done`` once harvested, otherwise ``in flight``
+        or ``queued (deps: …)``. Review column maps from the
+        ``MissionTaskState.review_status`` enum to a human glyph. Merge
+        column maps the merge_status enum likewise.
+        """
+        table = Table(
+            show_header=True,
+            header_style="bold",
+            box=None,
+            padding=(0, 1),
+            title=self._mission_panel_title(mission, task_states),
+            title_justify="left",
+        )
+        table.add_column("ID", max_width=12, no_wrap=True)
+        table.add_column("Builder", max_width=40, no_wrap=True)
+        table.add_column("Build", max_width=18, no_wrap=True)
+        table.add_column("Review", max_width=16, no_wrap=True)
+        table.add_column("Merge", max_width=22, no_wrap=True)
+
+        if not task_states:
+            table.add_row(
+                Text("--", style="dim"),
+                Text("no tasks yet — mission may still be planning", style="dim"),
+                Text(""),
+                Text(""),
+                Text(""),
+            )
+            return table
+
+        ordered = sorted(task_states.values(), key=lambda s: s.task_id)
+        merged_ids = {s.task_id for s in ordered if s.merge_status == "merged"}
+        for state in ordered:
+            table.add_row(
+                Text(state.task_id[:10], style="bold"),
+                self._render_builder_cell(state, now=now),
+                self._render_build_cell(state, merged_ids),
+                self._render_review_cell(state),
+                self._render_merge_cell(state),
+            )
+        return table
+
+    def _mission_panel_title(
+        self,
+        mission: dict,
+        task_states: dict[str, MissionTaskState],
+    ) -> str:
+        """Build a one-line header for the mission panel.
+
+        Format: ``Mission: <id>     Status: <status>     Tasks: M/N merged``.
+        ``M`` counts ``MissionTaskState.merge_status == "merged"`` so the
+        number tracks the live event stream rather than the lagging report.
+        """
+        mid = mission.get("mission_id", self._mission_id or "")
+        mstatus = mission.get("status", "")
+        total = len(task_states)
+        merged = sum(1 for s in task_states.values() if s.merge_status == "merged")
+        return f"Mission: {mid}     Status: {mstatus}     Tasks: {merged}/{total} merged"
+
+    def _render_builder_cell(
+        self,
+        state: MissionTaskState,
+        now: datetime | None = None,
+    ) -> Text:
+        """Render ``worker (now: <action> <target> <elapsed>)`` or em-dash."""
+        if not state.builder_worker:
+            return Text("—", style="dim")
+        text = Text()
+        text.append(state.builder_worker, style=self._color_for_worker(state.builder_worker))
+        if state.last_tool_action:
+            current = now or datetime.now(UTC)
+            elapsed_str = ""
+            if state.last_tool_ts is not None:
+                secs = max(0, int((current - state.last_tool_ts).total_seconds()))
+                if secs < 60:
+                    elapsed_str = f"{secs}s"
+                elif secs < 3600:
+                    mins, rem = divmod(secs, 60)
+                    elapsed_str = f"{mins}m{rem}s"
+                else:
+                    hrs, rem = divmod(secs, 3600)
+                    elapsed_str = f"{hrs}h{rem // 60}m"
+            target = state.last_tool_target or ""
+            label = state.last_tool_action
+            if target:
+                label = f"{label} {target}"
+            label = label[:24]
+            suffix = f" (now: {label}"
+            if elapsed_str:
+                suffix += f" {elapsed_str}"
+            suffix += ")"
+            text.append(suffix, style="dim")
+        return text
+
+    def _render_build_cell(
+        self,
+        state: MissionTaskState,
+        merged_ids: set[str],
+    ) -> Text:
+        """Render Build column glyph for a single task row."""
+        if state.harvested_at is not None or state.merge_status == "merged":
+            return Text("✓ done", style="green")
+        if state.builder_worker is not None:
+            return Text("in flight", style="yellow")
+        # No builder yet — distinguish "blocked on deps" from "ready to claim".
+        unmet = [d for d in state.deps if d not in merged_ids]
+        if unmet:
+            short = ", ".join(d.split("-")[-1] for d in unmet[:2])
+            if len(unmet) > 2:
+                short += "+"
+            return Text(f"queued (deps: {short})", style="dim")
+        return Text("queued", style="dim")
+
+    def _render_review_cell(self, state: MissionTaskState) -> Text:
+        """Map ``review_status`` to a glyph + style for the Review column."""
+        if state.review_status == "pass":
+            return Text("✓ pass", style="green")
+        if state.review_status == "needs_changes":
+            label = state.review_verdict or "needs_changes"
+            if len(label) > 14:
+                label = label[:11] + "…"
+            return Text(label, style="red")
+        if state.review_status == "reviewing":
+            return Text("in flight", style="yellow")
+        # queued — show em-dash if there's nothing to review yet, "queued"
+        # once the task is harvested.
+        if state.harvested_at is not None:
+            return Text("queued", style="dim")
+        return Text("—", style="dim")
+
+    def _render_merge_cell(self, state: MissionTaskState) -> Text:
+        """Map ``merge_status`` to a glyph + style for the Merge column."""
+        if state.merge_status == "merged":
+            pr = state.pr_url or ""
+            label = "✓ merged"
+            if pr:
+                label += f" → {self._format_pr(pr)}"
+            return Text(label, style="green")
+        if state.merge_status == "waiting_ci":
+            return Text("waiting CI", style="yellow")
+        if state.merge_status == "rebasing":
+            return Text("rebasing", style="yellow")
+        if state.merge_status == "failed":
+            return Text("failed", style="red")
+        return Text("—", style="dim")
+
+    @staticmethod
+    def _format_pr(pr: str) -> str:
+        """Compress a PR URL into ``PR#<n>`` when possible.
+
+        Accepts either a bare number, a ``#123`` form, or a full GitHub URL
+        ending in ``/pull/<n>``. Falls back to the raw input when the number
+        can't be extracted.
+        """
+        if not pr:
+            return ""
+        s = pr.strip()
+        if s.startswith("#"):
+            return f"PR{s}"
+        if s.isdigit():
+            return f"PR#{s}"
+        if "/pull/" in s:
+            tail = s.rsplit("/pull/", 1)[-1].split("/")[0].split("?")[0]
+            if tail.isdigit():
+                return f"PR#{tail}"
+        return s[:18]
 
     # ------------------------------------------------------------------
     # Classification
@@ -1149,8 +1614,7 @@ class AntfarmTUI:
             # OR when the actor isn't a known subsystem (heuristic - covers
             # legacy events that pre-date the worker_activity type).
             actor_is_worker = (
-                event_type_raw == "worker_activity"
-                or actor_raw not in self._NON_WORKER_ACTORS
+                event_type_raw == "worker_activity" or actor_raw not in self._NON_WORKER_ACTORS
             )
 
             # Row-level style for special event kinds - overrides actor color

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -522,6 +522,80 @@ def test_scout_oneshot_unchanged():
         mock_get.assert_called_once()
 
 
+def test_scout_tui_mission_flag():
+    """`scout --tui --mission abc` constructs the TUI with mission_id='abc'."""
+    runner = CliRunner()
+
+    captured: dict = {}
+
+    def _fake_init(self, **kwargs):  # type: ignore[no-redef]
+        captured.update(kwargs)
+        # Stash a sentinel so .run() is a no-op.
+        self._stub = True
+
+    def _fake_run(self):  # type: ignore[no-redef]
+        return None
+
+    with (
+        patch("antfarm.core.cli.httpx.get") as mock_get,
+        patch("antfarm.core.tui.AntfarmTUI.__init__", _fake_init),
+        patch("antfarm.core.tui.AntfarmTUI.run", _fake_run),
+    ):
+        ok = MagicMock()
+        ok.status_code = 200
+        ok.json.return_value = {"mission_id": "abc"}
+        mock_get.return_value = ok
+
+        result = runner.invoke(
+            main,
+            [
+                "scout",
+                "--tui",
+                "--mission",
+                "abc",
+                "--colony-url",
+                "http://localhost:7433",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert captured.get("mission_id") == "abc"
+    assert captured.get("colony_url") == "http://localhost:7433"
+
+
+def test_scout_tui_mission_unknown_id():
+    """`scout --tui --mission unknown` exits non-zero with a clear message."""
+    runner = CliRunner()
+
+    not_found = MagicMock()
+    not_found.status_code = 404
+    not_found.json.return_value = {"detail": "Mission 'unknown' not found"}
+
+    with (
+        patch("antfarm.core.cli.httpx.get", return_value=not_found),
+        patch("antfarm.core.tui.AntfarmTUI") as mock_tui,
+    ):
+        result = runner.invoke(
+            main,
+            [
+                "scout",
+                "--tui",
+                "--mission",
+                "unknown",
+                "--colony-url",
+                "http://localhost:7433",
+            ],
+        )
+
+    assert result.exit_code != 0
+    # Either stderr or output, depending on Click version
+    combined = (result.output or "") + (getattr(result, "stderr_bytes", b"") or b"").decode(
+        "utf-8", errors="replace"
+    )
+    assert "not found" in combined or "unknown" in combined
+    mock_tui.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # doctor
 # ---------------------------------------------------------------------------

--- a/tests/test_tui_mission.py
+++ b/tests/test_tui_mission.py
@@ -1,0 +1,522 @@
+"""Tests for the mission-scoped TUI panel (#386).
+
+Exercises ``AntfarmTUI._update_mission_state``,
+``_refresh_mission_state``, and ``_render_mission_panel`` in isolation —
+no live colony, no SSE stream. State is shaped via direct calls to
+``_ingest_event`` and the seeding helper.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from rich.table import Table
+
+from antfarm.core.tui import AntfarmTUI, MissionTaskState
+
+
+def _tui_with_mission(mission_id: str = "m1") -> AntfarmTUI:
+    """Return a TUI instance pinned to a mission, no SSE thread, no fetches."""
+    return AntfarmTUI(
+        colony_url="http://localhost:7433",
+        token=None,
+        autostart_activity=False,
+        mission_id=mission_id,
+    )
+
+
+def _seed_state(
+    tui: AntfarmTUI,
+    task_id: str = "task-01",
+    title: str = "Test task",
+    deps: list[str] | None = None,
+) -> MissionTaskState:
+    state = MissionTaskState(task_id=task_id, title=title, deps=deps or [])
+    tui._mission_task_states[task_id] = state
+    return state
+
+
+# ---------------------------------------------------------------------------
+# State updates
+# ---------------------------------------------------------------------------
+
+
+def test_state_record_updates_on_worker_activity():
+    """worker_activity event flips builder + last_tool_* fields on the row."""
+    tui = _tui_with_mission()
+    _seed_state(tui, "task-01")
+    tui._worker_to_task["worker-3"] = "task-01"
+
+    tui._ingest_event(
+        {
+            "id": 1,
+            "type": "worker_activity",
+            "actor": "worker-3",
+            "task_id": "",
+            "detail": "editing src/foo.py",
+            "data": {"action": "editing", "target": "src/foo.py", "text": "editing src/foo.py"},
+            "ts": "2026-04-22T12:00:00+00:00",
+        }
+    )
+    s = tui._mission_task_states["task-01"]
+    assert s.builder_worker == "worker-3"
+    assert s.last_tool_action == "editing"
+    assert s.last_tool_target == "src/foo.py"
+    assert s.last_tool_ts is not None
+    assert s.last_tool_ts.tzinfo is not None
+
+
+def test_state_record_updates_on_harvested():
+    """harvested event sets harvested_at + pr_url and resets review_status."""
+    tui = _tui_with_mission()
+    _seed_state(tui, "task-01")
+
+    tui._ingest_event(
+        {
+            "id": 2,
+            "type": "harvested",
+            "actor": "worker-3",
+            "task_id": "task-01",
+            "detail": "pr=https://github.com/o/r/pull/42 branch=feat/x",
+            "ts": "2026-04-22T12:05:00+00:00",
+        }
+    )
+    s = tui._mission_task_states["task-01"]
+    assert s.harvested_at is not None
+    assert s.pr_url == "https://github.com/o/r/pull/42"
+    assert s.review_status == "queued"
+
+
+def test_state_record_updates_on_auto_merged():
+    """auto_merged event flips merge_status to 'merged'."""
+    tui = _tui_with_mission()
+    _seed_state(tui, "task-01")
+
+    tui._ingest_event(
+        {
+            "id": 3,
+            "type": "auto_merged",
+            "actor": "soldier",
+            "task_id": "task-01",
+            "detail": "attempt=att-001 auto_merged=1",
+            "ts": "2026-04-22T12:10:00+00:00",
+        }
+    )
+    s = tui._mission_task_states["task-01"]
+    assert s.merge_status == "merged"
+
+
+def test_state_record_updates_on_merged():
+    """merged event flips merge_status to 'merged' (manual merge path)."""
+    tui = _tui_with_mission()
+    _seed_state(tui, "task-01")
+    tui._ingest_event(
+        {
+            "id": 4,
+            "type": "merged",
+            "actor": "soldier",
+            "task_id": "task-01",
+            "detail": "attempt=att-001",
+            "ts": "2026-04-22T12:11:00+00:00",
+        }
+    )
+    assert tui._mission_task_states["task-01"].merge_status == "merged"
+
+
+def test_state_record_updates_on_kickback():
+    """kickback bumps attempts and clears builder/last_tool/harvest fields."""
+    tui = _tui_with_mission()
+    s = _seed_state(tui, "task-01")
+    s.builder_worker = "worker-3"
+    s.last_tool_action = "editing"
+    s.last_tool_target = "src/foo.py"
+    s.harvested_at = datetime.now(UTC)
+    s.merge_status = "merged"
+    s.review_status = "pass"
+    tui._worker_to_task["worker-3"] = "task-01"
+
+    tui._ingest_event(
+        {
+            "id": 5,
+            "type": "kickback",
+            "actor": "soldier",
+            "task_id": "task-01",
+            "detail": "review:needs_changes",
+            "ts": "2026-04-22T12:15:00+00:00",
+        }
+    )
+    s = tui._mission_task_states["task-01"]
+    assert s.attempts == 2
+    assert s.builder_worker is None
+    assert s.last_tool_action is None
+    assert s.last_tool_target is None
+    assert s.last_tool_ts is None
+    assert s.harvested_at is None
+    assert s.merge_status == "—"
+    assert s.review_status == "queued"
+    assert "worker-3" not in tui._worker_to_task
+
+
+def test_state_record_updates_on_auto_merge_waiting_ci():
+    tui = _tui_with_mission()
+    _seed_state(tui, "task-01")
+    tui._ingest_event(
+        {
+            "id": 6,
+            "type": "auto_merge_waiting_ci",
+            "actor": "soldier",
+            "task_id": "task-01",
+            "detail": "pr=42",
+            "ts": "2026-04-22T12:20:00+00:00",
+        }
+    )
+    assert tui._mission_task_states["task-01"].merge_status == "waiting_ci"
+
+
+def test_state_record_updates_on_auto_merge_rebasing():
+    tui = _tui_with_mission()
+    _seed_state(tui, "task-01")
+    tui._ingest_event(
+        {
+            "id": 7,
+            "type": "auto_merge_rebasing",
+            "actor": "soldier",
+            "task_id": "task-01",
+            "detail": "pr=42",
+            "ts": "2026-04-22T12:21:00+00:00",
+        }
+    )
+    assert tui._mission_task_states["task-01"].merge_status == "rebasing"
+
+
+def test_state_record_updates_on_merge_failed():
+    tui = _tui_with_mission()
+    _seed_state(tui, "task-01")
+    tui._ingest_event(
+        {
+            "id": 8,
+            "type": "merge_failed",
+            "actor": "soldier",
+            "task_id": "task-01",
+            "detail": "reason=conflict",
+            "ts": "2026-04-22T12:22:00+00:00",
+        }
+    )
+    assert tui._mission_task_states["task-01"].merge_status == "failed"
+
+
+def test_state_record_updates_on_review_verdict_pass():
+    tui = _tui_with_mission()
+    _seed_state(tui, "task-01")
+    tui._ingest_event(
+        {
+            "id": 9,
+            "type": "review_pass",
+            "actor": "reviewer-1",
+            "task_id": "task-01",
+            "detail": "pass",
+            "ts": "2026-04-22T12:23:00+00:00",
+        }
+    )
+    s = tui._mission_task_states["task-01"]
+    assert s.review_status == "pass"
+    assert s.review_verdict == "pass"
+
+
+def test_state_record_updates_on_review_needs_changes():
+    tui = _tui_with_mission()
+    _seed_state(tui, "task-01")
+    tui._ingest_event(
+        {
+            "id": 10,
+            "type": "review_needs_changes",
+            "actor": "reviewer-1",
+            "task_id": "task-01",
+            "detail": "missing tests",
+            "ts": "2026-04-22T12:24:00+00:00",
+        }
+    )
+    s = tui._mission_task_states["task-01"]
+    assert s.review_status == "needs_changes"
+    assert s.review_verdict == "missing tests"
+
+
+def test_state_ignores_events_outside_mission():
+    """A task_id not present in the mission's state map is dropped."""
+    tui = _tui_with_mission()
+    _seed_state(tui, "task-01")
+    tui._ingest_event(
+        {
+            "id": 11,
+            "type": "merged",
+            "actor": "soldier",
+            "task_id": "task-99",
+            "detail": "attempt=att-001",
+            "ts": "2026-04-22T12:25:00+00:00",
+        }
+    )
+    assert tui._mission_task_states["task-01"].merge_status == "—"
+
+
+def test_state_ingest_skipped_when_no_mission_id():
+    """When mission_id is None the per-task ingest is a no-op."""
+    tui = AntfarmTUI(
+        colony_url="http://localhost:7433",
+        token=None,
+        autostart_activity=False,
+    )
+    # Even if we plant some state by hand, the code path should never read it.
+    tui._mission_task_states["task-01"] = MissionTaskState(task_id="task-01", title="x")
+    tui._ingest_event(
+        {
+            "id": 1,
+            "type": "merged",
+            "actor": "soldier",
+            "task_id": "task-01",
+            "detail": "attempt=att-001",
+            "ts": "2026-04-22T12:00:00+00:00",
+        }
+    )
+    # mission_id is None → state untouched.
+    assert tui._mission_task_states["task-01"].merge_status == "—"
+
+
+# ---------------------------------------------------------------------------
+# Render
+# ---------------------------------------------------------------------------
+
+
+def _row_strings(table: Table) -> list[list[str]]:
+    """Return rendered cells per row as plain strings (one per column)."""
+    rows: list[list[str]] = []
+    n_rows = len(table.rows)
+    for i in range(n_rows):
+        row_cells: list[str] = []
+        for col in table.columns:
+            cell = col._cells[i]  # type: ignore[attr-defined]
+            row_cells.append(cell.plain if hasattr(cell, "plain") else str(cell))
+        rows.append(row_cells)
+    return rows
+
+
+def test_render_mission_panel_renders_active_task():
+    """Active task row shows builder + tool action with elapsed seconds."""
+    tui = _tui_with_mission()
+    s = MissionTaskState(task_id="task-02", title="Edit foo")
+    s.builder_worker = "worker-4"
+    s.last_tool_action = "editing"
+    s.last_tool_target = "src/foo.py"
+    s.last_tool_ts = datetime(2026, 4, 22, 12, 0, 0, tzinfo=UTC)
+    tui._mission_task_states["task-02"] = s
+
+    mission = {"mission_id": "m1", "status": "building"}
+    table = tui._render_mission_panel(
+        mission,
+        tui._mission_task_states,
+        now=datetime(2026, 4, 22, 12, 4, 12, tzinfo=UTC),
+    )
+    rows = _row_strings(table)
+    assert any("task-02" in r[0] for r in rows)
+    builder_cell = next(r[1] for r in rows if "task-02" in r[0])
+    assert "worker-4" in builder_cell
+    assert "editing" in builder_cell
+    assert "src/foo.py" in builder_cell
+    assert "4m12s" in builder_cell
+    build_cell = next(r[2] for r in rows if "task-02" in r[0])
+    assert "in flight" in build_cell
+
+
+def test_render_mission_panel_renders_completed_task():
+    """Merged task row shows ✓ done in build column and ✓ merged + PR# in merge column."""
+    tui = _tui_with_mission()
+    s = MissionTaskState(task_id="task-01", title="Done task")
+    s.builder_worker = "worker-3"
+    s.harvested_at = datetime(2026, 4, 22, 11, 50, 0, tzinfo=UTC)
+    s.review_status = "pass"
+    s.merge_status = "merged"
+    s.pr_url = "https://github.com/o/r/pull/3"
+    tui._mission_task_states["task-01"] = s
+
+    mission = {"mission_id": "m1", "status": "building"}
+    table = tui._render_mission_panel(mission, tui._mission_task_states)
+    rows = _row_strings(table)
+    row = next(r for r in rows if "task-01" in r[0])
+    assert "✓ done" in row[2]
+    assert "✓ pass" in row[3]
+    assert "merged" in row[4]
+    assert "PR#3" in row[4]
+
+
+def test_render_mission_panel_renders_blocked_task():
+    """Task with unmet deps shows queued (deps: …) in build column."""
+    tui = _tui_with_mission()
+    s = MissionTaskState(task_id="task-03", title="Blocked", deps=["task-02"])
+    tui._mission_task_states["task-03"] = s
+    # Note: task-02 not present -> dep not satisfied.
+
+    mission = {"mission_id": "m1", "status": "building"}
+    table = tui._render_mission_panel(mission, tui._mission_task_states)
+    rows = _row_strings(table)
+    row = next(r for r in rows if "task-03" in r[0])
+    assert "—" in row[1]
+    assert "queued" in row[2]
+    assert "deps" in row[2]
+    assert "—" in row[3]
+    assert "—" in row[4]
+
+
+def test_render_mission_panel_handles_missing_mission(monkeypatch):
+    """Mission id not in /missions list -> _build_display short-circuits."""
+    tui = _tui_with_mission(mission_id="missing-1")
+
+    def _fake_fetch(path):
+        if path == "/status/full":
+            return {
+                "status": {"nodes": 0},
+                "tasks": [],
+                "workers": [],
+                "soldier": "idle",
+            }
+        if path == "/missions":
+            return []
+        return {}
+
+    monkeypatch.setattr(tui, "_fetch", _fake_fetch)
+    tui._build_display()
+    # Cheap fingerprint: ensure we hit the not-found path. The layout's
+    # repr embeds the panel's inner Text object.
+    assert tui._mission_not_found is True
+
+
+def test_render_mission_panel_title_includes_progress():
+    """Panel title shows Mission/Status/Tasks header line."""
+    tui = _tui_with_mission()
+    s1 = MissionTaskState(task_id="task-01", title="A", merge_status="merged")
+    s2 = MissionTaskState(task_id="task-02", title="B")
+    tui._mission_task_states = {"task-01": s1, "task-02": s2}
+    mission = {"mission_id": "m1", "status": "building"}
+    title = tui._mission_panel_title(mission, tui._mission_task_states)
+    assert "Mission: m1" in title
+    assert "Status: building" in title
+    assert "Tasks: 1/2 merged" in title
+
+
+def test_format_pr_extracts_number():
+    assert AntfarmTUI._format_pr("https://github.com/o/r/pull/42") == "PR#42"
+    assert AntfarmTUI._format_pr("#42") == "PR#42"
+    assert AntfarmTUI._format_pr("42") == "PR#42"
+    assert AntfarmTUI._format_pr("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Seeding
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_mission_state_seeds_from_snapshot():
+    """First refresh populates state from /missions + /tasks."""
+    tui = _tui_with_mission(mission_id="m1")
+    missions = [
+        {
+            "mission_id": "m1",
+            "status": "building",
+            "task_ids": ["task-01", "task-02", "review-001"],
+        }
+    ]
+    tasks = [
+        {
+            "id": "task-01",
+            "title": "First",
+            "status": "active",
+            "current_attempt": "att-001",
+            "attempts": [
+                {
+                    "attempt_id": "att-001",
+                    "worker_id": "worker-3",
+                    "status": "active",
+                    "started_at": "2026-04-22T11:00:00+00:00",
+                    "completed_at": None,
+                }
+            ],
+            "depends_on": [],
+            "capabilities_required": [],
+        },
+        {
+            "id": "task-02",
+            "title": "Second",
+            "status": "ready",
+            "current_attempt": None,
+            "attempts": [],
+            "depends_on": ["task-01"],
+            "capabilities_required": [],
+        },
+        {
+            "id": "review-001",
+            "title": "Review",
+            "status": "active",
+            "capabilities_required": ["review"],
+            "attempts": [],
+            "current_attempt": None,
+            "depends_on": [],
+        },
+    ]
+    workers = [{"worker_id": "worker-3"}]
+
+    tui._refresh_mission_state(missions, tasks, workers)
+    assert "task-01" in tui._mission_task_states
+    assert "task-02" in tui._mission_task_states
+    # review-001 is infra and excluded from the impl-task panel
+    assert "review-001" not in tui._mission_task_states
+    assert tui._mission_task_states["task-01"].builder_worker == "worker-3"
+    assert tui._worker_to_task["worker-3"] == "task-01"
+    assert tui._mission_seeded is True
+
+
+def test_refresh_mission_state_marks_not_found():
+    """No matching mission on first refresh sets the sticky not-found flag."""
+    tui = _tui_with_mission(mission_id="nope")
+    tui._refresh_mission_state(missions=[], tasks=[], workers=[])
+    assert tui._mission_not_found is True
+
+
+def test_refresh_mission_state_preserves_event_state():
+    """Re-seeding does not clobber event-driven last_tool_* fields."""
+    tui = _tui_with_mission(mission_id="m1")
+    # First seed
+    missions = [{"mission_id": "m1", "status": "building", "task_ids": ["task-01"]}]
+    tasks = [
+        {
+            "id": "task-01",
+            "title": "x",
+            "status": "active",
+            "current_attempt": "att-001",
+            "attempts": [
+                {
+                    "attempt_id": "att-001",
+                    "worker_id": "worker-3",
+                    "status": "active",
+                    "started_at": "2026-04-22T11:00:00+00:00",
+                }
+            ],
+            "depends_on": [],
+            "capabilities_required": [],
+        }
+    ]
+    tui._refresh_mission_state(missions, tasks, [{"worker_id": "worker-3"}])
+    # Event injects extra detail
+    tui._ingest_event(
+        {
+            "id": 1,
+            "type": "worker_activity",
+            "actor": "worker-3",
+            "task_id": "",
+            "detail": "editing src/foo.py",
+            "data": {"action": "editing", "target": "src/foo.py"},
+            "ts": "2026-04-22T11:05:00+00:00",
+        }
+    )
+    # Re-seed should preserve the live action info.
+    tui._refresh_mission_state(missions, tasks, [{"worker_id": "worker-3"}])
+    s = tui._mission_task_states["task-01"]
+    assert s.last_tool_action == "editing"
+    assert s.last_tool_target == "src/foo.py"


### PR DESCRIPTION
## Summary
- New ``scout --tui --mission <id>`` mode replaces the global activity feed with a per-task progress tree (id | builder + current activity | review | merge) — directly answers "where is mission X right now, task by task" (#386).
- Adds ``MissionTaskState`` and event-driven state tracking on ``AntfarmTUI`` so rows update live from worker_activity, harvested, merged/auto_merged, kickback, auto_merge_waiting_ci/rebasing, merge_failed, and review verdict events.
- CLI pre-flights ``--mission`` against ``GET /missions/<id>`` so an unknown id exits cleanly with "Mission '<id>' not found" instead of dropping the user into an empty TUI.

## Test plan
- [x] ``pytest tests/ -x -q`` — 1569 passed (1 pre-existing tmux test deselected; unrelated)
- [x] ``ruff check .`` — clean
- [x] New ``tests/test_tui_mission.py`` covers state updates per event type, render of active/completed/blocked rows, and the missing-mission path
- [x] New CLI tests cover ``scout --tui --mission abc`` and ``scout --tui --mission unknown``

## Related
Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)