### PR TITLE
fix(tests,process_manager): hermetic adopt_existing test via prefix filter (Closes #389)

### DIFF
--- a/antfarm/core/process_manager.py
+++ b/antfarm/core/process_manager.py
@@ -309,7 +309,7 @@ class ProcessManager(ABC):
         """List names of all managed processes matching this manager's prefix."""
         ...
 
-    def adopt_existing(self) -> dict[str, str]:
+    def adopt_existing(self, prefix: str | None = None) -> dict[str, str]:
         """Discover and return existing processes from a previous run.
 
         Uses TWO sources for discovery:
@@ -325,8 +325,18 @@ class ProcessManager(ABC):
           SubprocessProcessManager, which overrides this method to
           return {} anyway — see that class for rationale)
 
+        Args:
+            prefix: Optional name prefix to filter on. When set, only
+                sessions/metadata whose ``name`` starts with this prefix
+                are considered. When ``None`` (default), the manager's
+                own ``self.prefix`` is used — preserving backward
+                compatibility for callers that don't need hermetic
+                scoping. Pass an explicit, narrower prefix (e.g. a
+                uuid-scoped one) to ignore unrelated host state.
+
         Returns: {name: role} for each adopted process.
         """
+        effective_prefix = prefix if prefix is not None else self.prefix
         adopted: dict[str, str] = {}
         seen: set[str] = set()
         my_type = self._manager_type()
@@ -334,7 +344,7 @@ class ProcessManager(ABC):
         # 1. Metadata file adoption — FILTERED BY MANAGER TYPE.
         #    A tmux manager must not trust subprocess metadata, and vice versa.
         for meta in self._list_metadata():
-            if not meta.name.startswith(self.prefix):
+            if not meta.name.startswith(effective_prefix):
                 continue
             if meta.manager_type != my_type:
                 continue  # foreign metadata — ignore (subclass may sweep it)
@@ -348,10 +358,12 @@ class ProcessManager(ABC):
         for name in self.list_managed():
             if name in seen:
                 continue
+            if not name.startswith(effective_prefix):
+                continue
             if not self.is_alive(name):
                 self.cleanup(name)
                 continue
-            parsed = parse_session_name(name, self.prefix)
+            parsed = parse_session_name(name, effective_prefix)
             if parsed:
                 adopted[name] = parsed[0]
                 # Write metadata retroactively so next adoption finds it
@@ -382,17 +394,28 @@ class ProcessManager(ABC):
         """Return 'tmux' or 'subprocess'."""
         ...
 
-    def max_counter(self) -> int:
+    def max_counter(self, prefix: str | None = None) -> int:
         """Return the highest counter value among managed processes.
 
         Checks both live sessions and metadata files.
+
+        Args:
+            prefix: Optional name prefix to filter on. When set, only
+                sessions/metadata whose ``name`` starts with this prefix
+                are considered. When ``None`` (default), the manager's
+                own ``self.prefix`` is used — preserving backward
+                compatibility. Use a uuid-scoped prefix to avoid leaking
+                unrelated host state into the result.
         """
+        effective_prefix = prefix if prefix is not None else self.prefix
         max_n = 0
         all_names = set(self.list_managed())
         for meta in self._list_metadata():
             all_names.add(meta.name)
         for name in all_names:
-            parsed = parse_session_name(name, self.prefix)
+            if not name.startswith(effective_prefix):
+                continue
+            parsed = parse_session_name(name, effective_prefix)
             if parsed:
                 max_n = max(max_n, parsed[1])
         return max_n
@@ -514,7 +537,7 @@ class SubprocessProcessManager(ProcessManager):
         logger.info("started subprocess: %s pid=%d", name, process.pid)
         return True
 
-    def adopt_existing(self) -> dict[str, str]:
+    def adopt_existing(self, prefix: str | None = None) -> dict[str, str]:
         """Subprocess backend does NOT support restart adoption.
 
         Rationale:
@@ -526,10 +549,17 @@ class SubprocessProcessManager(ProcessManager):
         Behavior: scan subprocess metadata files left by prior runs and
         remove them (best-effort cleanup), then return empty. Callers
         that need restart recovery must use TmuxProcessManager.
+
+        Args:
+            prefix: Optional name prefix to filter on. Maintained for
+                signature parity with the base class (and tmux backend);
+                only metadata whose ``name`` starts with this prefix is
+                swept. Defaults to ``self.prefix``.
         """
+        effective_prefix = prefix if prefix is not None else self.prefix
         removed = 0
         for meta in self._list_metadata():
-            if not meta.name.startswith(self.prefix):
+            if not meta.name.startswith(effective_prefix):
                 continue
             if meta.manager_type != "subprocess":
                 continue

--- a/tests/test_process_manager.py
+++ b/tests/test_process_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import uuid
 from unittest.mock import patch
 
 import pytest
@@ -218,19 +219,51 @@ def test_tmux_pm_writes_metadata(tmp_path):
 
 @pytest.mark.skipif(not shutil.which("tmux"), reason="tmux not installed")
 def test_tmux_pm_adopt_existing(tmp_path):
+    # Hermetic prefix so the test ignores any leftover ``auto-*`` tmux sessions
+    # already on the host (e.g. from a prior antfarm mission). Without this
+    # filter ``max_counter`` would parse all sessions matching the manager's
+    # default ``auto-`` prefix and the assertion below would be host-dependent.
+    prefix = f"auto-test-{uuid.uuid4().hex[:8]}-"
+    builder_name = f"{prefix}builder-5"
+    reviewer_name = f"{prefix}reviewer-2"
+
     pm = TmuxProcessManager(state_dir=str(tmp_path))
     try:
-        pm.start("auto-builder-5", ["sleep", "60"], role="builder")
-        pm.start("auto-reviewer-2", ["sleep", "60"], role="reviewer")
-        # New manager discovers existing sessions
+        pm.start(builder_name, ["sleep", "60"], role="builder")
+        pm.start(reviewer_name, ["sleep", "60"], role="reviewer")
+        # New manager discovers existing sessions, scoped to this test's prefix.
         pm2 = TmuxProcessManager(state_dir=str(tmp_path))
-        adopted = pm2.adopt_existing()
-        assert "auto-builder-5" in adopted
-        assert adopted["auto-builder-5"] == "builder"
-        assert pm2.max_counter() == 5
+        adopted = pm2.adopt_existing(prefix=prefix)
+        assert builder_name in adopted
+        assert adopted[builder_name] == "builder"
+        assert pm2.max_counter(prefix=prefix) == 5
     finally:
-        pm.stop("auto-builder-5")
-        pm.stop("auto-reviewer-2")
+        pm.stop(builder_name)
+        pm.stop(reviewer_name)
+
+
+@pytest.mark.skipif(not shutil.which("tmux"), reason="tmux not installed")
+def test_tmux_pm_adopt_existing_filters_by_prefix(tmp_path):
+    """Explicit prefix narrows adoption: only matching sessions are adopted."""
+    prefix = f"auto-test-{uuid.uuid4().hex[:8]}-"
+    matching_name = f"{prefix}builder-1"
+    # Use a different uuid-scoped prefix for the non-matching session so we
+    # don't pollute (or collide with) any other test or real colony state.
+    other_prefix = f"auto-test-{uuid.uuid4().hex[:8]}-"
+    non_matching_name = f"{other_prefix}builder-1"
+
+    pm = TmuxProcessManager(state_dir=str(tmp_path))
+    try:
+        pm.start(matching_name, ["sleep", "60"], role="builder")
+        pm.start(non_matching_name, ["sleep", "60"], role="builder")
+
+        pm2 = TmuxProcessManager(state_dir=str(tmp_path))
+        adopted = pm2.adopt_existing(prefix=prefix)
+        assert matching_name in adopted
+        assert non_matching_name not in adopted
+    finally:
+        pm.stop(matching_name)
+        pm.stop(non_matching_name)
 
 
 @pytest.mark.skipif(not shutil.which("tmux"), reason="tmux not installed")


### PR DESCRIPTION
## Summary
- Add optional `prefix: str | None = None` parameter to `ProcessManager.adopt_existing()` and `ProcessManager.max_counter()` (defaults to the manager's own prefix for backward compat). When set, the parsed tmux session list and metadata files are filtered by this prefix BEFORE deriving the adopted dict / max-counter integer. Same parameter is added to `SubprocessProcessManager.adopt_existing()` for signature parity.
- Make `tests/test_process_manager.py::test_tmux_pm_adopt_existing` hermetic by giving each invocation a unique uuid-scoped prefix (`auto-test-{uuid}-`) and passing it to `adopt_existing(prefix=...)` / `max_counter(prefix=...)`. The test now ignores any prior `auto-*` tmux sessions on the host (e.g. from a leaked dogfood mission) instead of folding them into the assertion.
- Add `test_tmux_pm_adopt_existing_filters_by_prefix` to verify the new filter — start one session matching the prefix and one not, assert only the matching one is adopted.

## Test Plan
- [x] `pytest tests/test_process_manager.py -v` — all 20 tests pass (incl. new test).
- [x] Verified hermetic: ran the target test with `auto-leftover-builder-794`, `auto-leftover-reviewer-100`, and a pre-existing `auto-438ddd82-reviewer-1677` tmux session present — passes (the pre-fix flow would have failed `max_counter == 5` and instead returned 1677).
- [x] `pytest tests/ -x -q` — full suite green (1571 passed).
- [x] `ruff check .` — clean.

Closes #389