### PR TITLE
fix(adapter,stop_hook): read transcript_path from stdin JSON (Closes #395)

### DIFF
--- a/antfarm/adapters/claude_code/hooks/stop.sh
+++ b/antfarm/adapters/claude_code/hooks/stop.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 # Stop hook: report the final assistant message's usage block to the colony.
 #
-# Claude Code invokes Stop hooks when the conversation ends. The transcript
-# path is passed in $CLAUDE_TRANSCRIPT_PATH; the last assistant message
-# carries a `usage` object with input_tokens / output_tokens / cache_*_tokens.
+# Claude Code invokes Stop hooks when the conversation ends. The hook event
+# data is delivered as a JSON object on stdin per Claude Code's hook protocol;
+# `.transcript_path` is the canonical source for the transcript file. The
+# `$CLAUDE_TRANSCRIPT_PATH` env var is honored as a fallback for manual
+# invocation or older Claude Code versions.
+#
+# The transcript is JSONL; the last assistant message carries a `usage` object
+# with input_tokens / output_tokens / cache_*_tokens.
 #
 # This is best-effort — every failure path falls through to `|| true`, so a
 # broken jq install or a missing transcript never blocks Claude. We POST to
@@ -15,6 +20,25 @@ set -u
 : "${WORKER_ID:=}"
 : "${CLAUDE_TRANSCRIPT_PATH:=}"
 
+# Require jq for JSON extraction. If jq isn't installed, skip silently —
+# antfarm will warn about it elsewhere. We need jq both for parsing the
+# stdin event payload and for walking the transcript further down.
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+# Claude Code pipes the hook event JSON on stdin. Prefer that over the env
+# var so we don't get fooled by stale environment from a parent process.
+if ! [ -t 0 ]; then
+  STDIN_JSON="$(cat 2>/dev/null || true)"
+  if [ -n "${STDIN_JSON}" ]; then
+    TPATH_FROM_STDIN="$(printf '%s' "${STDIN_JSON}" | jq -r '.transcript_path // empty' 2>/dev/null || true)"
+    if [ -n "${TPATH_FROM_STDIN}" ]; then
+      CLAUDE_TRANSCRIPT_PATH="${TPATH_FROM_STDIN}"
+    fi
+  fi
+fi
+
 # If any required input is missing, do nothing. Do not error — Claude stops
 # anyway and the hook must stay out of the way.
 if [ -z "${ANTFARM_URL}" ] || [ -z "${WORKER_ID}" ] || [ -z "${CLAUDE_TRANSCRIPT_PATH}" ]; then
@@ -22,12 +46,6 @@ if [ -z "${ANTFARM_URL}" ] || [ -z "${WORKER_ID}" ] || [ -z "${CLAUDE_TRANSCRIPT
 fi
 
 if [ ! -f "${CLAUDE_TRANSCRIPT_PATH}" ]; then
-  exit 0
-fi
-
-# Require jq for JSON extraction. If jq isn't installed, skip silently —
-# antfarm will warn about it elsewhere.
-if ! command -v jq >/dev/null 2>&1; then
   exit 0
 fi
 

--- a/docs/antfarm/missions/mission-auth-1.md
+++ b/docs/antfarm/missions/mission-auth-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-auth-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:02:58.224936+00:00
-**Completed:** 2026-05-07T04:02:58.252869+00:00 (0s)
+**Created:** 2026-05-09T01:35:00.715732+00:00
+**Completed:** 2026-05-09T01:35:00.750512+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -21,8 +21,8 @@
 
 ## Timeline highlights
 
-- 04:02:58  mission created
-- 04:02:58  plan ready
-- 04:02:58  task-auth-01 merged
-- 04:02:58  task-auth-02 merged
-- 04:02:58  mission complete
+- 01:35:00  mission created
+- 01:35:00  plan ready
+- 01:35:00  task-auth-01 merged
+- 01:35:00  task-auth-02 merged
+- 01:35:00  mission complete

--- a/docs/antfarm/missions/mission-blocked-1.md
+++ b/docs/antfarm/missions/mission-blocked-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-blocked-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:02:58.981729+00:00
-**Completed:** 2026-05-07T04:02:59.013305+00:00 (0s)
+**Created:** 2026-05-09T01:35:01.542785+00:00
+**Completed:** 2026-05-09T01:35:01.576721+00:00 (0s)
 **Outcome:** complete (1/2 merged)
 
 ## Plan
@@ -21,10 +21,10 @@
 
 ## Timeline highlights
 
-- 04:02:58  mission created
-- 04:02:58  plan ready
-- 04:02:59  task-blocked-02 merged
-- 04:02:59  task-blocked-01 kicked back (kickback)
-- 04:02:59  task-blocked-01 kicked back (kickback)
-- 04:02:59  task-blocked-01 kicked back (kickback)
-- 04:02:59  mission complete
+- 01:35:01  mission created
+- 01:35:01  plan ready
+- 01:35:01  task-blocked-02 merged
+- 01:35:01  task-blocked-01 kicked back (kickback)
+- 01:35:01  task-blocked-01 kicked back (kickback)
+- 01:35:01  task-blocked-01 kicked back (kickback)
+- 01:35:01  mission complete

--- a/docs/antfarm/missions/mission-budget-cancel.md
+++ b/docs/antfarm/missions/mission-budget-cancel.md
@@ -1,8 +1,8 @@
 # Mission: mission-budget-cancel
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:03:09.256751+00:00
-**Completed:** 2026-05-07T04:03:09.258774+00:00 (0s)
+**Created:** 2026-05-09T01:35:12.974250+00:00
+**Completed:** 2026-05-09T01:35:12.976264+00:00 (0s)
 **Outcome:** cancelled (0/0 merged)
 
 ## Plan
@@ -20,5 +20,5 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 04:03:09  mission created
-- 04:03:09  mission cancelled
+- 01:35:12  mission created
+- 01:35:12  mission cancelled

--- a/docs/antfarm/missions/mission-replan-1.md
+++ b/docs/antfarm/missions/mission-replan-1.md
@@ -1,8 +1,8 @@
 # Mission: mission-replan-1
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:02:59.717111+00:00
-**Completed:** 2026-05-07T04:02:59.753252+00:00 (0s)
+**Created:** 2026-05-09T01:35:03.351312+00:00
+**Completed:** 2026-05-09T01:35:03.390382+00:00 (0s)
 **Outcome:** complete (2/2 merged)
 
 ## Plan
@@ -27,8 +27,8 @@ The plan above is the final accepted version. Earlier rejected drafts can be rec
 
 ## Timeline highlights
 
-- 04:02:59  mission created
-- 04:02:59  plan ready
-- 04:02:59  task-replan-01 merged
-- 04:02:59  task-replan-02 merged
-- 04:02:59  mission complete
+- 01:35:03  mission created
+- 01:35:03  plan ready
+- 01:35:03  task-replan-01 merged
+- 01:35:03  task-replan-02 merged
+- 01:35:03  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-09T01:35:11.116027+00:00
-**Completed:** 2026-05-09T01:35:11.131891+00:00 (0s)
-**Outcome:** complete (1/2 merged)
+**Created:** 2026-05-09T01:35:11.799319+00:00
+**Completed:** 2026-05-09T01:35:11.814621+00:00 (0s)
+**Outcome:** complete (2/2 merged)
 
 ## Plan
 
@@ -16,12 +16,13 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | p | 1 | pass | 0s | — |
-| task-test-02 | — | 0 | blocked | — | blocked |
+| task-test-01 | https://example.com/pr/0 | 1 | pass | 0s | — |
+| task-test-02 | https://example.com/pr/1 | 1 | pass | 0s | — |
 
 ## Timeline highlights
 
 - 01:35:11  mission created
 - 01:35:11  plan ready
 - 01:35:11  task-test-01 merged
+- 01:35:11  task-test-02 merged
 - 01:35:11  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:03:08.655659+00:00
-**Completed:** 2026-05-07T04:03:08.657365+00:00 (0s)
+**Created:** 2026-05-09T01:35:05.626083+00:00
+**Completed:** 2026-05-09T01:35:05.652571+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -15,5 +15,5 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 04:03:08  mission created
-- 04:03:08  mission failed
+- 01:35:05  mission created
+- 01:35:05  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-09T01:35:06.847097+00:00
-**Completed:** 2026-05-09T01:35:06.851791+00:00 (0s)
+**Created:** 2026-05-09T01:35:07.507782+00:00
+**Completed:** 2026-05-09T01:35:07.515147+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -14,7 +14,7 @@
 
 ## Re-plans
 
-Re-plan cycles: **1**.
+Re-plan cycles: **2**.
 
 The plan above is the final accepted version. Earlier rejected drafts can be reconstructed from the plan task's attempt history in `.antfarm/tasks/`.
 
@@ -24,6 +24,6 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 01:35:06  mission created
-- 01:35:06  plan ready
-- 01:35:06  mission failed
+- 01:35:07  mission created
+- 01:35:07  plan ready
+- 01:35:07  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-09T01:35:06.269744+00:00
-**Completed:** 2026-05-09T01:35:06.272307+00:00 (0s)
+**Created:** 2026-05-09T01:35:06.847097+00:00
+**Completed:** 2026-05-09T01:35:06.851791+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -11,6 +11,12 @@
 |---|---|---|---|---|
 | task-01 | Child task 1 | — | api | M |
 | task-02 | Child task 2 | — | api | M |
+
+## Re-plans
+
+Re-plan cycles: **1**.
+
+The plan above is the final accepted version. Earlier rejected drafts can be reconstructed from the plan task's attempt history in `.antfarm/tasks/`.
 
 ## Tasks
 

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-09T01:35:08.661238+00:00
-**Completed:** 2026-05-09T01:35:08.664132+00:00 (0s)
-**Outcome:** failed (0/0 merged)
+**Created:** 2026-05-09T01:35:09.218188+00:00
+**Completed:** 2026-05-09T01:35:09.235159+00:00 (0s)
+**Outcome:** complete (2/2 merged)
 
 ## Plan
 
@@ -14,10 +14,15 @@
 
 ## Tasks
 
-_(no implementation tasks)_
+| ID | PR | Attempts | Verdict | Wall | Notes |
+|---|---|---|---|---|---|
+| task-test-01 | https://github.com/test/pr/0 | 1 | pass | 0s | — |
+| task-test-02 | https://github.com/test/pr/1 | 1 | pass | 0s | — |
 
 ## Timeline highlights
 
-- 01:35:08  mission created
-- 01:35:08  plan ready
-- 01:35:08  mission failed
+- 01:35:09  mission created
+- 01:35:09  plan ready
+- 01:35:09  task-test-01 merged
+- 01:35:09  task-test-02 merged
+- 01:35:09  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,8 +1,8 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-09T01:35:07.507782+00:00
-**Completed:** 2026-05-09T01:35:07.515147+00:00 (0s)
+**Created:** 2026-05-09T01:35:08.661238+00:00
+**Completed:** 2026-05-09T01:35:08.664132+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -12,18 +12,12 @@
 | task-01 | Child task 1 | — | api | M |
 | task-02 | Child task 2 | — | api | M |
 
-## Re-plans
-
-Re-plan cycles: **2**.
-
-The plan above is the final accepted version. Earlier rejected drafts can be reconstructed from the plan task's attempt history in `.antfarm/tasks/`.
-
 ## Tasks
 
 _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 01:35:07  mission created
-- 01:35:07  plan ready
-- 01:35:07  mission failed
+- 01:35:08  mission created
+- 01:35:08  plan ready
+- 01:35:08  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,13 +1,16 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-09T01:35:05.626083+00:00
-**Completed:** 2026-05-09T01:35:05.652571+00:00 (0s)
+**Created:** 2026-05-09T01:35:06.269744+00:00
+**Completed:** 2026-05-09T01:35:06.272307+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
 
-_(no plan artifact recorded)_
+| ID | Title | Deps | Touches | Complexity |
+|---|---|---|---|---|
+| task-01 | Child task 1 | — | api | M |
+| task-02 | Child task 2 | — | api | M |
 
 ## Tasks
 
@@ -15,5 +18,6 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 01:35:05  mission created
-- 01:35:05  mission failed
+- 01:35:06  mission created
+- 01:35:06  plan ready
+- 01:35:06  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,28 +1,19 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-09T01:35:11.799319+00:00
-**Completed:** 2026-05-09T01:35:11.814621+00:00 (0s)
-**Outcome:** complete (2/2 merged)
+**Created:** 2026-05-09T01:35:12.401160+00:00
+**Completed:** 2026-05-09T01:35:12.402907+00:00 (0s)
+**Outcome:** failed (0/0 merged)
 
 ## Plan
 
-| ID | Title | Deps | Touches | Complexity |
-|---|---|---|---|---|
-| task-01 | Child task 1 | — | api | M |
-| task-02 | Child task 2 | — | api | M |
+_(no plan artifact recorded)_
 
 ## Tasks
 
-| ID | PR | Attempts | Verdict | Wall | Notes |
-|---|---|---|---|---|---|
-| task-test-01 | https://example.com/pr/0 | 1 | pass | 0s | — |
-| task-test-02 | https://example.com/pr/1 | 1 | pass | 0s | — |
+_(no implementation tasks)_
 
 ## Timeline highlights
 
-- 01:35:11  mission created
-- 01:35:11  plan ready
-- 01:35:11  task-test-01 merged
-- 01:35:11  task-test-02 merged
-- 01:35:11  mission complete
+- 01:35:12  mission created
+- 01:35:12  mission failed

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-09T01:35:09.218188+00:00
-**Completed:** 2026-05-09T01:35:09.235159+00:00 (0s)
-**Outcome:** complete (2/2 merged)
+**Created:** 2026-05-09T01:35:09.803691+00:00
+**Completed:** 2026-05-09T01:35:09.820603+00:00 (0s)
+**Outcome:** complete (1/2 merged)
 
 ## Plan
 
@@ -16,13 +16,13 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | https://github.com/test/pr/0 | 1 | pass | 0s | — |
-| task-test-02 | https://github.com/test/pr/1 | 1 | pass | 0s | — |
+| task-test-01 | p | 1 | pass | 0s | — |
+| task-test-02 | — | 1 | blocked | — | blocked |
 
 ## Timeline highlights
 
 - 01:35:09  mission created
 - 01:35:09  plan ready
 - 01:35:09  task-test-01 merged
-- 01:35:09  task-test-02 merged
+- 01:35:09  task-test-02 kicked back (kickback)
 - 01:35:09  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-09T01:35:10.429155+00:00
-**Completed:** 2026-05-09T01:35:10.444441+00:00 (0s)
-**Outcome:** failed (0/2 merged)
+**Created:** 2026-05-09T01:35:11.116027+00:00
+**Completed:** 2026-05-09T01:35:11.131891+00:00 (0s)
+**Outcome:** complete (1/2 merged)
 
 ## Plan
 
@@ -16,11 +16,12 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | — | 0 | blocked | — | blocked |
+| task-test-01 | p | 1 | pass | 0s | — |
 | task-test-02 | — | 0 | blocked | — | blocked |
 
 ## Timeline highlights
 
-- 01:35:10  mission created
-- 01:35:10  plan ready
-- 01:35:10  mission failed
+- 01:35:11  mission created
+- 01:35:11  plan ready
+- 01:35:11  task-test-01 merged
+- 01:35:11  mission complete

--- a/docs/antfarm/missions/mission-test-001.md
+++ b/docs/antfarm/missions/mission-test-001.md
@@ -1,9 +1,9 @@
 # Mission: mission-test-001
 
 **Spec:** `(inline)`
-**Created:** 2026-05-09T01:35:09.803691+00:00
-**Completed:** 2026-05-09T01:35:09.820603+00:00 (0s)
-**Outcome:** complete (1/2 merged)
+**Created:** 2026-05-09T01:35:10.429155+00:00
+**Completed:** 2026-05-09T01:35:10.444441+00:00 (0s)
+**Outcome:** failed (0/2 merged)
 
 ## Plan
 
@@ -16,13 +16,11 @@
 
 | ID | PR | Attempts | Verdict | Wall | Notes |
 |---|---|---|---|---|---|
-| task-test-01 | p | 1 | pass | 0s | — |
-| task-test-02 | — | 1 | blocked | — | blocked |
+| task-test-01 | — | 0 | blocked | — | blocked |
+| task-test-02 | — | 0 | blocked | — | blocked |
 
 ## Timeline highlights
 
-- 01:35:09  mission created
-- 01:35:09  plan ready
-- 01:35:09  task-test-01 merged
-- 01:35:09  task-test-02 kicked back (kickback)
-- 01:35:09  mission complete
+- 01:35:10  mission created
+- 01:35:10  plan ready
+- 01:35:10  mission failed

--- a/docs/antfarm/missions/mission-zero-cap.md
+++ b/docs/antfarm/missions/mission-zero-cap.md
@@ -1,8 +1,8 @@
 # Mission: mission-zero-cap
 
 **Spec:** `(inline)`
-**Created:** 2026-05-07T04:03:04.177252+00:00
-**Completed:** 2026-05-07T04:03:04.180274+00:00 (0s)
+**Created:** 2026-05-09T01:35:08.089591+00:00
+**Completed:** 2026-05-09T01:35:08.092617+00:00 (0s)
 **Outcome:** failed (0/0 merged)
 
 ## Plan
@@ -18,6 +18,6 @@ _(no implementation tasks)_
 
 ## Timeline highlights
 
-- 04:03:04  mission created
-- 04:03:04  plan ready
-- 04:03:04  mission failed
+- 01:35:08  mission created
+- 01:35:08  plan ready
+- 01:35:08  mission failed

--- a/tests/test_stop_hook.py
+++ b/tests/test_stop_hook.py
@@ -1,0 +1,181 @@
+"""Tests for antfarm.adapters.claude_code.hooks.stop.sh.
+
+Verifies the Stop hook correctly reads the transcript path from the JSON event
+piped on stdin (Claude Code's hook protocol) and POSTs a usage event to the
+colony. Also verifies the env-var fallback and the best-effort failure paths.
+
+These tests require `jq`, `tac`, `curl` to be on PATH. macOS dev boxes do not
+ship `tac`, so the suite skips locally there; CI runs Ubuntu and exercises
+all of them.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socketserver
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler
+
+import pytest
+
+from antfarm.core.hook_setup import stop_hook_path
+
+REQUIRED_TOOLS = ("jq", "tac", "curl")
+
+
+def _missing_tools() -> list[str]:
+    return [t for t in REQUIRED_TOOLS if shutil.which(t) is None]
+
+
+pytestmark = pytest.mark.skipif(
+    bool(_missing_tools()),
+    reason=f"stop.sh tests require {REQUIRED_TOOLS} on PATH; missing: {_missing_tools()}",
+)
+
+
+class _RecordingHandler(BaseHTTPRequestHandler):
+    """Capture POST path + body into the server's `recorded` list."""
+
+    def do_POST(self):  # noqa: N802 - http.server API
+        length = int(self.headers.get("Content-Length", "0") or "0")
+        body = self.rfile.read(length) if length else b""
+        self.server.recorded.append((self.path, body))  # type: ignore[attr-defined]
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b"{}")
+
+    def log_message(self, *args, **kwargs):  # silence test output
+        return
+
+
+@pytest.fixture
+def mock_colony():
+    """Run an in-process HTTP server that records POSTs."""
+    socketserver.TCPServer.allow_reuse_address = True
+    server = socketserver.TCPServer(("127.0.0.1", 0), _RecordingHandler)
+    server.recorded = []  # type: ignore[attr-defined]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        port = server.server_address[1]
+        yield server, port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _write_fake_transcript(path) -> None:
+    """Write a JSONL transcript with one assistant line carrying a usage block."""
+    line = {
+        "message": {
+            "model": "claude-sonnet-4-7",
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_read_input_tokens": 10,
+                "cache_creation_input_tokens": 5,
+            },
+        }
+    }
+    path.write_text(json.dumps(line) + "\n")
+
+
+def _run_hook(stdin_bytes: bytes, env_extra: dict[str, str]) -> subprocess.CompletedProcess:
+    """Invoke the bundled stop.sh with the given stdin and env overlay."""
+    env = {"PATH": os.environ.get("PATH", "")}
+    env.update(env_extra)
+    return subprocess.run(
+        [str(stop_hook_path())],
+        input=stdin_bytes,
+        env=env,
+        capture_output=True,
+        timeout=10,
+    )
+
+
+def test_stop_hook_reads_transcript_path_from_stdin(tmp_path, mock_colony):
+    server, port = mock_colony
+    transcript = tmp_path / "transcript.jsonl"
+    _write_fake_transcript(transcript)
+
+    event = {"transcript_path": str(transcript), "session_id": "abc-123"}
+    stdin = (json.dumps(event) + "\n").encode("utf-8")
+
+    result = _run_hook(
+        stdin,
+        {
+            "ANTFARM_URL": f"http://127.0.0.1:{port}",
+            "WORKER_ID": "node-1/w-1",
+            # Intentionally omit CLAUDE_TRANSCRIPT_PATH — stdin must win.
+        },
+    )
+
+    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")
+    assert len(server.recorded) == 1
+    path, body = server.recorded[0]
+    assert path == "/workers/node-1/w-1/usage"
+    payload = json.loads(body)
+    assert payload["input_tokens"] == 100
+    assert payload["output_tokens"] == 50
+    assert payload["model"] == "claude-sonnet-4-7"
+    assert payload["source"] == "claude_stop_hook"
+    assert payload["event_id"]
+
+
+def test_stop_hook_falls_back_to_env_when_stdin_empty(tmp_path, mock_colony):
+    server, port = mock_colony
+    transcript = tmp_path / "transcript.jsonl"
+    _write_fake_transcript(transcript)
+
+    result = _run_hook(
+        b"",
+        {
+            "ANTFARM_URL": f"http://127.0.0.1:{port}",
+            "WORKER_ID": "node-1/w-1",
+            "CLAUDE_TRANSCRIPT_PATH": str(transcript),
+        },
+    )
+
+    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")
+    assert len(server.recorded) == 1
+
+
+def test_stop_hook_exits_zero_on_malformed_stdin(tmp_path, mock_colony):
+    server, port = mock_colony
+
+    result = _run_hook(
+        b"not json",
+        {
+            "ANTFARM_URL": f"http://127.0.0.1:{port}",
+            "WORKER_ID": "node-1/w-1",
+            # No env fallback — required input is missing after stdin parse fails.
+        },
+    )
+
+    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")
+    assert len(server.recorded) == 0
+
+
+def test_stop_hook_exits_zero_when_required_env_missing(tmp_path, mock_colony):
+    server, port = mock_colony
+    transcript = tmp_path / "transcript.jsonl"
+    _write_fake_transcript(transcript)
+
+    event = {"transcript_path": str(transcript)}
+    stdin = (json.dumps(event) + "\n").encode("utf-8")
+
+    result = _run_hook(
+        stdin,
+        {
+            "ANTFARM_URL": f"http://127.0.0.1:{port}",
+            # WORKER_ID intentionally omitted — hook must skip silently.
+        },
+    )
+
+    assert result.returncode == 0, result.stderr.decode("utf-8", errors="replace")
+    assert len(server.recorded) == 0


### PR DESCRIPTION
## Summary
- stop.sh now parses the JSON event Claude Code pipes on stdin, extracting `.transcript_path` as the canonical source
- `$CLAUDE_TRANSCRIPT_PATH` env var kept as a fallback (manual invocation, older Claude versions)
- Best-effort discipline preserved — every failure path still `exit 0`
- New `tests/test_stop_hook.py` exercises stdin happy path, env fallback, malformed stdin, and missing-required-env paths against an in-process mock colony
- Closes #395 (and as a side-effect, #390 / #392 — every mission audit doc that previously showed `Budget: $0.00` will now show real cost data)

## Test plan
- [x] ruff check .
- [x] pytest tests/ -x -q
- [x] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)