### PR TITLE
fix(worker,adapter): register Claude Code Stop hook per-worktree (Closes #391)

### DIFF
--- a/antfarm/core/hook_setup.py
+++ b/antfarm/core/hook_setup.py
@@ -1,0 +1,107 @@
+"""Per-worktree Claude Code hook registration.
+
+Claude Code reads hook configuration from `.claude/settings.json` in the
+project (the directory it is invoked in). For per-mission usage telemetry
+(#354) the worker must register the Stop hook before launching `claude`,
+otherwise `stop.sh` never fires and cost tracking is silently broken (#391).
+
+This module performs an idempotent, deep-merging write to the worktree-local
+settings file: existing keys are preserved, the antfarm Stop entry is added
+exactly once, and re-running on the same worktree is a no-op.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def register_stop_hook(workspace: Path | str, hook_script: Path | str) -> None:
+    """Register `hook_script` as a Stop hook in `<workspace>/.claude/settings.json`.
+
+    The file is created if absent. If present, the antfarm Stop hook entry is
+    deep-merged into the existing `hooks.Stop` array, preserving any other
+    user/project-level hooks and unrelated keys. Calling twice with the same
+    arguments is a no-op (idempotent).
+
+    Args:
+        workspace: Absolute path to the git worktree where `claude` will run.
+        hook_script: Absolute path to the executable hook script (e.g. stop.sh).
+    """
+    workspace_path = Path(workspace)
+    hook_command = str(hook_script)
+
+    settings_dir = workspace_path / ".claude"
+    settings_path = settings_dir / "settings.json"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+
+    settings: dict = {}
+    if settings_path.exists():
+        try:
+            with settings_path.open() as fh:
+                settings = json.load(fh) or {}
+        except (json.JSONDecodeError, OSError) as exc:
+            # Corrupt or unreadable settings file. Don't clobber it — log and
+            # bail out so the operator notices via the missing usage telemetry.
+            logger.warning(
+                "could not parse %s (%s); leaving file untouched",
+                settings_path,
+                exc,
+            )
+            return
+
+    if not isinstance(settings, dict):
+        logger.warning(
+            "%s is not a JSON object (got %s); leaving file untouched",
+            settings_path,
+            type(settings).__name__,
+        )
+        return
+
+    hooks = settings.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        logger.warning("%s has non-object 'hooks' key; leaving file untouched", settings_path)
+        return
+
+    stop_matchers = hooks.setdefault("Stop", [])
+    if not isinstance(stop_matchers, list):
+        logger.warning("%s has non-array 'hooks.Stop' key; leaving file untouched", settings_path)
+        return
+
+    # Idempotency: if any existing matcher already references our hook command,
+    # nothing to do.
+    for matcher in stop_matchers:
+        if not isinstance(matcher, dict):
+            continue
+        for hook in matcher.get("hooks", []) or []:
+            if isinstance(hook, dict) and hook.get("command") == hook_command:
+                return
+
+    stop_matchers.append(
+        {
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": hook_command,
+                }
+            ]
+        }
+    )
+
+    with settings_path.open("w") as fh:
+        json.dump(settings, fh, indent=2)
+        fh.write("\n")
+
+
+def stop_hook_path() -> Path:
+    """Return the absolute path to the bundled Claude Code Stop hook script."""
+    return (
+        Path(__file__).resolve().parent.parent
+        / "adapters"
+        / "claude_code"
+        / "hooks"
+        / "stop.sh"
+    )

--- a/antfarm/core/worker.py
+++ b/antfarm/core/worker.py
@@ -869,6 +869,17 @@ class WorkerRuntime:
         # Ensure Claude Code agent definitions exist in the worktree
         self._setup_agent_definitions(workspace)
 
+        # Register the Stop hook so usage telemetry (#354) reaches the colony.
+        # Without this, claude never invokes stop.sh and cost tracking is
+        # silently broken (#391). Only relevant for the claude-code adapter.
+        if self.agent_type == "claude-code":
+            from antfarm.core.hook_setup import register_stop_hook, stop_hook_path
+
+            try:
+                register_stop_hook(workspace, stop_hook_path())
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("failed to register Claude Code Stop hook: %s", exc)
+
         if is_plan:
             prompt = (
                 f"Task: {title}\n\n"

--- a/docs/antfarm/missions/mission-auth-1.md
+++ b/docs/antfarm/missions/mission-auth-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-auth-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T03:50:00.786921+00:00
-**Completed:** 2026-05-07T03:50:00.825916+00:00 (0s)
+**Created:** 2026-05-07T04:02:38.368924+00:00
+**Completed:** 2026-05-07T04:02:38.405237+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -21,8 +21,8 @@
 
 ## Timeline highlights
 
-- 03:50:00  mission created
-- 03:50:00  plan ready
-- 03:50:00  task-auth-01 merged
-- 03:50:00  task-auth-02 merged
-- 03:50:00  mission complete
+- 04:02:38  mission created
+- 04:02:38  plan ready
+- 04:02:38  task-auth-01 merged
+- 04:02:38  task-auth-02 merged
+- 04:02:38  mission complete

--- a/docs/antfarm/missions/mission-auth-1.md
+++ b/docs/antfarm/missions/mission-auth-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-auth-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:02:38.368924+00:00
-**Completed:** 2026-05-07T04:02:38.405237+00:00 (0s)
+**Created:** 2026-05-07T04:02:58.224936+00:00
+**Completed:** 2026-05-07T04:02:58.252869+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -21,8 +21,8 @@
 
 ## Timeline highlights
 
-- 04:02:38  mission created
-- 04:02:38  plan ready
-- 04:02:38  task-auth-01 merged
-- 04:02:38  task-auth-02 merged
-- 04:02:38  mission complete
+- 04:02:58  mission created
+- 04:02:58  plan ready
+- 04:02:58  task-auth-01 merged
+- 04:02:58  task-auth-02 merged
+- 04:02:58  mission complete

--- a/docs/antfarm/missions/mission-blocked-1.md
+++ b/docs/antfarm/missions/mission-blocked-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-blocked-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:02:39.245117+00:00
-**Completed:** 2026-05-07T04:02:39.278075+00:00 (0s)
+**Created:** 2026-05-07T04:02:58.981729+00:00
+**Completed:** 2026-05-07T04:02:59.013305+00:00 (0s)
 **Outcome:** complete (1/2 merged)
 
 ## Plan
@@ -21,10 +21,10 @@
 
 ## Timeline highlights
 
-- 04:02:39  mission created
-- 04:02:39  plan ready
-- 04:02:39  task-blocked-02 merged
-- 04:02:39  task-blocked-01 kicked back (kickback)
-- 04:02:39  task-blocked-01 kicked back (kickback)
-- 04:02:39  task-blocked-01 kicked back (kickback)
-- 04:02:39  mission complete
+- 04:02:58  mission created
+- 04:02:58  plan ready
+- 04:02:59  task-blocked-02 merged
+- 04:02:59  task-blocked-01 kicked back (kickback)
+- 04:02:59  task-blocked-01 kicked back (kickback)
+- 04:02:59  task-blocked-01 kicked back (kickback)
+- 04:02:59  mission complete

--- a/docs/antfarm/missions/mission-blocked-1.md
+++ b/docs/antfarm/missions/mission-blocked-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-blocked-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T03:50:02.626083+00:00
-**Completed:** 2026-05-07T03:50:02.660227+00:00 (0s)
+**Created:** 2026-05-07T04:02:39.245117+00:00
+**Completed:** 2026-05-07T04:02:39.278075+00:00 (0s)
 **Outcome:** complete (1/2 merged)
 
 ## Plan
@@ -21,10 +21,10 @@
 
 ## Timeline highlights
 
-- 03:50:02  mission created
-- 03:50:02  plan ready
-- 03:50:02  task-blocked-02 merged
-- 03:50:02  task-blocked-01 kicked back (kickback)
-- 03:50:02  task-blocked-01 kicked back (kickback)
-- 03:50:02  task-blocked-01 kicked back (kickback)
-- 03:50:02  mission complete
+- 04:02:39  mission created
+- 04:02:39  plan ready
+- 04:02:39  task-blocked-02 merged
+- 04:02:39  task-blocked-01 kicked back (kickback)
+- 04:02:39  task-blocked-01 kicked back (kickback)
+- 04:02:39  task-blocked-01 kicked back (kickback)
+- 04:02:39  mission complete

--- a/docs/antfarm/missions/mission-budget-cancel.md
+++ b/docs/antfarm/missions/mission-budget-cancel.md
@@ -1,8 +1,8 @@
 # Mission: mission-budget-cancel
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T03:50:23.115023+00:00
-**Completed:** 2026-05-07T03:50:23.117047+00:00 (0s)
+**Created:** 2026-05-07T04:03:09.256751+00:00
+**Completed:** 2026-05-07T04:03:09.258774+00:00 (0s)
 **Outcome:** cancelled (0/0 merged)
 
 ## Plan
@@ -20,5 +20,5 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 03:50:23  mission created
-- 03:50:23  mission cancelled
+- 04:03:09  mission created
+- 04:03:09  mission cancelled

--- a/docs/antfarm/missions/mission-replan-1.md
+++ b/docs/antfarm/missions/mission-replan-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-replan-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:02:39.907508+00:00
-**Completed:** 2026-05-07T04:02:39.946050+00:00 (0s)
+**Created:** 2026-05-07T04:02:59.717111+00:00
+**Completed:** 2026-05-07T04:02:59.753252+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -27,8 +27,8 @@ The plan above is the final accepted version. Earlier rejected drafts can be rec
 
 ## Timeline highlights
 
-- 04:02:39  mission created
-- 04:02:39  plan ready
-- 04:02:39  task-replan-01 merged
-- 04:02:39  task-replan-02 merged
-- 04:02:39  mission complete
+- 04:02:59  mission created
+- 04:02:59  plan ready
+- 04:02:59  task-replan-01 merged
+- 04:02:59  task-replan-02 merged
+- 04:02:59  mission complete

--- a/docs/antfarm/missions/mission-replan-1.md
+++ b/docs/antfarm/missions/mission-replan-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-replan-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T03:50:04.049053+00:00
-**Completed:** 2026-05-07T03:50:04.091134+00:00 (0s)
+**Created:** 2026-05-07T04:02:39.907508+00:00
+**Completed:** 2026-05-07T04:02:39.946050+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -27,8 +27,8 @@ The plan above is the final accepted version. Earlier rejected drafts can be rec
 
 ## Timeline highlights
 
-- 03:50:04  mission created
-- 03:50:04  plan ready
-- 03:50:04  task-replan-01 merged
-- 03:50:04  task-replan-02 merged
-- 03:50:04  mission complete
+- 04:02:39  mission created
+- 04:02:39  plan ready
+- 04:02:39  task-replan-01 merged
+- 04:02:39  task-replan-02 merged
+- 04:02:39  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:03:03.001350+00:00
-**Completed:** 2026-05-07T04:03:03.006217+00:00 (0s)
+**Created:** 2026-05-07T04:03:03.555741+00:00
+**Completed:** 2026-05-07T04:03:03.563572+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -14,7 +14,7 @@
 
 ## Re-plans
 
-Re-plan cycles: **1**.
+Re-plan cycles: **2**.
 
 The plan above is the final accepted version. Earlier rejected drafts can be reconstructed from the plan task's attempt history in `.antfarm/tasks/`.
 

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:03:07.309820+00:00
-**Completed:** 2026-05-07T04:03:07.325564+00:00 (0s)
-**Outcome:** complete (1/2 merged)
+**Created:** 2026-05-07T04:03:08.101211+00:00
+**Completed:** 2026-05-07T04:03:08.116062+00:00 (0s)
+**Outcome:** complete (2/2 merged)
 
 ## Plan
 
@@ -16,12 +16,13 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | p | 1 | pass | 0s | — |
-| task-test-02 | — | 0 | blocked | — | blocked |
+| task-test-01 | https://example.com/pr/0 | 1 | pass | 0s | — |
+| task-test-02 | https://example.com/pr/1 | 1 | pass | 0s | — |
 
 ## Timeline highlights
 
-- 04:03:07  mission created
-- 04:03:07  plan ready
-- 04:03:07  task-test-01 merged
-- 04:03:07  mission complete
+- 04:03:08  mission created
+- 04:03:08  plan ready
+- 04:03:08  task-test-01 merged
+- 04:03:08  task-test-02 merged
+- 04:03:08  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:03:06.705450+00:00
-**Completed:** 2026-05-07T04:03:06.720934+00:00 (0s)
-**Outcome:** failed (0/2 merged)
+**Created:** 2026-05-07T04:03:07.309820+00:00
+**Completed:** 2026-05-07T04:03:07.325564+00:00 (0s)
+**Outcome:** complete (1/2 merged)
 
 ## Plan
 
@@ -16,11 +16,12 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | — | 0 | blocked | — | blocked |
+| task-test-01 | p | 1 | pass | 0s | — |
 | task-test-02 | — | 0 | blocked | — | blocked |
 
 ## Timeline highlights
 
-- 04:03:06  mission created
-- 04:03:06  plan ready
-- 04:03:06  mission failed
+- 04:03:07  mission created
+- 04:03:07  plan ready
+- 04:03:07  task-test-01 merged
+- 04:03:07  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:03:05.375815+00:00
-**Completed:** 2026-05-07T04:03:05.392488+00:00 (0s)
-**Outcome:** complete (2/2 merged)
+**Created:** 2026-05-07T04:03:06.019769+00:00
+**Completed:** 2026-05-07T04:03:06.035116+00:00 (0s)
+**Outcome:** complete (1/2 merged)
 
 ## Plan
 
@@ -16,13 +16,13 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | https://github.com/test/pr/0 | 1 | pass | 0s | — |
-| task-test-02 | https://github.com/test/pr/1 | 1 | pass | 0s | — |
+| task-test-01 | p | 1 | pass | 0s | — |
+| task-test-02 | — | 1 | blocked | — | blocked |
 
 ## Timeline highlights
 
-- 04:03:05  mission created
-- 04:03:05  plan ready
-- 04:03:05  task-test-01 merged
-- 04:03:05  task-test-02 merged
-- 04:03:05  mission complete
+- 04:03:06  mission created
+- 04:03:06  plan ready
+- 04:03:06  task-test-01 merged
+- 04:03:06  task-test-02 kicked back (kickback)
+- 04:03:06  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T03:50:21.790996+00:00
-**Completed:** 2026-05-07T03:50:21.792641+00:00 (0s)
+**Created:** 2026-05-07T04:03:01.786110+00:00
+**Completed:** 2026-05-07T04:03:01.787471+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -15,5 +15,5 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 03:50:21  mission created
-- 03:50:21  mission failed
+- 04:03:01  mission created
+- 04:03:01  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:03:04.826328+00:00
-**Completed:** 2026-05-07T04:03:04.828895+00:00 (0s)
-**Outcome:** failed (0/0 merged)
+**Created:** 2026-05-07T04:03:05.375815+00:00
+**Completed:** 2026-05-07T04:03:05.392488+00:00 (0s)
+**Outcome:** complete (2/2 merged)
 
 ## Plan
 
@@ -14,10 +14,15 @@
 
 ## Tasks
 
-_(no implementation tasks)_
+| ID | PR | Attempts | Verdict | Wall | Notes |
+|---|---|---|---|---|---|
+| task-test-01 | https://github.com/test/pr/0 | 1 | pass | 0s | — |
+| task-test-02 | https://github.com/test/pr/1 | 1 | pass | 0s | — |
 
 ## Timeline highlights
 
-- 04:03:04  mission created
-- 04:03:04  plan ready
-- 04:03:04  mission failed
+- 04:03:05  mission created
+- 04:03:05  plan ready
+- 04:03:05  task-test-01 merged
+- 04:03:05  task-test-02 merged
+- 04:03:05  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,13 +1,16 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:03:01.786110+00:00
-**Completed:** 2026-05-07T04:03:01.787471+00:00 (0s)
+**Created:** 2026-05-07T04:03:02.363521+00:00
+**Completed:** 2026-05-07T04:03:02.365988+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
 
-_(no plan artifact recorded)_
+| ID | Title | Deps | Touches | Complexity |
+|---|---|---|---|---|
+| task-01 | Child task 1 | — | api | M |
+| task-02 | Child task 2 | — | api | M |
 
 ## Tasks
 
@@ -15,5 +18,6 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 04:03:01  mission created
-- 04:03:01  mission failed
+- 04:03:02  mission created
+- 04:03:02  plan ready
+- 04:03:02  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:03:06.019769+00:00
-**Completed:** 2026-05-07T04:03:06.035116+00:00 (0s)
-**Outcome:** complete (1/2 merged)
+**Created:** 2026-05-07T04:03:06.705450+00:00
+**Completed:** 2026-05-07T04:03:06.720934+00:00 (0s)
+**Outcome:** failed (0/2 merged)
 
 ## Plan
 
@@ -16,13 +16,11 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | p | 1 | pass | 0s | — |
-| task-test-02 | — | 1 | blocked | — | blocked |
+| task-test-01 | — | 0 | blocked | — | blocked |
+| task-test-02 | — | 0 | blocked | — | blocked |
 
 ## Timeline highlights
 
 - 04:03:06  mission created
 - 04:03:06  plan ready
-- 04:03:06  task-test-01 merged
-- 04:03:06  task-test-02 kicked back (kickback)
-- 04:03:06  mission complete
+- 04:03:06  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:03:02.363521+00:00
-**Completed:** 2026-05-07T04:03:02.365988+00:00 (0s)
+**Created:** 2026-05-07T04:03:03.001350+00:00
+**Completed:** 2026-05-07T04:03:03.006217+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -12,12 +12,18 @@
 | task-01 | Child task 1 | — | api | M |
 | task-02 | Child task 2 | — | api | M |
 
+## Re-plans
+
+Re-plan cycles: **1**.
+
+The plan above is the final accepted version. Earlier rejected drafts can be reconstructed from the plan task's attempt history in `.antfarm/tasks/`.
+
 ## Tasks
 
 _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 04:03:02  mission created
-- 04:03:02  plan ready
-- 04:03:02  mission failed
+- 04:03:03  mission created
+- 04:03:03  plan ready
+- 04:03:03  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,28 +1,19 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:03:08.101211+00:00
-**Completed:** 2026-05-07T04:03:08.116062+00:00 (0s)
-**Outcome:** complete (2/2 merged)
+**Created:** 2026-05-07T04:03:08.655659+00:00
+**Completed:** 2026-05-07T04:03:08.657365+00:00 (0s)
+**Outcome:** failed (0/0 merged)
 
 ## Plan
 
-| ID | Title | Deps | Touches | Complexity |
-|---|---|---|---|---|
-| task-01 | Child task 1 | — | api | M |
-| task-02 | Child task 2 | — | api | M |
+_(no plan artifact recorded)_
 
 ## Tasks
 
-| ID | PR | Attempts | Verdict | Wall | Notes |
-|---|---|---|---|---|---|
-| task-test-01 | https://example.com/pr/0 | 1 | pass | 0s | — |
-| task-test-02 | https://example.com/pr/1 | 1 | pass | 0s | — |
+_(no implementation tasks)_
 
 ## Timeline highlights
 
 - 04:03:08  mission created
-- 04:03:08  plan ready
-- 04:03:08  task-test-01 merged
-- 04:03:08  task-test-02 merged
-- 04:03:08  mission complete
+- 04:03:08  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:03:03.555741+00:00
-**Completed:** 2026-05-07T04:03:03.563572+00:00 (0s)
+**Created:** 2026-05-07T04:03:04.826328+00:00
+**Completed:** 2026-05-07T04:03:04.828895+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -12,18 +12,12 @@
 | task-01 | Child task 1 | — | api | M |
 | task-02 | Child task 2 | — | api | M |
 
-## Re-plans
-
-Re-plan cycles: **2**.
-
-The plan above is the final accepted version. Earlier rejected drafts can be reconstructed from the plan task's attempt history in `.antfarm/tasks/`.
-
 ## Tasks
 
 _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 04:03:03  mission created
-- 04:03:03  plan ready
-- 04:03:03  mission failed
+- 04:03:04  mission created
+- 04:03:04  plan ready
+- 04:03:04  mission failed

--- a/docs/antfarm/missions/mission-zero-cap.md
+++ b/docs/antfarm/missions/mission-zero-cap.md
@@ -1,8 +1,8 @@
 # Mission: mission-zero-cap
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T03:50:12.188808+00:00
-**Completed:** 2026-05-07T03:50:12.191713+00:00 (0s)
+**Created:** 2026-05-07T04:03:04.177252+00:00
+**Completed:** 2026-05-07T04:03:04.180274+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -18,6 +18,6 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 03:50:12  mission created
-- 03:50:12  plan ready
-- 03:50:12  mission failed
+- 04:03:04  mission created
+- 04:03:04  plan ready
+- 04:03:04  mission failed

--- a/tests/test_hook_setup.py
+++ b/tests/test_hook_setup.py
@@ -1,0 +1,148 @@
+"""Tests for antfarm.core.hook_setup.
+
+Covers per-worktree Claude Code Stop hook registration:
+- fresh write when no settings.json exists
+- deep merge that preserves existing settings
+- idempotent re-registration
+"""
+
+from __future__ import annotations
+
+import json
+
+from antfarm.core.hook_setup import register_stop_hook, stop_hook_path
+
+
+def test_register_stop_hook_writes_fresh_settings(tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    hook = tmp_path / "stop.sh"
+    hook.write_text("#!/bin/sh\nexit 0\n")
+
+    register_stop_hook(workspace, hook)
+
+    settings_path = workspace / ".claude" / "settings.json"
+    assert settings_path.exists()
+    data = json.loads(settings_path.read_text())
+    stop = data["hooks"]["Stop"]
+    assert isinstance(stop, list)
+    assert len(stop) == 1
+    assert stop[0]["hooks"][0]["type"] == "command"
+    assert stop[0]["hooks"][0]["command"] == str(hook)
+
+
+def test_register_stop_hook_merges_existing_settings(tmp_path):
+    workspace = tmp_path / "ws"
+    settings_dir = workspace / ".claude"
+    settings_dir.mkdir(parents=True)
+    settings_path = settings_dir / "settings.json"
+
+    existing = {
+        "permissions": {"allow": ["Bash(npm test)"]},
+        "hooks": {
+            "PostToolUse": [
+                {"hooks": [{"type": "command", "command": "/some/other/hook.sh"}]}
+            ]
+        },
+        "env": {"MY_VAR": "1"},
+    }
+    settings_path.write_text(json.dumps(existing, indent=2))
+
+    hook = tmp_path / "stop.sh"
+    hook.write_text("#!/bin/sh\n")
+
+    register_stop_hook(workspace, hook)
+
+    data = json.loads(settings_path.read_text())
+    # Pre-existing keys preserved
+    assert data["permissions"] == {"allow": ["Bash(npm test)"]}
+    assert data["env"] == {"MY_VAR": "1"}
+    # Pre-existing hook category preserved
+    assert data["hooks"]["PostToolUse"][0]["hooks"][0]["command"] == "/some/other/hook.sh"
+    # New Stop hook entry appended
+    stop = data["hooks"]["Stop"]
+    assert len(stop) == 1
+    assert stop[0]["hooks"][0]["command"] == str(hook)
+
+
+def test_register_stop_hook_idempotent(tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    hook = tmp_path / "stop.sh"
+    hook.write_text("#!/bin/sh\n")
+
+    register_stop_hook(workspace, hook)
+    register_stop_hook(workspace, hook)
+    register_stop_hook(workspace, hook)
+
+    data = json.loads((workspace / ".claude" / "settings.json").read_text())
+    stop = data["hooks"]["Stop"]
+    assert len(stop) == 1
+    assert stop[0]["hooks"][0]["command"] == str(hook)
+
+
+def test_register_stop_hook_preserves_other_stop_entries(tmp_path):
+    workspace = tmp_path / "ws"
+    settings_dir = workspace / ".claude"
+    settings_dir.mkdir(parents=True)
+    settings_path = settings_dir / "settings.json"
+
+    existing = {
+        "hooks": {
+            "Stop": [
+                {"hooks": [{"type": "command", "command": "/user/global/stop.sh"}]}
+            ]
+        }
+    }
+    settings_path.write_text(json.dumps(existing))
+
+    hook = tmp_path / "stop.sh"
+    hook.write_text("#!/bin/sh\n")
+    register_stop_hook(workspace, hook)
+
+    data = json.loads(settings_path.read_text())
+    stop = data["hooks"]["Stop"]
+    assert len(stop) == 2
+    commands = [m["hooks"][0]["command"] for m in stop]
+    assert "/user/global/stop.sh" in commands
+    assert str(hook) in commands
+
+
+def test_register_stop_hook_creates_claude_dir(tmp_path):
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    assert not (workspace / ".claude").exists()
+
+    hook = tmp_path / "stop.sh"
+    hook.write_text("#!/bin/sh\n")
+    register_stop_hook(workspace, hook)
+
+    assert (workspace / ".claude").is_dir()
+    assert (workspace / ".claude" / "settings.json").is_file()
+
+
+def test_register_stop_hook_handles_corrupt_settings(tmp_path):
+    workspace = tmp_path / "ws"
+    settings_dir = workspace / ".claude"
+    settings_dir.mkdir(parents=True)
+    settings_path = settings_dir / "settings.json"
+    settings_path.write_text("{not valid json")
+
+    hook = tmp_path / "stop.sh"
+    hook.write_text("#!/bin/sh\n")
+
+    # Should not raise, should not clobber the corrupt file.
+    register_stop_hook(workspace, hook)
+
+    # File contents preserved (not overwritten by us).
+    assert settings_path.read_text() == "{not valid json"
+
+
+def test_stop_hook_path_points_to_bundled_script():
+    path = stop_hook_path()
+    assert path.is_absolute()
+    assert path.name == "stop.sh"
+    assert path.parent.name == "hooks"
+    assert path.parent.parent.name == "claude_code"
+    # The bundled script should actually exist in the source tree.
+    assert path.exists()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -407,6 +407,109 @@ def test_aider_command_includes_yes_and_no_auto_commits(tmp_path, http_client):
 
 
 # ---------------------------------------------------------------------------
+# Test 9: Claude Code Stop hook registration (#391)
+# ---------------------------------------------------------------------------
+
+
+def test_launch_agent_claude_code_registers_stop_hook(tmp_path, http_client):
+    """For agent_type=claude-code, .claude/settings.json registers stop.sh
+    before `claude` is invoked. Without this the Stop hook never fires and
+    per-mission usage telemetry (#354) silently fails (#391).
+    """
+    import json
+    import subprocess
+    import threading
+    from unittest.mock import patch
+
+    from antfarm.core.hook_setup import stop_hook_path
+
+    rt = WorkerRuntime(
+        colony_url="http://test",
+        node_id="node-1",
+        name="worker-cc",
+        agent_type="claude-code",
+        workspace_root=str(tmp_path / "workspaces"),
+        repo_path=str(tmp_path),
+        integration_branch="main",
+        heartbeat_interval=999.0,
+        client=http_client,
+    )
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    rt.workspace_mgr.create = MagicMock(return_value=str(workspace))
+
+    task = {
+        "id": "task-cc-001",
+        "title": "Test Claude Code Task",
+        "spec": "add a hello function",
+        "current_attempt": 1,
+    }
+
+    settings_at_launch: dict = {}
+    main_thread = threading.current_thread()
+
+    def fake_run(cmd, **kwargs):
+        # Capture the settings file state at the moment claude is invoked.
+        if threading.current_thread() is main_thread:
+            settings_path = workspace / ".claude" / "settings.json"
+            if settings_path.exists():
+                settings_at_launch.update(json.loads(settings_path.read_text()))
+        return MagicMock(returncode=0, stdout="done", stderr="")
+
+    with patch.object(subprocess, "run", side_effect=fake_run):
+        rt._launch_agent(task, str(workspace))
+
+    # Assert hook was registered before claude was invoked.
+    assert "hooks" in settings_at_launch
+    stop = settings_at_launch["hooks"]["Stop"]
+    assert len(stop) == 1
+    assert stop[0]["hooks"][0]["type"] == "command"
+    assert stop[0]["hooks"][0]["command"] == str(stop_hook_path())
+
+
+def test_launch_agent_non_claude_code_skips_hook_registration(tmp_path, http_client):
+    """For non-claude-code adapters, no .claude/settings.json is written."""
+    import subprocess
+    import threading
+    from unittest.mock import patch
+
+    rt = WorkerRuntime(
+        colony_url="http://test",
+        node_id="node-1",
+        name="worker-codex",
+        agent_type="codex",
+        workspace_root=str(tmp_path / "workspaces"),
+        repo_path=str(tmp_path),
+        integration_branch="main",
+        heartbeat_interval=999.0,
+        client=http_client,
+    )
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    rt.workspace_mgr.create = MagicMock(return_value=str(workspace))
+
+    task = {
+        "id": "task-codex-002",
+        "title": "Test Codex Task",
+        "spec": "add a hello function",
+        "current_attempt": 1,
+    }
+
+    main_thread = threading.current_thread()
+
+    def fake_run(cmd, **kwargs):
+        if threading.current_thread() is main_thread:
+            pass
+        return MagicMock(returncode=0, stdout="done", stderr="")
+
+    with patch.object(subprocess, "run", side_effect=fake_run):
+        rt._launch_agent(task, str(workspace))
+
+    # Codex adapter has no Stop hook; settings.json must not be created.
+    assert not (workspace / ".claude" / "settings.json").exists()
+
+
+# ---------------------------------------------------------------------------
 # v0.5.1: Failure classification + retry policy
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Worker now writes `<workspace>/.claude/settings.json` registering the bundled `stop.sh` as a Stop hook before invoking `claude` for the `claude-code` adapter (Option A from #391).
- Without this the Stop hook never fires, per-mission usage telemetry (#354) is silently dropped, and cost tracking reports $0.00 on missions that actually run.
- Settings write is a deep merge: existing keys (permissions, env, other hook categories, other Stop matchers) are preserved; re-running is a no-op (idempotent).

## Changes
- New `antfarm/core/hook_setup.py` with `register_stop_hook(workspace, hook_script)` and `stop_hook_path()` helpers.
- `WorkerRuntime._launch_agent` calls them for `agent_type == "claude-code"`, immediately after `_setup_agent_definitions` and before `subprocess.run`.
- `ANTFARM_URL` and `WORKER_ID` were already propagated to the agent subprocess env, so `stop.sh` has what it needs to POST to `/workers/{id}/usage`.

## Test Plan
- [x] `pytest tests/test_hook_setup.py -q` — 7 passed (fresh write, deep merge, idempotent, preserves unrelated Stop matchers, creates `.claude/`, handles corrupt settings, bundled hook path resolution).
- [x] `pytest tests/test_worker.py -q` — 84 passed, including two new tests:
  - `test_launch_agent_claude_code_registers_stop_hook` — settings.json contains the antfarm Stop hook entry at the moment `claude` is invoked.
  - `test_launch_agent_non_claude_code_skips_hook_registration` — non-claude adapters do not write `.claude/settings.json`.
- [x] `ruff check .` — clean.
- [x] Full suite green except two pre-existing tmux-test failures (`test_tmux_pm_adopt_existing`, `test_tmux_pm_start_and_lifecycle`) unrelated to this PR — confirmed reproducing on origin/main and being addressed by `fix/389-tmux-test-hermetic`.

## Related Issues
Closes #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)